### PR TITLE
implement #14670 - autorequire file_line's path

### DIFF
--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -45,6 +45,11 @@ Puppet::Type.newtype(:file_line) do
     end
   end
 
+  # Autorequire the file resource if it's being managed
+  autorequire(:file) do
+    self[:path]
+  end
+
   validate do
     unless self[:line] and self[:path]
       raise(Puppet::Error, "Both line and path are required attributes")

--- a/spec/unit/puppet/type/file_line_spec.rb
+++ b/spec/unit/puppet/type/file_line_spec.rb
@@ -24,4 +24,23 @@ describe Puppet::Type.type(:file_line) do
   it 'should default to ensure => present' do
     file_line[:ensure].should eq :present
   end
+
+  it "should autorequire the file it manages" do
+    catalog = Puppet::Resource::Catalog.new
+    file = Puppet::Type.type(:file).new(:name => "/tmp/path")
+    catalog.add_resource file
+    catalog.add_resource file_line
+    reqs = file_line.autorequire
+    reqs.size.should eq 1
+    reqs[0].source.should eq file
+    reqs[0].target.should eq file_line
+  end
+
+  it "should not autorequire the file it manages if it is not managed" do
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource file_line
+    reqs = file_line.autorequire
+    reqs.size.should eq 0
+  end
+
 end


### PR DESCRIPTION
If we manage a file we edit with file_line, it should be
autorequired by file_line.

http://projects.puppetlabs.com/issues/14670
