### PR TITLE
(#12776) Added validate_slength function and rspec test

### DIFF
--- a/lib/puppet/parser/functions/validate_slength.rb
+++ b/lib/puppet/parser/functions/validate_slength.rb
@@ -1,0 +1,52 @@
+module Puppet::Parser::Functions
+
+  newfunction(:validate_slength, :doc => <<-'ENDHEREDOC') do |args|
+    Validate that the first argument is a string (or an array of strings), and
+    less/equal to than the length of the second argument.  It fails if the first
+    argument is not a string or array of strings, and if arg 2 is not convertable
+    to a number.
+
+    The following values will pass:
+
+      validate_slength("discombobulate",17)
+      validate_slength(["discombobulate","moo"],17)
+
+    The following valueis will not:
+
+      validate_slength("discombobulate",1)
+      validate_slength(["discombobulate","thermometer"],5)
+
+    ENDHEREDOC
+
+    raise Puppet::ParseError, ("validate_slength(): Wrong number of arguments (#{args.length}; must be = 2)") unless args.length == 2
+
+    unless (args[0].is_a?(String) or args[0].is_a?(Array))
+      raise Puppet::ParseError, ("validate_slength(): please pass a string, or an array of strings - what you passed didn't work for me at all - #{args[0].class}")
+    end
+
+    begin
+      max_length = args[1].to_i
+    rescue NoMethodError => e
+      raise Puppet::ParseError, ("validate_slength(): Couldn't convert whatever you passed as the length parameter to an integer  - sorry: " + e.message )
+    end
+
+    raise Puppet::ParseError, ("validate_slength(): please pass a positive number as max_length") unless max_length > 0
+
+    case args[0]
+      when String
+        raise Puppet::ParseError, ("validate_slength(): #{args[0].inspect} is #{args[0].length} characters.  It should have been less than or equal to #{max_length} characters") unless args[0].length <= max_length
+      when Array
+        args[0].each do |arg|
+          if arg.is_a?(String)
+            unless ( arg.is_a?(String) and arg.length <= max_length )
+              raise Puppet::ParseError, ("validate_slength(): #{arg.inspect} is #{arg.length} characters.  It should have been less than or equal to #{max_length} characters")
+            end
+          else
+            raise Puppet::ParseError, ("validate_slength(): #{arg.inspect} is not a string, it's a #{arg.class}")
+          end
+        end
+      else
+        raise Puppet::ParseError, ("validate_slength(): please pass a string, or an array of strings - what you passed didn't work for me at all - #{args[0].class}")
+    end
+  end
+end

--- a/spec/unit/puppet/parser/functions/validate_slength_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_slength_spec.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env rspec
+
+require 'spec_helper'
+
+describe "the validate_slength function" do
+  before :all do
+    Puppet::Parser::Functions.autoloader.loadall
+  end
+
+  let(:scope) { Puppet::Parser::Scope.new }
+
+  it "should exist" do
+    Puppet::Parser::Functions.function("validate_slength").should == "function_validate_slength"
+  end
+
+  it "should raise a ParseError if there is less than 2 arguments" do
+    expect { scope.function_validate_slength([]) }.to(raise_error(Puppet::ParseError))
+    expect { scope.function_validate_slength(["asdf"]) }.to(raise_error(Puppet::ParseError))
+  end
+
+  it "should raise a ParseError if argument 2 doesn't convert to a fixnum" do
+    expect { scope.function_validate_slength(["moo",["2"]]) }.to(raise_error(Puppet::ParseError, /Couldn't convert whatever you passed/))
+  end
+
+  it "should raise a ParseError if argument 2 converted, but to 0, e.g. a string" do
+    expect { scope.function_validate_slength(["moo","monkey"]) }.to(raise_error(Puppet::ParseError, /please pass a positive number as max_length/))
+  end
+
+  it "should raise a ParseError if argument 2 converted, but to 0" do
+    expect { scope.function_validate_slength(["moo","0"]) }.to(raise_error(Puppet::ParseError, /please pass a positive number as max_length/))
+  end
+
+  it "should fail if string greater then size" do
+    expect { scope.function_validate_slength(["test", 2]) }.to(raise_error(Puppet::ParseError, /It should have been less than or equal to/))
+  end
+
+  it "should fail if you pass an array of something other than strings" do
+    expect { scope.function_validate_slength([["moo",["moo"],Hash.new["moo" => 7]], 7]) }.to(raise_error(Puppet::ParseError, /is not a string, it's a/))
+  end
+
+  it "should fail if you pass something other than a string or array" do
+    expect { scope.function_validate_slength([Hash.new["moo" => "7"],6]) }.to(raise_error(Puppet::ParseError), /please pass a string, or an array of strings/)
+  end
+
+  it "should not fail if string is smaller or equal to size" do
+    expect { scope.function_validate_slength(["test", 5]) }.to_not(raise_error(Puppet::ParseError))
+  end
+
+  it "should not fail if array of string is are all smaller or equal to size" do
+    expect { scope.function_validate_slength([["moo","foo","bar"], 5]) }.to_not(raise_error(Puppet::ParseError))
+  end
+end


### PR DESCRIPTION
This function is used to validate a string is less than a maximum length.  The
string, or array of strings, is passed as the first argument to the function.
The maximum length of the string is passed as the second argument.

It is useful to validate, for example, that Puppet is not sending a username
to a downstream system that the system cannot cope with, but that might not
cause an error message - for example, MySQL will not accept a username of
more than 16 characters.  This enables a Puppet administrator to validate
the data that it may have been passed from upstream through, for example,
Hiera.
