### PR TITLE
(#12377) Avoid infinite loop when retrying require json

### DIFF
--- a/lib/facter/facter_dot_d.rb
+++ b/lib/facter/facter_dot_d.rb
@@ -54,8 +54,8 @@ class Facter::Util::DotD
         begin
             require 'json'
         rescue LoadError
-            require 'rubygems'
-            retry
+            retry if require 'rubygems'
+            raise
         end
 
         JSON.load(File.read(file)).each_pair do |f, v|


### PR DESCRIPTION
Without this patch an infinite loop will be entered if the json and
rubygems libraries are not available.

This patch fixes the problem by retrying the `require 'json'` only if
rubygems was successfully loaded for the first time.  Subsequent
attempts to load rubygems will cause the LoadError exception from a
missing json library to be re-raised.

Thanks to Krzysztof Wilczynski for pointing out this issue.
