### PR TITLE
(#12357) Fix broken compatibility with Puppet 2.6

### DIFF
--- a/lib/puppet/parser/functions/validate_absolute_path.rb
+++ b/lib/puppet/parser/functions/validate_absolute_path.rb
@@ -30,8 +30,26 @@ module Puppet::Parser::Functions
     args.each do |arg|
       # This logic was borrowed from
       # [lib/puppet/file_serving/base.rb](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/file_serving/base.rb)
-      unless Puppet::Util.absolute_path?(arg, :posix) or Puppet::Util.absolute_path?(arg, :windows)
-        raise Puppet::ParseError, ("#{arg.inspect} is not an absolute path.")
+
+      # Puppet 2.7 and beyond will have Puppet::Util.absolute_path?  Fall back to a back-ported implementation otherwise.
+      if Puppet::Util.respond_to?(:absolute_path?) then
+        unless Puppet::Util.absolute_path?(arg, :posix) or Puppet::Util.absolute_path?(arg, :windows)
+          raise Puppet::ParseError, ("#{arg.inspect} is not an absolute path.")
+        end
+      else
+        # This code back-ported from 2.7.x's lib/puppet/util.rb Puppet::Util.absolute_path?
+        # Determine in a platform-specific way whether a path is absolute. This
+        # defaults to the local platform if none is specified.
+        # Escape once for the string literal, and once for the regex.
+        slash = '[\\\\/]'
+        name = '[^\\\\/]+'
+        regexes = {
+          :windows => %r!^(([A-Z]:#{slash})|(#{slash}#{slash}#{name}#{slash}#{name})|(#{slash}#{slash}\?#{slash}#{name}))!i,
+          :posix   => %r!^/!,
+        }
+
+        rval = (!!(arg =~ regexes[:posix])) || (!!(arg =~ regexes[:windows]))
+        rval or raise Puppet::ParseError, ("#{arg.inspect} is not an absolute path.")
       end
     end
   end

--- a/spec/unit/puppet/parser/functions/validate_absolute_path_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_absolute_path_spec.rb
@@ -5,51 +5,14 @@ describe Puppet::Parser::Functions.function(:validate_absolute_path) do
     Puppet::Parser::Functions.autoloader.loadall
   end
 
-  let(:scope) do
-    scope = Puppet::Parser::Scope.new
-  end
-
   # The subject of these examplres is the method itself.
   subject do
-    scope.method :function_validate_absolute_path
+    Puppet::Parser::Scope.new.method :function_validate_absolute_path
   end
 
-  context 'Using Puppet::Parser::Scope.new' do
-
-    describe 'Garbage inputs' do
-      paths = [
-        nil,
-        [ nil ],
-        { 'foo' => 'bar' },
-        { },
-        '',
-      ]
-
-      paths.each do |path|
-        it "validate_absolute_path(#{path.inspect}) should fail" do
-          expect { subject.call [path] }.to raise_error Puppet::ParseError
-        end
-      end
-    end
-    describe 'relative paths' do
-      paths = %w{
-        relative1
-        .
-        ..
-        ./foo
-        ../foo
-        etc/puppetlabs/puppet
-        opt/puppet/bin
-      }
-
-      paths.each do |path|
-        it "validate_absolute_path(#{path.inspect}) should fail" do
-          expect { subject.call [path] }.to raise_error Puppet::ParseError
-        end
-      end
-    end
-    describe 'absolute paths' do
-      paths = %w{
+  describe "Valid Paths" do
+    def self.valid_paths
+      %w{
         C:/
         C:\\
         C:\\WINDOWS\\System32
@@ -60,15 +23,59 @@ describe Puppet::Parser::Functions.function(:validate_absolute_path) do
         /var/lib/puppet
         /var/opt/../lib/puppet
       }
+    end
 
-      paths = paths + [
-        'C:\\Program Files (x86)\\Puppet Labs\\Puppet Enterprise',
-        'C:/Program Files (x86)/Puppet Labs/Puppet Enterprise',
-      ]
-
-      paths.each do |path|
+    context "Without Puppet::Util.absolute_path? (e.g. Puppet <= 2.6)" do
+      before :each do
+        # The intent here is to mock Puppet to behave like Puppet 2.6 does.
+        # Puppet 2.6 does not have the absolute_path? method.  This is only a
+        # convenience test, stdlib should be run with the Puppet 2.6.x in the
+        # $LOAD_PATH in addition to 2.7.x and master.
+        Puppet::Util.expects(:respond_to?).with(:absolute_path?).returns(false)
+      end
+      valid_paths.each do |path|
         it "validate_absolute_path(#{path.inspect}) should not fail" do
-          expect { subject.call [path] }.not_to raise_error
+          expect { subject.call [path] }.not_to raise_error Puppet::ParseError
+        end
+      end
+    end
+
+    context "Puppet without mocking" do
+      valid_paths.each do |path|
+        it "validate_absolute_path(#{path.inspect}) should not fail" do
+          expect { subject.call [path] }.not_to raise_error Puppet::ParseError
+        end
+      end
+    end
+  end
+
+  describe 'Invalid paths' do
+    context 'Garbage inputs' do
+      [
+        nil,
+        [ nil ],
+        { 'foo' => 'bar' },
+        { },
+        '',
+      ].each do |path|
+        it "validate_absolute_path(#{path.inspect}) should fail" do
+          expect { subject.call [path] }.to raise_error Puppet::ParseError
+        end
+      end
+    end
+
+    context 'Relative paths' do
+      %w{
+        relative1
+        .
+        ..
+        ./foo
+        ../foo
+        etc/puppetlabs/puppet
+        opt/puppet/bin
+      }.each do |path|
+        it "validate_absolute_path(#{path.inspect}) should fail" do
+          expect { subject.call [path] }.to raise_error Puppet::ParseError
         end
       end
     end


### PR DESCRIPTION
Without this patch, the previous change set to the
validate_absolute_path() parser function contains Puppet 2.6
incompatible changes.  stdlib 2.x is compatible with Puppet 2.6.  These
changes are a problem because we cannot introduce backwards incompatible
changes in a minor release.

This patch fixes the problem by back porting the implementation of the
`Puppet::Util.absolute_path?` from 2.7.x to the function block itself.

The function block tests to see if `Puppet::Util.absolute_path?` will
respond and if not, falls back to the inline back ported implementation.

The spec tests have been updated to simulate the behavior of Puppet 2.6
even when running with Puppet 2.7.
