### PR TITLE
(#10285) Refactor json to use pson instead.

### DIFF
--- a/lib/puppet/parser/functions/parsejson.rb
+++ b/lib/puppet/parser/functions/parsejson.rb
@@ -15,11 +15,9 @@ structure.
     end
 
     json = arguments[0]
-    
-    require 'json'
 
-    JSON.load(json)
-
+    # PSON is natively available in puppet
+    PSON.load(json)
   end
 end
 


### PR DESCRIPTION
Remove json requirement since puppet already provides pson which is
equivalent.
