### PR TITLE
implement #11017 - make file_line type ensurable

### DIFF
--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -1,7 +1,7 @@
 Puppet::Type.type(:file_line).provide(:ruby) do
 
   def exists?
-    File.readlines(resource[:path]).find do |line|
+    lines.find do |line|
       line.chomp == resource[:line].chomp
     end
   end
@@ -10,6 +10,18 @@ Puppet::Type.type(:file_line).provide(:ruby) do
     File.open(resource[:path], 'a') do |fh|
       fh.puts resource[:line]
     end
+  end
+
+  def destroy
+    local_lines = lines
+    File.open(resource[:path],'w') do |fh|
+      fh.write(local_lines.reject{|l| l.chomp == resource[:line] }.join(''))
+    end
+  end
+
+  private
+  def lines
+    @lines ||= File.readlines(resource[:path])
   end
 
 end

--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -23,12 +23,7 @@ Puppet::Type.newtype(:file_line) do
 
   EOT
 
-  ensurable do
-    defaultto :present
-    newvalue(:present) do
-      provider.create
-    end
-  end
+  ensurable
 
   newparam(:name, :namevar => true) do
     desc 'arbitrary name used as identity'

--- a/spec/unit/puppet/provider/file_line/ruby_spec.rb
+++ b/spec/unit/puppet/provider/file_line/ruby_spec.rb
@@ -2,29 +2,66 @@ require 'puppet'
 require 'tempfile'
 provider_class = Puppet::Type.type(:file_line).provider(:ruby)
 describe provider_class do
-  before :each do
-    tmp = Tempfile.new('tmp')
-    @tmpfile = tmp.path
-    tmp.close!
-    @resource = Puppet::Type::File_line.new(
-      {:name => 'foo', :path => @tmpfile, :line => 'foo'}
-    )
-    @provider = provider_class.new(@resource)
-  end
-  it 'should detect if the line exists in the file' do
-    File.open(@tmpfile, 'w') do |fh|
-      fh.write('foo')
+  context "add" do
+    before :each do
+      tmp = Tempfile.new('tmp')
+      @tmpfile = tmp.path
+      tmp.close!
+      @resource = Puppet::Type::File_line.new(
+        {:name => 'foo', :path => @tmpfile, :line => 'foo'}
+      )
+      @provider = provider_class.new(@resource)
     end
-    @provider.exists?.should be_true
-  end
-  it 'should detect if the line does not exist in the file' do
-    File.open(@tmpfile, 'w') do |fh|
-      fh.write('foo1')
+    it 'should detect if the line exists in the file' do
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write('foo')
+      end
+      @provider.exists?.should be_true
     end
-    @provider.exists?.should be_nil
+    it 'should detect if the line does not exist in the file' do
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write('foo1')
+      end
+      @provider.exists?.should be_nil
+    end
+    it 'should append to an existing file when creating' do
+      @provider.create
+      File.read(@tmpfile).chomp.should == 'foo'
+    end
   end
-  it 'should append to an existing file when creating' do
-    @provider.create
-    File.read(@tmpfile).chomp.should == 'foo'
+
+  context "remove" do
+    before :each do
+      tmp = Tempfile.new('tmp')
+      @tmpfile = tmp.path
+      tmp.close!
+      @resource = Puppet::Type::File_line.new(
+        {:name => 'foo', :path => @tmpfile, :line => 'foo', :ensure => 'absent' }
+      )
+      @provider = provider_class.new(@resource)
+    end
+    it 'should remove the line if it exists' do
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write("foo1\nfoo\nfoo2")
+      end
+      @provider.destroy
+      File.read(@tmpfile).should eql("foo1\nfoo2")
+    end
+
+    it 'should remove the line without touching the last new line' do
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write("foo1\nfoo\nfoo2\n")
+      end
+      @provider.destroy
+      File.read(@tmpfile).should eql("foo1\nfoo2\n")
+    end
+
+    it 'should remove any occurence of the line' do
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write("foo1\nfoo\nfoo2\nfoo\nfoo")
+      end
+      @provider.destroy
+      File.read(@tmpfile).should eql("foo1\nfoo2\n")
+    end
   end
 end


### PR DESCRIPTION
- Implement a simple destroy method.
- Add tests for it
- Refactor code, so file is actually read only once. However, due
  to the nature how provider tests are run, we need to ensure that
  the file is read before we open it to write it.
