### PR TITLE
(#1) Adds a standard spool directory to stdlib

### DIFF
--- a/lib/facter/vardir.rb
+++ b/lib/facter/vardir.rb
@@ -1,0 +1,10 @@
+# Turns puppet's agent side vardir configuration setting into a fact so we can use it
+# in our manifests.
+
+Facter.add(:vardir) do
+  setcode do
+    if defined?(Puppet)
+      Puppet[:vardir]
+    end
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,17 +2,18 @@
 #
 # This module manages stdlib
 #
-# Parameters:
+# == Parameters
 #
-# Actions:
+# == Actions
 #
-# Requires:
+# == Requires
 #
-# Sample Usage:
+# == Sample Usage
 #
 # [Remember: No empty lines between comments and class definition]
 class stdlib {
 
   class { 'stdlib::stages': }
+  class { 'stdlib::spool': }
 
 }

--- a/manifests/spool.pp
+++ b/manifests/spool.pp
@@ -1,0 +1,30 @@
+# Class: stdlib::spool
+#
+#   This class manages a standard base directory location for use in file fragment
+# patterns.
+#
+# Default location is $vardir/spool
+#
+# == Parameters
+#
+# [*basedir*]
+#   This parameter sets the base directory location for file fragments.  Defaults
+# to $vardir.
+#
+# == Examples
+#
+#  node default {
+#    class { 'stdlib::spool':
+#      basedir => '/var/lib/puppet'
+#    }
+#  }
+#
+class stdlib::spool($basedir = $::vardir) {
+
+  file { "${basedir}/spool":
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0600',
+  }
+}

--- a/manifests/stages.pp
+++ b/manifests/stages.pp
@@ -13,16 +13,12 @@
 #  * deploy_app
 #  * deploy
 #
-# Parameters:
-#
-# Actions:
+# == Actions
 #
 #   Declares various run-stages for deploying infrastructure,
 #   language runtimes, and application layers.
 #
-# Requires:
-#
-# Sample Usage:
+# == Examples
 #
 #  node default {
 #    include stdlib::stages


### PR DESCRIPTION
  This adds a standard place to store file fragments for use by other
  modules.  Also cleans up documentation to match the style guide.
