### PR TITLE
Stage declaration syntax fix.

### DIFF
--- a/manifests/stages.pp
+++ b/manifests/stages.pp
@@ -32,12 +32,13 @@
 #
 class stdlib::stages {
 
-  stage { 'setup':  before => Stage['main'] }
-  stage { 'runtime': require => Stage['main'] }
-  -> stage { 'setup_infra': }
-  -> stage { 'deploy_infra': }
-  -> stage { 'setup_app': }
-  -> stage { 'deploy_app': }
-  -> stage { 'deploy': }
+  stage { 'setup': }
+  stage { 'runtime': }
+  stage { 'setup_infra': }
+  stage { 'deploy_infra': }
+  stage { 'setup_app': }
+  stage { 'deploy_app': }
+  stage { 'deploy': }
 
+  Stage[setup] -> Stage[main] -> Stage[runtime]-> Stage[setup_infra] -> Stage[deploy_infra] -> Stage[setup_app] -> Stage[deploy_app] -> Stage[deploy]
 }


### PR DESCRIPTION
I have changed the way the standard stages are declared and ordered because the other way was broken in puppet 2.7.9.  

It doesn't like the mix of declaration and -> syntax. Declare first, then order then using ->.
