### PR TITLE
(#12357) Fix root_home fact on Windows

### DIFF
--- a/lib/facter/root_home.rb
+++ b/lib/facter/root_home.rb
@@ -7,7 +7,9 @@ module Facter::Util::RootHome
   def get_root_home
     root_ent = Facter::Util::Resolution.exec("getent passwd root")
     # The home directory is the sixth element in the passwd entry
-    root_ent.split(":")[5]
+    # If the platform doesn't have getent, root_ent will be nil and we should
+    # return it straight away.
+    root_ent && root_ent.split(":")[5]
   end
   end
 end

--- a/spec/unit/facter/root_home_spec.rb
+++ b/spec/unit/facter/root_home_spec.rb
@@ -30,13 +30,11 @@ describe Facter::Util::RootHome do
     end
   end
   context "windows" do
-    let(:root_ent) { "FIXME TBD on Windows" }
-    let(:expected_root_home) { "FIXME TBD on Windows" }
-
-    it "should return FIXME TBD on windows" do
-      pending "FIXME: TBD on windows"
-      Facter::Util::Resolution.expects(:exec).with("getent passwd root").returns(root_ent)
-      Facter::Util::RootHome.get_root_home.should == expected_root_home
+    before :each do
+      Facter::Util::Resolution.expects(:exec).with("getent passwd root").returns(nil)
+    end
+    it "should be nil on windows" do
+      Facter::Util::RootHome.get_root_home.should be_nil
     end
   end
 end


### PR DESCRIPTION
Without this patch the root_home fact fails on windows.  This patch
fixes the problem by only calling methods on the object returned by the
`getent passwd root` command if the object evaluates to true.

Because there is no root account on Windows the code block simply
returns `nil` which makes the Facter fact undefined on Windows
platforms.

The root cause of the failure is that we always expected the command to
succeed and return something useful, and it may not on all supported
platforms.
