### PR TITLE
Create a str2pbkdf2_hash function

### DIFF
--- a/lib/puppet/parser/functions/str2pbkdf2_hash.rb
+++ b/lib/puppet/parser/functions/str2pbkdf2_hash.rb
@@ -1,0 +1,89 @@
+#
+# str2pbkdf2_hash.rb
+#
+
+module Puppet::Parser::Functions
+  newfunction(:str2pbkdf2_hash, :type => :rvalue, :doc => <<-EOS
+This converts a string, a salt, and an iterations value to a
+salted-SHA512-PBKDF2 password hash (which is used for OS X versions > 10.7).
+For more information about PBKDF2, see --> http://en.wikipedia.org/wiki/PBKDF2
+
+Given a plaintext password string, a 32-byte salt, and an integer value for
+the number of iterations the computational hash will be calcultated, you will
+get a hex version of a salted-SHA512-PBKDF2 password hash that can be inserted
+into your Puppet manifests as a valid password attribute in versions of OS X
+greater than 10.7.  For example:
+
+    $password_hash = str2pbkdf2_hash('password', 'saltvalue', 10000)
+
+Because a PBKDF2 password hash is useless without knowing the value of the salt
+and the iterations value, you MUST pass all three arguments in the following
+format:
+
+    plaintext password:   A String
+    salt:                 A String, 32-bytes is recommended
+    iterations:           An Integer, between 10000 and 15000 is recommended
+
+Failing to pass the salt and iterations value is a ParseError
+    EOS
+  ) do |arguments|
+    require 'openssl'
+
+    raise(Puppet::ParseError, "str2pbkdf2_hash(): Wrong number of arguments " +
+      "passed (#{arguments.size} but we require exactly 3)") \
+      if arguments.size != 3
+
+    password   = arguments[0]
+    salt       = arguments[1]
+    begin
+      iterations = Integer(arguments[2])
+    rescue ArgumentError => e
+      raise(Puppet::ParseError, 'str2pbkdf2_hash(): The third argument, the ' +
+                                'iterations value, could not be cast to an ' +
+                                'Integer. Please pass an Integer (between ' +
+                                '10000 and 15000 is recommended). ' + e.message)
+    end
+
+    unless password.is_a?(String)
+      raise(Puppet::ParseError, 'str2pbkdf2_hash(): The first argument, a ' +
+        'plaintext password, must be a String, ' +
+        "you passed: #{password.class}")
+    end
+
+    unless salt.is_a?(String)
+      raise(Puppet::ParseError, 'str2pbkdf2_hash(): The second argument, the ' +
+        'password salt, must be a String (32 bytes is recommended), ' +
+        "you passed: #{salt.class}")
+    end
+
+    returned_hash = ''
+
+    # The method employed is similar to the method used in the PBKDF2 Rubygem
+    # located at <https://github.com/emerose/pbkdf2-ruby/>. Remember that
+    # PBKDF2 is just a method for implementing key stretching, so the iterations
+    # value becomes important (as it's essentially how many times you 'spin the
+    # tumblers' to calculate the hash). It's recommended to use an iterations
+    # value of 10,000 or greater for added security.
+    1.upto(2) do |t|
+      password_hash = OpenSSL::HMAC.digest('sha512', password, (salt+[t].pack("N")))
+      stored_value = password_hash
+      2.upto(iterations) do
+        password_hash = OpenSSL::HMAC.digest('sha512', password, password_hash)
+        password_hash_ord = password_hash.unpack('C*')
+        stored_value = stored_value.unpack('C*')
+        stored_value = (0..stored_value.length-1).collect do |element|
+          # In Ruby 1.9, stored_value[element] is a String, but in 1.8 it's
+          # a Fixnum. To avoid the situation, we unpack the String so that
+          # the XOR operator ( ^ ) will work just fine on 1.8 and 1.9
+          stored_value[element] ^ password_hash_ord[element]
+        end
+        stored_value = stored_value.pack('C*')
+      end
+      returned_hash << stored_value
+    end
+
+    returned_hash.slice(0, 128).unpack('H*').first
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/spec/unit/puppet/parser/functions/str2pbkdf2_hash_spec.rb
+++ b/spec/unit/puppet/parser/functions/str2pbkdf2_hash_spec.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe "the str2pbkdf2_hash function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    Puppet::Parser::Functions.function("str2pbkdf2_hash").should == "function_str2pbkdf2_hash"
+  end
+
+  it "should raise a ParseError if there is less than 3 arguments" do
+    expect { scope.function_str2pbkdf2_hash([]) }.
+     to raise_error Puppet::ParseError, /Wrong number of arguments/
+  end
+
+  it "should raise a ParseError if there is more than 3 arguments" do
+    expect { scope.function_str2pbkdf2_hash(['foo', 'bar', 'baz', 'buz']) }.
+      to raise_error Puppet::ParseError, /Wrong number of arguments/
+  end
+
+  it "should return a salted-sha512-pbkdf2 password hash 256 characters in length" do
+    result = scope.function_str2pbkdf2_hash(["password", 'salt', 10000])
+    result.length.should(eq(256))
+  end
+
+  it "should raise an error if you pass a non-string password" do
+    expect { scope.function_str2pbkdf2_hash([1234,'salt', 10000]) }.
+      to raise_error Puppet::ParseError, /The first argument.+must be a String/
+  end
+
+  it "should raise an error if you pass a non-string salt" do
+    expect { scope.function_str2pbkdf2_hash(['password', 1234, 10000]) }.
+      to raise_error Puppet::ParseError, /The second argument.+must be a String/
+  end
+
+  it "should raise an error if you pass a non-integer iterations value" do
+    expect { scope.function_str2pbkdf2_hash(['password', 'salt', 'buckeyebill']) }.
+      to raise_error Puppet::ParseError, /The third argument, the iterations value, could not be cast to an Integer/
+  end
+
+  it "should generate a valid password" do
+    pw_hash = '72629a41b076e588fba8c71ca37fadc9acdc8e7321b9cb4ea55fd0bf9fe8ed72def92b4c7dff5242a0254945b945394ce4d6008e947bdc7593085cd1e2f6a375e3efe32510e0f982abcc57991cb705243a3a42086e6a9e56c7b063c72636793b7622587882a872b19bb15e8fc8a865a8e83264bf802d0e52f825f18cc46a2147'
+
+    scope.function_str2pbkdf2_hash(["password", 'salt', 10000] \
+                                    ).should(eq(pw_hash))
+  end
+end


### PR DESCRIPTION
In future versions of OS X, PBKDF2 passwords are utilized. This password
hashing scheme requires a plaintext password, a salt, and a value for
the number of iterations to programmatically execute the hashing scheme
before it will generate a password hash. The resultant password hash
evaluates to be a 256 character hex value, and is tied to the value of
the salt (a string) and the iterations (an integer). If the salt or the
iterations value is changed, the resultant password hash will be
different.

Because these values are so intimately related, Puppet will need to
support two additional properties for the User resource type ('salt' and
'iterations'). This function will assist Puppet users who manage
User resources in versions of OS X that support PBKDF2 passwords.

Passing a value for the plaintext password, the salt, and the
iterations, the function will return a 256-character password hash that
can be directly inserted into a User resource's password property.

Spec tests are also included to ensure that correct values are passed
and calculated.
