### PR TITLE
Make anchor type feed through refresh events

### DIFF
--- a/lib/puppet/type/anchor.rb
+++ b/lib/puppet/type/anchor.rb
@@ -38,4 +38,10 @@ Puppet::Type.newtype(:anchor) do
     desc "The name of the anchor resource."
   end
 
+  def refresh
+    # We don't do anything with them, but we need this to
+    #   show that we are "refresh aware" and not break the
+    #   chain of propagation.
+  end
+
 end


### PR DESCRIPTION
This commit makes anchor pass through refresh events, so that it can be used to manage subscribe-style relationships between classes as well as require-style relationships. This is exactly the way that whit.rb does it in puppet core.
