### PR TITLE
bug #13917 - file_line messes up if a file doesn't end with a newline

### DIFF
--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -7,6 +7,12 @@ Puppet::Type.type(:file_line).provide(:ruby) do
   end
 
   def create
+    unless File.readlines(resource[:path])[-1] =~ /\n$/
+      File.open(resource[:path], 'a') do |fh|
+	fh.puts '\n'
+      end
+    end
+
     File.open(resource[:path], 'a') do |fh|
       fh.puts resource[:line]
     end


### PR DESCRIPTION
http://projects.puppetlabs.com/issues/13917

If a file doesn’t end with a new line, file_line will append its line to the last line of the file instead of starting a new line for itself.

```
$ cat foo.pp 
file_line { 'messes up when there is no newline':
line => 'bar=2',
path => '/tmp/test.txt',
}
$ # create that doesn't end with a newline
$ echo -n 'foo=1' > /tmp/test.txt
$ puppet apply foo.pp 
notice: /Stage[main]//File_line[messes up when there is no newline]/ensure: created
notice: Finished catalog run in 0.21 seconds
$ cat /tmp/test.txt 
foo=1bar=2
$     
```
