### PR TITLE
(#13091) Fix LoadError exception with puppet apply

### DIFF
--- a/lib/facter/facter_dot_d.rb
+++ b/lib/facter/facter_dot_d.rb
@@ -12,8 +12,6 @@
 # 600 file and will have the end result of not calling your
 # fact scripts more often than is needed
 
-require 'facter/util/puppet_settings'
-
 class Facter::Util::DotD
     require 'yaml'
 

--- a/lib/facter/puppet_vardir.rb
+++ b/lib/facter/puppet_vardir.rb
@@ -4,7 +4,17 @@
 # regardless of the node's platform.
 #
 # The value should be directly usable in a File resource path attribute.
-require 'facter/util/puppet_settings'
+
+
+begin
+  require 'facter/util/puppet_settings'
+rescue LoadError => e
+  # puppet apply does not add module lib directories to the $LOAD_PATH (See
+  # #4248). It should (in the future) but for the time being we need to be
+  # defensive which is what this rescue block is doing.
+  rb_file = File.join(File.dirname(__FILE__), 'util', 'puppet_settings.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
 
 Facter.add(:puppet_vardir) do
   setcode do

--- a/lib/facter/util/puppet_settings.rb
+++ b/lib/facter/util/puppet_settings.rb
@@ -1,15 +1,19 @@
 module Facter
   module Util
     module PuppetSettings
-      class << self
-        def with_puppet
-          begin
-            Module.const_get("Puppet")
-          rescue NameError
-            nil
-          else
-            yield
-          end
+      # This method is intended to provide a convenient way to evaluate a
+      # Facter code block only if Puppet is loaded.  This is to account for the
+      # situation where the fact happens to be in the load path, but Puppet is
+      # not loaded for whatever reason.  Perhaps the user is simply running
+      # facter without the --puppet flag and they happen to be working in a lib
+      # directory of a module.
+      def self.with_puppet
+        begin
+          Module.const_get("Puppet")
+        rescue NameError
+          nil
+        else
+          yield
         end
       end
     end


### PR DESCRIPTION
Puppet apply does not add the stdlib lib directory to the $LOAD_PATH.
This is a problem because the puppet_vardir fact requires the
puppet_settings library to be available for the `with_puppet` utility
method.

Without this patch, puppet apply will result in the following error:

```
$ puppet apply --modulepath=/vagrant/modules -e 'notice $puppet_vardir'
warning: Could not load fact file stdlib/lib/facter/puppet_vardir.rb: no such file to load -- facter/util/puppet_settings
notice: Scope(Class[main]):
notice: Finished catalog run in 0.01 seconds
```

With this patch applied, puppet apply works as expected:

```
$ puppet apply --modulepath=/vagrant/modules.pe -e 'notice $puppet_vardir'
notice: Scope(Class[main]): /Users/jeff/.puppet/var
notice: Finished catalog run in 0.01 seconds
```

This patch defensively tries to load facter/util/puppet_settings.  If it cannot
load it, it falls back to trying to explicitly locate and load the library.

Once puppet is fixed such that a modules lib directory is truly in the
$LOAD_PATH, the fall back implementation will no longer be exercised since the
LoadError should not be raised.
