### PR TITLE
Fix regression of fix for #11017

### DIFF
--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -24,6 +24,7 @@ Puppet::Type.newtype(:file_line) do
   EOT
 
   ensurable do
+    defaultvalues
     defaultto :present
   end
 


### PR DESCRIPTION
ensure should have a default of :present. Unfortunately, the
Ensure class does not do that by default for our type. So we
need to do that here explicitly.

This restores the old (sane) behavior. See part of the discussion in 
https://github.com/puppetlabs/puppetlabs-stdlib/pull/36
