### PR TITLE
Ticket/2.3.x/13018 any on string

### DIFF
--- a/lib/puppet/parser/functions/validate_re.rb
+++ b/lib/puppet/parser/functions/validate_re.rb
@@ -30,7 +30,7 @@ module Puppet::Parser::Functions
 
     msg = args[2] || "validate_re(): #{args[0].inspect} does not match #{args[1].inspect}"
 
-    raise Puppet::ParseError, (msg) unless args[1].any? do |re_str|
+    raise Puppet::ParseError, (msg) unless [args[1]].flatten.any? do |re_str|
       args[0] =~ Regexp.compile(re_str)
     end
 


### PR DESCRIPTION
The any? method doesn't exist for 1.9.x, this converts a string to a single
element array to work around the problem.
