### PR TITLE
(#13202) Modify join() to pass strings unmodified without errors.

### DIFF
--- a/lib/puppet/parser/functions/join.rb
+++ b/lib/puppet/parser/functions/join.rb
@@ -21,6 +21,10 @@ Would result in: "a,b,c"
     array = arguments[0]
 
     unless array.is_a?(Array)
+      if array.is_a?(String)
+        # Ok, fine. return the string unmodified.
+        return array
+      end
       raise(Puppet::ParseError, 'join(): Requires array to work with')
     end
 

--- a/spec/unit/puppet/parser/functions/join_spec.rb
+++ b/spec/unit/puppet/parser/functions/join_spec.rb
@@ -23,4 +23,8 @@ describe "the join function" do
     result.should(eq("a:b:c"))
   end
 
+  it "should pass a string unmodified" do
+    result = @scope.function_join(["abc"])
+    result.should(eq("abc"))
+  end
 end


### PR DESCRIPTION
Previously the join function would raise an error if anything besides an
array was passed. This changes it to allow strings to be passed through
join unmodified. This allows puppet code to be written that can accept
either a string or an array, and act appropriately in both cases
automatically. Specifically, join("abc") would return "abc".
