### PR TITLE
(#2157) Make facts_dot_d compatible with external facts

### DIFF
--- a/lib/facter/facter_dot_d.rb
+++ b/lib/facter/facter_dot_d.rb
@@ -94,6 +94,7 @@ class Facter::Util::DotD
                 cache_save!
             end
         else
+            Puppet.deprecation_warning("TTL for external facts is being removed. See http://links.puppetlabs.com/factercaching for more information.")
             Facter.debug("Using cached data for #{file}")
         end
 


### PR DESCRIPTION
Since facts_dot_d will eventually be removed and replaced by
external facts, warn users who are using a ttl on their external
facts that this feature will not be in Facter external facts.

Provide a link to a page explaining how to cache fact values
without the ttl functionality.
