### PR TITLE
(#13439) refactor spec helper for spec compatibility between 2.7 and master

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,22 +63,14 @@ RSpec.configure do |config|
   config.before :each do
     GC.disable
 
-    # these globals are set by Application
-    $puppet_application_mode = nil
-    $puppet_application_name = nil
 
     # REVISIT: I think this conceals other bad tests, but I don't have time to
     # fully diagnose those right now.  When you read this, please come tell me
     # I suck for letting this float. --daniel 2011-04-21
     Signal.stubs(:trap)
 
-    # Set the confdir and vardir to gibberish so that tests
-    # have to be correctly mocked.
-    Puppet[:confdir] = "/dev/null"
-    Puppet[:vardir] = "/dev/null"
+    Puppet.settings.send(:initialize_everything_for_tests)
 
-    # Avoid opening ports to the outside world
-    Puppet.settings[:bindaddress] = "127.0.0.1"
 
     @logs = []
     Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(@logs))
@@ -87,7 +79,7 @@ RSpec.configure do |config|
   end
 
   config.after :each do
-    Puppet.settings.clear
+    Puppet.settings.send(:clear_everything_for_tests)
     Puppet::Node::Environment.clear
     Puppet::Util::Storage.clear
     Puppet::Util::ExecutionStub.reset if Puppet::Util.constants.include? "ExecutionStub"


### PR DESCRIPTION
This change is intended to allow specs in external projects (grayskull, puppetlabs-stdlib) to be compatible with both 2.7 and master versions of puppet.  It basically just abstracts the interactions with the Settings objects that was happening in spec_helper into private setup / teardown methods in the Settings class itself.

We'd already started this pattern in master, so this change just exposes it in 2.7 as well.

Should be merged at the same time as pull request 602:

https://github.com/puppetlabs/puppet/pull/602
