### PR TITLE
(#11873) time function spec failure on Fixnum matcher

### DIFF
--- a/spec/unit/puppet/parser/functions/time_spec.rb
+++ b/spec/unit/puppet/parser/functions/time_spec.rb
@@ -20,7 +20,7 @@ describe "the time function" do
 
   it "should return a number" do
     result = @scope.function_time([])
-    result.class.should(eq(Fixnum))
+    result.should be_an(Integer)
   end
 
   it "should be higher then when I wrote this test" do


### PR DESCRIPTION
The rspec code for the time function was trying to match the type to be a
'Fixnum'. Ruby will sometimes make this a 'Bignum' depending on its internals
and we can't rely on this to be true all the time.

This patch just makes sure the type is an integer instead.
