### PR TITLE
add a "step" argument to range()

### DIFF
--- a/lib/puppet/parser/functions/range.rb
+++ b/lib/puppet/parser/functions/range.rb
@@ -18,6 +18,13 @@ Will return: [0,1,2,3,4,5,6,7,8,9]
     range("a", "c")
 
 Will return: ["a","b","c"]
+
+Passing a third argument will cause the generated range to step by that 
+interval, e.g.
+
+    range("0", "9", "2")
+
+Will return: [0,2,4,6,8]
     EOS
   ) do |arguments|
 
@@ -28,6 +35,7 @@ Will return: ["a","b","c"]
     if arguments.size > 1
       start = arguments[0]
       stop  = arguments[1]
+      step  = arguments[2].nil? ? 1 : arguments[2].to_i.abs
 
       type = '..' # We select simplest type for Range available in Ruby ...
 
@@ -62,7 +70,7 @@ Will return: ["a","b","c"]
         when /^(\.\.\.)$/  then (start ... stop) # Exclusive of last element ...
       end
 
-      result = range.collect { |i| i } # Get them all ... Pokemon ...
+      result = range.step(step).collect { |i| i } # Get them all ... Pokemon ...
 
     return result
   end

--- a/spec/unit/puppet/parser/functions/range_spec.rb
+++ b/spec/unit/puppet/parser/functions/range_spec.rb
@@ -23,9 +23,39 @@ describe "the range function" do
     result.should(eq(['a','b','c','d']))
   end
 
+  it "should return a letter range given a step of 1" do
+    result = @scope.function_range(["a","d","1"])
+    result.should(eq(['a','b','c','d']))
+  end
+
+  it "should return a stepped letter range" do
+    result = @scope.function_range(["a","d","2"])
+    result.should(eq(['a','c']))
+  end
+
+  it "should return a stepped letter range given a negative step" do
+    result = @scope.function_range(["1","4","-2"])
+    result.should(eq(['a','c']))
+  end
+
   it "should return a number range" do
     result = @scope.function_range(["1","4"])
     result.should(eq([1,2,3,4]))
+  end
+
+  it "should return a number range given a step of 1" do
+    result = @scope.function_range(["1","4","1"])
+    result.should(eq([1,2,3,4]))
+  end
+
+  it "should return a stepped number range" do
+    result = @scope.function_range(["1","4","2"])
+    result.should(eq([1,3]))
+  end
+
+  it "should return a stepped number range given a negative step" do
+    result = @scope.function_range(["1","4","-2"])
+    result.should(eq([1,3]))
   end
 
 end


### PR DESCRIPTION
This patch adds an optional "step" argument to the stdlib range()
function.  There is no change to the default behavior of the function;
however, passing a numeric "step" argument invokes the Ruby Range#step
method, e.g.

```
range("0", "9", "2")
```

returns

```
[0,2,4,6,8]
```

I've created ticket [13601](https://projects.puppetlabs.com/issues/13601) 
in Redmine to track this request.

-steve
