### PR TITLE
(#11607) Add Rakefile to enable spec testing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,16 @@
+require 'rake'
+require 'rspec/core/rake_task'
+
+task :default => [:test]
+
+desc 'Run RSpec'
+RSpec::Core::RakeTask.new(:test) do |t|
+  t.pattern = 'spec/{unit}/**/*.rb'
+  t.rspec_opts = ['--color']
+end
+
+desc 'Generate code coverage'
+RSpec::Core::RakeTask.new(:coverage) do |t|
+  t.rcov = true
+  t.rcov_opts = ['--exclude', 'spec']
+end


### PR DESCRIPTION
Without this patch the 2.1.x branch does not have a Rakefile like the
2.2.x and master branches do.  This is a problem for the continuous
integration testing since it executes `rake test` against 2.1.x, 2.2.x
and master currently.

This patch fixes the problem by copying the Rakefile into place enabling
the `rake test` task.
