### PR TITLE
(#9859) Add root_home fact and tests

### DIFF
--- a/lib/facter/root_home.rb
+++ b/lib/facter/root_home.rb
@@ -1,0 +1,17 @@
+# A facter fact to determine the root home directory.
+# This varies on PE supported platforms and may be
+# reconfigured by the end user.
+
+module Facter::Util::RootHome
+  class << self
+  def get_root_home
+    root_ent = Facter::Util::Resolution.exec("getent passwd root")
+    # The home directory is the sixth element in the passwd entry
+    root_ent.split(":")[5]
+  end
+  end
+end
+
+Facter.add(:root_home) do
+  setcode { Facter::Util::RootHome.get_root_home }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ p dir
 ARGV.clear
 
 require 'puppet'
+require 'facter'
 require 'mocha'
 gem 'rspec', '>=2.0.0'
 require 'rspec/expectations'

--- a/spec/unit/facter/root_home_spec.rb
+++ b/spec/unit/facter/root_home_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'facter/root_home'
+
+describe Facter::Util::RootHome do
+  context "solaris" do
+    let(:root_ent) { "root:x:0:0:Super-User:/:/sbin/sh" }
+    let(:expected_root_home) { "/" }
+
+    it "should return /" do
+      Facter::Util::Resolution.expects(:exec).with("getent passwd root").returns(root_ent)
+      Facter::Util::RootHome.get_root_home.should == expected_root_home
+    end
+  end
+  context "linux" do
+    let(:root_ent) { "root:x:0:0:root:/root:/bin/bash" }
+    let(:expected_root_home) { "/root" }
+
+    it "should return /root" do
+      Facter::Util::Resolution.expects(:exec).with("getent passwd root").returns(root_ent)
+      Facter::Util::RootHome.get_root_home.should == expected_root_home
+    end
+  end
+  context "macosx" do
+    let(:root_ent) { "root:*:0:0:System Administrator:/var/root:/bin/sh" }
+    let(:expected_root_home) { "/var/root" }
+
+    it "should return /var/root" do
+      Facter::Util::Resolution.expects(:exec).with("getent passwd root").returns(root_ent)
+      Facter::Util::RootHome.get_root_home.should == expected_root_home
+    end
+  end
+  context "windows" do
+    let(:root_ent) { "FIXME TBD on Windows" }
+    let(:expected_root_home) { "FIXME TBD on Windows" }
+
+    it "should return FIXME TBD on windows" do
+      pending "FIXME: TBD on windows"
+      Facter::Util::Resolution.expects(:exec).with("getent passwd root").returns(root_ent)
+      Facter::Util::RootHome.get_root_home.should == expected_root_home
+    end
+  end
+end


### PR DESCRIPTION
Without this patch applied, the stdlib module does not provide a
root_home fact.  This fact is necessary to easily determine the root
account home directory on platforms Puppet is supported on.
## The major variations this fact address are:

solaris: /
linux: /root
macosx: /var/root

Spec tests using rspec have been provided as well to cover these three
general cases.  Windows tests are marked as pending.
