### PR TITLE
fix #13917 - add linebreak if there isn't yet one

### DIFF
--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -7,8 +7,9 @@ Puppet::Type.type(:file_line).provide(:ruby) do
   end
 
   def create
+    lbr = ends_with_linebreak? ? "\n" : ''
     File.open(resource[:path], 'a') do |fh|
-      fh.puts resource[:line]
+       fh.puts "#{lbr}#{resource[:line]}"
     end
   end
 
@@ -22,6 +23,10 @@ Puppet::Type.type(:file_line).provide(:ruby) do
   private
   def lines
     @lines ||= File.readlines(resource[:path])
+  end
+
+  def ends_with_linebreak?
+    (File.size(resource[:path]) > 0) && File.read(resource[:path],1,File.size(resource[:path])-1) != "\n"
   end
 
 end

--- a/spec/unit/puppet/provider/file_line/ruby_spec.rb
+++ b/spec/unit/puppet/provider/file_line/ruby_spec.rb
@@ -25,8 +25,16 @@ describe provider_class do
       @provider.exists?.should be_nil
     end
     it 'should append to an existing file when creating' do
+      FileUtils.touch(@tmpfile) # *existing* file
       @provider.create
       File.read(@tmpfile).chomp.should == 'foo'
+    end
+    it 'should append a linebreak to an existing file when it does not end with one' do
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write('foo1')
+      end
+      @provider.create
+      File.read(@tmpfile).chomp.should == "foo1\nfoo"
     end
   end
 


### PR DESCRIPTION
If a file didn't yet have a linebreak at the end we wouldn't add
our new line on a new line rather at the end of the last line.

This commit fixes that bug, furthermore it ensures that while
running all the "add" specs all the tmpfile exists, as this is
what we assume in our current codebase.

This is an alternative implementation to GH-62
