### PR TITLE
(#12512) Add dashboard_json function.

### DIFF
--- a/lib/puppet/parser/functions/dashboard_json.rb
+++ b/lib/puppet/parser/functions/dashboard_json.rb
@@ -1,0 +1,29 @@
+#
+# dashboard_json.rb
+#
+
+module Puppet::Parser::Functions
+  newfunction(:dashboard_json, :type => :rvalue, :doc => <<-EOS
+This function returns dashboard JSON data string and converts it.
+
+*Examples:*
+
+    # $::ntpserver = "[\\\"0.pool.ntp.org\\\"]"
+    $ntpserver = dashboard_json($::ntpserver)
+
+Would result in: ["0.pool.ntp.org"]
+    EOS
+  ) do |arguments|
+
+    if (arguments.size != 1) then
+      raise(Puppet::ParseError, "dashboard_json(): Wrong number of arguments "+
+        "given #{arguments.size} for 1")
+    end
+
+    json = arguments[0].gsub(/\\/,'')
+
+    PSON.load(json) unless json.nil?
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/spec/unit/puppet/parser/functions/dashboard_json_spec.rb
+++ b/spec/unit/puppet/parser/functions/dashboard_json_spec.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+
+describe "the dashboard_json function" do
+  before :all do
+    Puppet::Parser::Functions.autoloader.loadall
+  end
+
+  before :each do
+    @scope = Puppet::Parser::Scope.new
+  end
+
+  it "should exist" do
+    Puppet::Parser::Functions.function("dashboard_json").should == "function_dashboard_json"
+  end
+
+  it "should raise a ParseError if there is less than 1 arguments" do
+    lambda { @scope.function_dashboard_json([]) }.should( raise_error(Puppet::ParseError))
+  end
+
+  it "should convert JSON to a data structure" do
+    json = <<-EOS
+[\\\"aaa\\\",\\\"bbb\\\",\\\"ccc\\\"]
+EOS
+    result = @scope.function_dashboard_json([json])
+    result.should(eq(["aaa","bbb","ccc"]))
+  end
+
+end


### PR DESCRIPTION
Dashboard doens't support complex data, and if we attempt to use JSON
data in dashboard it returns it in an escaped format that parsejson
function will not handle. This function provides the ability to consume
JSON data from dashboard variables.
