### PR TITLE
Rewrite of is_domain_name function

### DIFF
--- a/lib/puppet/parser/functions/is_domain_name.rb
+++ b/lib/puppet/parser/functions/is_domain_name.rb
@@ -15,11 +15,31 @@ Returns true if the string passed to this function is a syntactically correct do
 
     domain = arguments[0]
 
-    if domain =~ /^(([a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\.?$/ then
-      return true
-    else
-      return false
+    # Limits (rfc1035, 3.1)
+    domain_max_length=255
+    label_min_length=1
+    label_max_length=63
+
+    # Allow ".", it is the top level domain
+    return true if domain == '.'
+
+    # Remove the final dot, if present.
+    domain.chomp!('.')
+
+    # Check the whole domain
+    return false if domain.empty?
+    return false if domain.length > domain_max_length
+
+    # Check each label in the domain
+    labels = domain.split('.')
+    vlabels = labels.each do |label|
+      break if label.length < label_min_length
+      break if label.length > label_max_length
+      break if label[-1..-1] == '-'
+      break if label[0..0] == '-'
+      break unless /^[a-z\d-]+$/i.match(label)
     end
+    return vlabels == labels
 
   end
 end


### PR DESCRIPTION
The is_domain_name function does not check the domain according to the DNS rfc.  For instance, it disallows "x.com", which is a correct domain name.

I've attempted to rewrite the checks in order to allow syntactically correct DNS names.

I've also updated the docstring, which referred to "ip address" and not domain.
