### PR TITLE
(#11901) Fix problem with order in tests for 'keys' and 'values'

### DIFF
--- a/spec/unit/puppet/parser/functions/keys_spec.rb
+++ b/spec/unit/puppet/parser/functions/keys_spec.rb
@@ -20,7 +20,7 @@ describe "the keys function" do
 
   it "should return an array of keys when given a hash" do
     result = @scope.function_keys([{'a'=>1, 'b' => 2}])
-    result.should(eq(['a','b']))
+    result.sort.should(eq(['a','b']))
   end
 
 end

--- a/spec/unit/puppet/parser/functions/values_spec.rb
+++ b/spec/unit/puppet/parser/functions/values_spec.rb
@@ -20,7 +20,7 @@ describe "the values function" do
 
   it "should return values from a hash" do
     result = @scope.function_values([{'a'=>'1','b'=>'2','c'=>'3'}])
-    result.should(eq(['1','2','3']))
+    result.sort.should(eq(['1','2','3']))
   end
 
   it "should return values from a hash" do


### PR DESCRIPTION
Between Ruby 1.8.7 p352 and p357 the way hashes were returned when using keys
and values in Ruby changed, and due to assumption about the ordering our tests
are now changing. To fix this I've made sure we sort before comparison in the
relevant rspec examples.
