### PR TITLE
(Maint) use PuppetlabsSpec::PuppetSeams.parser_scope

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,6 @@
 dir = File.expand_path(File.dirname(__FILE__))
 $LOAD_PATH.unshift File.join(dir, 'lib')
 
-p dir
-
 # Don't want puppet getting the command line arguments for rake or autotest
 ARGV.clear
 
@@ -12,27 +10,5 @@ require 'mocha'
 gem 'rspec', '>=2.0.0'
 require 'rspec/expectations'
 
+require 'puppetlabs_spec_helper/module_spec_helper'
 
-# So everyone else doesn't have to include this base constant.
-module PuppetSpec
-  FIXTURE_DIR = File.join(dir = File.expand_path(File.dirname(__FILE__)), "fixtures") unless defined?(FIXTURE_DIR)
-end
-
-# TODO: ultimately would like to move these requires into the puppet_spec_helper.rb file, but the namespaces
-#  are not currently the same between the two, so tests would need to be modified.  Not ready to undertake that
-#  just yet.
-require 'puppet_spec/files'
-
-require 'puppet_spec_helper'
-
-
-RSpec.configure do |config|
-
-  config.before :each do
-    GC.disable
-  end
-
-  config.after :each do
-    GC.enable
-  end
-end

--- a/spec/unit/puppet/parser/functions/abs_spec.rb
+++ b/spec/unit/puppet/parser/functions/abs_spec.rb
@@ -1,31 +1,25 @@
 #! /usr/bin/env ruby -S rspec
+
 require 'spec_helper'
 
 describe "the abs function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("abs").should == "function_abs"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_abs([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_abs([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should convert a negative number into a positive" do
-    result = @scope.function_abs(["-34"])
+    result = scope.function_abs(["-34"])
     result.should(eq(34))
   end
 
   it "should do nothing with a positive number" do
-    result = @scope.function_abs(["5678"])
+    result = scope.function_abs(["5678"])
     result.should(eq(5678))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/bool2num_spec.rb
+++ b/spec/unit/puppet/parser/functions/bool2num_spec.rb
@@ -2,30 +2,23 @@
 require 'spec_helper'
 
 describe "the bool2num function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("bool2num").should == "function_bool2num"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_bool2num([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_bool2num([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should convert true to 1" do
-    result = @scope.function_bool2num([true])
+    result = scope.function_bool2num([true])
     result.should(eq(1))
   end
 
   it "should convert false to 0" do
-    result = @scope.function_bool2num([false])
+    result = scope.function_bool2num([false])
     result.should(eq(0))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/capitalize_spec.rb
+++ b/spec/unit/puppet/parser/functions/capitalize_spec.rb
@@ -2,25 +2,18 @@
 require 'spec_helper'
 
 describe "the capitalize function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("capitalize").should == "function_capitalize"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_capitalize([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_capitalize([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should capitalize the beginning of a string" do
-    result = @scope.function_capitalize(["abc"])
+    result = scope.function_capitalize(["abc"])
     result.should(eq("Abc"))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/chomp_spec.rb
+++ b/spec/unit/puppet/parser/functions/chomp_spec.rb
@@ -2,25 +2,18 @@
 require 'spec_helper'
 
 describe "the chomp function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("chomp").should == "function_chomp"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_chomp([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_chomp([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should chomp the end of a string" do
-    result = @scope.function_chomp(["abc\n"])
+    result = scope.function_chomp(["abc\n"])
     result.should(eq("abc"))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/chop_spec.rb
+++ b/spec/unit/puppet/parser/functions/chop_spec.rb
@@ -2,25 +2,18 @@
 require 'spec_helper'
 
 describe "the chop function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("chop").should == "function_chop"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_chop([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_chop([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should chop the end of a string" do
-    result = @scope.function_chop(["asdf\n"])
+    result = scope.function_chop(["asdf\n"])
     result.should(eq("asdf"))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/delete_at_spec.rb
+++ b/spec/unit/puppet/parser/functions/delete_at_spec.rb
@@ -2,25 +2,18 @@
 require 'spec_helper'
 
 describe "the delete_at function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("delete_at").should == "function_delete_at"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_delete_at([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_delete_at([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should delete an item at specified location from an array" do
-    result = @scope.function_delete_at([['a','b','c'],1])
+    result = scope.function_delete_at([['a','b','c'],1])
     result.should(eq(['a','c']))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/delete_spec.rb
+++ b/spec/unit/puppet/parser/functions/delete_spec.rb
@@ -2,25 +2,18 @@
 require 'spec_helper'
 
 describe "the delete function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("delete").should == "function_delete"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_delete([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_delete([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should delete an item from an array" do
-    result = @scope.function_delete([['a','b','c'],'b'])
+    result = scope.function_delete([['a','b','c'],'b'])
     result.should(eq(['a','c']))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/downcase_spec.rb
+++ b/spec/unit/puppet/parser/functions/downcase_spec.rb
@@ -2,30 +2,23 @@
 require 'spec_helper'
 
 describe "the downcase function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("downcase").should == "function_downcase"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_downcase([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_downcase([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should downcase a string" do
-    result = @scope.function_downcase(["ASFD"])
+    result = scope.function_downcase(["ASFD"])
     result.should(eq("asfd"))
   end
 
   it "should do nothing to a string that is already downcase" do
-    result = @scope.function_downcase(["asdf asdf"])
+    result = scope.function_downcase(["asdf asdf"])
     result.should(eq("asdf asdf"))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/empty_spec.rb
+++ b/spec/unit/puppet/parser/functions/empty_spec.rb
@@ -2,30 +2,22 @@
 require 'spec_helper'
 
 describe "the empty function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
-
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
   it "should exist" do
     Puppet::Parser::Functions.function("empty").should == "function_empty"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_empty([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_empty([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return a true for an empty string" do
-    result = @scope.function_empty([''])
+    result = scope.function_empty([''])
     result.should(eq(true))
   end
 
   it "should return a false for a non-empty string" do
-    result = @scope.function_empty(['asdf'])
+    result = scope.function_empty(['asdf'])
     result.should(eq(false))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/flatten_spec.rb
+++ b/spec/unit/puppet/parser/functions/flatten_spec.rb
@@ -2,30 +2,22 @@
 require 'spec_helper'
 
 describe "the flatten function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
-
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
   it "should exist" do
     Puppet::Parser::Functions.function("flatten").should == "function_flatten"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_flatten([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_flatten([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should flatten a complex data structure" do
-    result = @scope.function_flatten([["a","b",["c",["d","e"],"f","g"]]])
+    result = scope.function_flatten([["a","b",["c",["d","e"],"f","g"]]])
     result.should(eq(["a","b","c","d","e","f","g"]))
   end
 
   it "should do nothing to a structure that is already flat" do
-    result = @scope.function_flatten([["a","b","c","d"]])
+    result = scope.function_flatten([["a","b","c","d"]])
     result.should(eq(["a","b","c","d"]))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/getvar_spec.rb
+++ b/spec/unit/puppet/parser/functions/getvar_spec.rb
@@ -1,36 +1,17 @@
-require 'puppet'
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
 
-# We don't need this for the basic tests we're doing
-# require 'spec_helper'
-
-# Dan mentioned that Nick recommended the function method call
-# to return the string value for the test description.
-# this will not even try the test if the function cannot be
-# loaded.
 describe Puppet::Parser::Functions.function(:getvar) do
-
-  # Pulled from Dan's create_resources function
-  def get_scope
-    @topscope = Puppet::Parser::Scope.new
-    # This is necessary so we don't try to use the compiler to discover our parent.
-    @topscope.parent = nil
-    @scope = Puppet::Parser::Scope.new
-    @scope.compiler = Puppet::Parser::Compiler.new(Puppet::Node.new("floppy", :environment => 'production'))
-    @scope.parent = @topscope
-    @compiler = @scope.compiler
-  end
-
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
   describe 'when calling getvar from puppet' do
 
     it "should not compile when no arguments are passed" do
       Puppet[:code] = 'getvar()'
-      get_scope
-      expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
+      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
     end
     it "should not compile when too many arguments are passed" do
       Puppet[:code] = 'getvar("foo::bar", "baz")'
-      get_scope
-      expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
+      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
     end
 
     it "should lookup variables in other namespaces" do
@@ -43,11 +24,7 @@ describe Puppet::Parser::Functions.function(:getvar) do
           fail('getvar did not return what we expect')
         }
       ENDofPUPPETcode
-      get_scope
-      @scope.compiler.compile
+      scope.compiler.compile
     end
-
   end
-
 end
-

--- a/spec/unit/puppet/parser/functions/grep_spec.rb
+++ b/spec/unit/puppet/parser/functions/grep_spec.rb
@@ -2,25 +2,18 @@
 require 'spec_helper'
 
 describe "the grep function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("grep").should == "function_grep"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_grep([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_grep([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should grep contents from an array" do
-    result = @scope.function_grep([["aaabbb","bbbccc","dddeee"], "bbb"])
+    result = scope.function_grep([["aaabbb","bbbccc","dddeee"], "bbb"])
     result.should(eq(["aaabbb","bbbccc"]))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/has_key_spec.rb
+++ b/spec/unit/puppet/parser/functions/has_key_spec.rb
@@ -1,37 +1,21 @@
-require 'puppet'
-require 'mocha'
-describe Puppet::Parser::Functions.function(:has_key) do
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
 
-  # Pulled from Dan's create_resources function
-  # TODO - this should be moved to spec_helper since the
-  # logic is likely to be applied to multiple rspec files.
-  let(:compiler) {
-    topscope = Puppet::Parser::Scope.new
-    # This is necessary so we don't try to use the compiler to discover our parent.
-    topscope.parent = nil
-    my_scope = Puppet::Parser::Scope.new
-    my_scope.compiler = Puppet::Parser::Compiler.new(Puppet::Node.new("floppy", :environment => 'production'))
-    my_scope.parent = topscope
-    compiler = my_scope.compiler
-  }
-  let(:scope) {
-    scope = Puppet::Parser::Scope.new
-    scope.stubs(:environment).returns(Puppet::Node::Environment.new('production'))
-    scope
-  }
+describe Puppet::Parser::Functions.function(:has_key) do
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   describe 'when calling has_key from puppet' do
     it "should not compile when no arguments are passed" do
       Puppet[:code] = 'has_key()'
-      expect { compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
+      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
     end
     it "should not compile when 1 argument is passed" do
       Puppet[:code] = "has_key('foo')"
-      expect { compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
+      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
     end
     it "should require the first value to be a Hash" do
       Puppet[:code] = "has_key('foo', 'bar')"
-      expect { compiler.compile }.should raise_error(Puppet::ParseError, /expects the first argument to be a hash/)
+      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /expects the first argument to be a hash/)
     end
   end
   describe 'when calling the function has_key from a scope instance' do
@@ -42,5 +26,4 @@ describe Puppet::Parser::Functions.function(:has_key) do
       scope.function_has_key([{'one' => 1}, 'two']).should be_false
     end
   end
-
 end

--- a/spec/unit/puppet/parser/functions/hash_spec.rb
+++ b/spec/unit/puppet/parser/functions/hash_spec.rb
@@ -2,25 +2,18 @@
 require 'spec_helper'
 
 describe "the hash function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("hash").should == "function_hash"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_hash([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_hash([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should convert an array to a hash" do
-    result = @scope.function_hash([['a',1,'b',2,'c',3]])
+    result = scope.function_hash([['a',1,'b',2,'c',3]])
     result.should(eq({'a'=>1,'b'=>2,'c'=>3}))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/is_array_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_array_spec.rb
@@ -2,35 +2,28 @@
 require 'spec_helper'
 
 describe "the is_array function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_array").should == "function_is_array"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_is_array([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_is_array([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return true if passed an array" do
-    result = @scope.function_is_array([[1,2,3]])
+    result = scope.function_is_array([[1,2,3]])
     result.should(eq(true))
   end
 
   it "should return false if passed a hash" do
-    result = @scope.function_is_array([{'a'=>1}])
+    result = scope.function_is_array([{'a'=>1}])
     result.should(eq(false))
   end
 
   it "should return false if passed a string" do
-    result = @scope.function_is_array(["asdf"])
+    result = scope.function_is_array(["asdf"])
     result.should(eq(false))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/is_domain_name_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_domain_name_spec.rb
@@ -2,11 +2,7 @@
 require 'spec_helper'
 
 describe "the is_domain_name function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  let(:scope) { Puppet::Parser::Scope.new }
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_domain_name").should == "function_is_domain_name"

--- a/spec/unit/puppet/parser/functions/is_float_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_float_spec.rb
@@ -2,35 +2,28 @@
 require 'spec_helper'
 
 describe "the is_float function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_float").should == "function_is_float"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_is_float([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_is_float([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return true if a float" do
-    result = @scope.function_is_float(["0.12"])
+    result = scope.function_is_float(["0.12"])
     result.should(eq(true))
   end
 
   it "should return false if a string" do
-    result = @scope.function_is_float(["asdf"])
+    result = scope.function_is_float(["asdf"])
     result.should(eq(false))
   end
 
   it "should return false if an integer" do
-    result = @scope.function_is_float(["3"])
+    result = scope.function_is_float(["3"])
     result.should(eq(false))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/is_hash_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_hash_spec.rb
@@ -2,35 +2,28 @@
 require 'spec_helper'
 
 describe "the is_hash function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_hash").should == "function_is_hash"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_is_hash([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_is_hash([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return true if passed a hash" do
-    result = @scope.function_is_hash([{"a"=>1,"b"=>2}])
+    result = scope.function_is_hash([{"a"=>1,"b"=>2}])
     result.should(eq(true))
   end
 
   it "should return false if passed an array" do
-    result = @scope.function_is_hash([["a","b"]])
+    result = scope.function_is_hash([["a","b"]])
     result.should(eq(false))
   end
 
   it "should return false if passed a string" do
-    result = @scope.function_is_hash(["asdf"])
+    result = scope.function_is_hash(["asdf"])
     result.should(eq(false))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/is_integer_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_integer_spec.rb
@@ -2,35 +2,28 @@
 require 'spec_helper'
 
 describe "the is_integer function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_integer").should == "function_is_integer"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_is_integer([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_is_integer([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return true if an integer" do
-    result = @scope.function_is_integer(["3"])
+    result = scope.function_is_integer(["3"])
     result.should(eq(true))
   end
 
   it "should return false if a float" do
-    result = @scope.function_is_integer(["3.2"])
+    result = scope.function_is_integer(["3.2"])
     result.should(eq(false))
   end
 
   it "should return false if a string" do
-    result = @scope.function_is_integer(["asdf"])
+    result = scope.function_is_integer(["asdf"])
     result.should(eq(false))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/is_ip_address_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_ip_address_spec.rb
@@ -2,44 +2,38 @@
 require 'spec_helper'
 
 describe "the is_ip_address function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_ip_address").should == "function_is_ip_address"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_is_ip_address([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_is_ip_address([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return true if an IPv4 address" do
-    result = @scope.function_is_ip_address(["1.2.3.4"])
+    result = scope.function_is_ip_address(["1.2.3.4"])
     result.should(eq(true))
   end
 
   it "should return true if a full IPv6 address" do
-    result = @scope.function_is_ip_address(["fe80:0000:cd12:d123:e2f8:47ff:fe09:dd74"])
+    result = scope.function_is_ip_address(["fe80:0000:cd12:d123:e2f8:47ff:fe09:dd74"])
     result.should(eq(true))
   end
 
   it "should return true if a compressed IPv6 address" do
-    result = @scope.function_is_ip_address(["fe00::1"])
+    result = scope.function_is_ip_address(["fe00::1"])
     result.should(eq(true))
   end
 
   it "should return false if not valid" do
-    result = @scope.function_is_ip_address(["asdf"])
+    result = scope.function_is_ip_address(["asdf"])
     result.should(eq(false))
   end
 
   it "should return false if IP octets out of range" do
-    result = @scope.function_is_ip_address(["1.1.1.300"])
+    result = scope.function_is_ip_address(["1.1.1.300"])
     result.should(eq(false))
   end
 end

--- a/spec/unit/puppet/parser/functions/is_mac_address_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_mac_address_spec.rb
@@ -2,35 +2,28 @@
 require 'spec_helper'
 
 describe "the is_mac_address function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_mac_address").should == "function_is_mac_address"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_is_mac_address([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_is_mac_address([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return true if a valid mac address" do
-    result = @scope.function_is_mac_address(["00:a0:1f:12:7f:a0"])
+    result = scope.function_is_mac_address(["00:a0:1f:12:7f:a0"])
     result.should(eq(true))
   end
 
   it "should return false if octets are out of range" do
-    result = @scope.function_is_mac_address(["00:a0:1f:12:7f:g0"])
+    result = scope.function_is_mac_address(["00:a0:1f:12:7f:g0"])
     result.should(eq(false))
   end
 
   it "should return false if not valid" do
-    result = @scope.function_is_mac_address(["not valid"])
+    result = scope.function_is_mac_address(["not valid"])
     result.should(eq(false))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/is_numeric_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_numeric_spec.rb
@@ -2,35 +2,28 @@
 require 'spec_helper'
 
 describe "the is_numeric function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_numeric").should == "function_is_numeric"
   end
 
   it "should raise a ParseError if there is less than 1 argument" do
-    lambda { @scope.function_is_numeric([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_is_numeric([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return true if an integer" do
-    result = @scope.function_is_numeric(["3"])
+    result = scope.function_is_numeric(["3"])
     result.should(eq(true))
   end
 
   it "should return true if a float" do
-    result = @scope.function_is_numeric(["3.2"])
+    result = scope.function_is_numeric(["3.2"])
     result.should(eq(true))
   end
 
   it "should return false if a string" do
-    result = @scope.function_is_numeric(["asdf"])
+    result = scope.function_is_numeric(["asdf"])
     result.should(eq(false))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/is_string_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_string_spec.rb
@@ -2,40 +2,33 @@
 require 'spec_helper'
 
 describe "the is_string function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_string").should == "function_is_string"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_is_string([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_is_string([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return true if a string" do
-    result = @scope.function_is_string(["asdf"])
+    result = scope.function_is_string(["asdf"])
     result.should(eq(true))
   end
 
   it "should return false if an integer" do
-    result = @scope.function_is_string(["3"])
+    result = scope.function_is_string(["3"])
     result.should(eq(false))
   end
 
   it "should return false if a float" do
-    result = @scope.function_is_string(["3.23"])
+    result = scope.function_is_string(["3.23"])
     result.should(eq(false))
   end
 
   it "should return false if an array" do
-    result = @scope.function_is_string([["a","b","c"]])
+    result = scope.function_is_string([["a","b","c"]])
     result.should(eq(false))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/join_spec.rb
+++ b/spec/unit/puppet/parser/functions/join_spec.rb
@@ -2,25 +2,18 @@
 require 'spec_helper'
 
 describe "the join function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("join").should == "function_join"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_join([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_join([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should join an array into a string" do
-    result = @scope.function_join([["a","b","c"], ":"])
+    result = scope.function_join([["a","b","c"], ":"])
     result.should(eq("a:b:c"))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/keys_spec.rb
+++ b/spec/unit/puppet/parser/functions/keys_spec.rb
@@ -2,11 +2,7 @@
 require 'spec_helper'
 
 describe "the keys function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  let(:scope) { Puppet::Parser::Scope.new }
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("keys").should == "function_keys"

--- a/spec/unit/puppet/parser/functions/lstrip_spec.rb
+++ b/spec/unit/puppet/parser/functions/lstrip_spec.rb
@@ -2,25 +2,18 @@
 require 'spec_helper'
 
 describe "the lstrip function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("lstrip").should == "function_lstrip"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_lstrip([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_lstrip([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should lstrip a string" do
-    result = @scope.function_lstrip(["  asdf"])
+    result = scope.function_lstrip(["  asdf"])
     result.should(eq('asdf'))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/member_spec.rb
+++ b/spec/unit/puppet/parser/functions/member_spec.rb
@@ -2,30 +2,23 @@
 require 'spec_helper'
 
 describe "the member function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("member").should == "function_member"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_member([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_member([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return true if a member is in an array" do
-    result = @scope.function_member([["a","b","c"], "a"])
+    result = scope.function_member([["a","b","c"], "a"])
     result.should(eq(true))
-  end  
+  end
 
   it "should return false if a member is not in an array" do
-    result = @scope.function_member([["a","b","c"], "d"])
+    result = scope.function_member([["a","b","c"], "d"])
     result.should(eq(false))
-  end  
-
+  end
 end

--- a/spec/unit/puppet/parser/functions/merge_spec.rb
+++ b/spec/unit/puppet/parser/functions/merge_spec.rb
@@ -1,33 +1,18 @@
-require 'puppet'
-require 'mocha'
-describe Puppet::Parser::Functions.function(:merge) do
+#! /usr/bin/env ruby -S rspec
 
-  # Pulled from Dan's create_resources function
-  # TODO - these let statements should be moved somewhere
-  # where they can be resued
-  let(:compiler) {
-    topscope = Puppet::Parser::Scope.new
-    # This is necessary so we don't try to use the compiler to discover our parent.
-    topscope.parent = nil
-    my_scope = Puppet::Parser::Scope.new
-    my_scope.compiler = Puppet::Parser::Compiler.new(Puppet::Node.new("floppy", :environment => 'production'))
-    my_scope.parent = topscope
-    compiler = my_scope.compiler
-  }
-  let(:scope) {
-    scope = Puppet::Parser::Scope.new
-    scope.stubs(:environment).returns(Puppet::Node::Environment.new('production'))
-    scope
-  }
+require 'spec_helper'
+
+describe Puppet::Parser::Functions.function(:merge) do
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   describe 'when calling merge from puppet' do
     it "should not compile when no arguments are passed" do
       Puppet[:code] = 'merge()'
-      expect { compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
+      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
     end
     it "should not compile when 1 argument is passed" do
       Puppet[:code] = "$my_hash={'one' => 1}\nmerge($my_hash)"
-      expect { compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
+      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
     end
   end
   describe 'when calling merge on the scope instance' do
@@ -48,7 +33,5 @@ describe Puppet::Parser::Functions.function(:merge) do
     it 'should accept empty hashes' do
       scope.function_merge([{},{},{}]).should == {}
     end
-
   end
-
 end

--- a/spec/unit/puppet/parser/functions/num2bool_spec.rb
+++ b/spec/unit/puppet/parser/functions/num2bool_spec.rb
@@ -2,30 +2,23 @@
 require 'spec_helper'
 
 describe "the num2bool function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("num2bool").should == "function_num2bool"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_num2bool([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_num2bool([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return true if 1" do
-    result = @scope.function_num2bool(["1"])
+    result = scope.function_num2bool(["1"])
     result.should(be_true)
   end
 
   it "should return false if 0" do
-    result = @scope.function_num2bool(["0"])
+    result = scope.function_num2bool(["0"])
     result.should(be_false)
   end
-
 end

--- a/spec/unit/puppet/parser/functions/parsejson_spec.rb
+++ b/spec/unit/puppet/parser/functions/parsejson_spec.rb
@@ -2,28 +2,21 @@
 require 'spec_helper'
 
 describe "the parsejson function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("parsejson").should == "function_parsejson"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_parsejson([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_parsejson([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should convert JSON to a data structure" do
     json = <<-EOS
 ["aaa","bbb","ccc"]
 EOS
-    result = @scope.function_parsejson([json])
+    result = scope.function_parsejson([json])
     result.should(eq(['aaa','bbb','ccc']))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/parseyaml_spec.rb
+++ b/spec/unit/puppet/parser/functions/parseyaml_spec.rb
@@ -2,20 +2,14 @@
 require 'spec_helper'
 
 describe "the parseyaml function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("parseyaml").should == "function_parseyaml"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_parseyaml([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_parseyaml([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should convert YAML to a data structure" do
@@ -24,8 +18,7 @@ describe "the parseyaml function" do
 - bbb
 - ccc
 EOS
-    result = @scope.function_parseyaml([yaml])
+    result = scope.function_parseyaml([yaml])
     result.should(eq(['aaa','bbb','ccc']))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/prefix_spec.rb
+++ b/spec/unit/puppet/parser/functions/prefix_spec.rb
@@ -2,25 +2,18 @@
 require 'spec_helper'
 
 describe "the prefix function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("prefix").should == "function_prefix"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_prefix([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_prefix([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return a prefixed array" do
-    result = @scope.function_prefix([['a','b','c'], 'p'])
+    result = scope.function_prefix([['a','b','c'], 'p'])
     result.should(eq(['pa','pb','pc']))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/range_spec.rb
+++ b/spec/unit/puppet/parser/functions/range_spec.rb
@@ -2,13 +2,7 @@
 require 'spec_helper'
 
 describe "the range function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  let :scope do
-    Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("range").should == "function_range"

--- a/spec/unit/puppet/parser/functions/reverse_spec.rb
+++ b/spec/unit/puppet/parser/functions/reverse_spec.rb
@@ -2,25 +2,18 @@
 require 'spec_helper'
 
 describe "the reverse function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("reverse").should == "function_reverse"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_reverse([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_reverse([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should reverse a string" do
-    result = @scope.function_reverse(["asdfghijkl"])
+    result = scope.function_reverse(["asdfghijkl"])
     result.should(eq('lkjihgfdsa'))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/rstrip_spec.rb
+++ b/spec/unit/puppet/parser/functions/rstrip_spec.rb
@@ -2,30 +2,23 @@
 require 'spec_helper'
 
 describe "the rstrip function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("rstrip").should == "function_rstrip"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_rstrip([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_rstrip([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should rstrip a string" do
-    result = @scope.function_rstrip(["asdf  "])
+    result = scope.function_rstrip(["asdf  "])
     result.should(eq('asdf'))
   end
 
   it "should rstrip each element in an array" do
-    result = @scope.function_rstrip([["a ","b ", "c "]])
+    result = scope.function_rstrip([["a ","b ", "c "]])
     result.should(eq(['a','b','c']))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/shuffle_spec.rb
+++ b/spec/unit/puppet/parser/functions/shuffle_spec.rb
@@ -2,30 +2,23 @@
 require 'spec_helper'
 
 describe "the shuffle function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("shuffle").should == "function_shuffle"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_shuffle([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_shuffle([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should shuffle a string and the result should be the same size" do
-    result = @scope.function_shuffle(["asdf"])
+    result = scope.function_shuffle(["asdf"])
     result.size.should(eq(4))
   end
 
   it "should shuffle a string but the sorted contents should still be the same" do
-    result = @scope.function_shuffle(["adfs"])
+    result = scope.function_shuffle(["adfs"])
     result.split("").sort.join("").should(eq("adfs"))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/size_spec.rb
+++ b/spec/unit/puppet/parser/functions/size_spec.rb
@@ -2,30 +2,23 @@
 require 'spec_helper'
 
 describe "the size function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("size").should == "function_size"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_size([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_size([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return the size of a string" do
-    result = @scope.function_size(["asdf"])
+    result = scope.function_size(["asdf"])
     result.should(eq(4))
   end
 
   it "should return the size of an array" do
-    result = @scope.function_size([["a","b","c"]])
+    result = scope.function_size([["a","b","c"]])
     result.should(eq(3))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/sort_spec.rb
+++ b/spec/unit/puppet/parser/functions/sort_spec.rb
@@ -2,30 +2,23 @@
 require 'spec_helper'
 
 describe "the sort function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("sort").should == "function_sort"
   end
 
   it "should raise a ParseError if there is not 1 arguments" do
-    lambda { @scope.function_sort(['','']) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_sort(['','']) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should sort an array" do
-    result = @scope.function_sort([["a","c","b"]])
+    result = scope.function_sort([["a","c","b"]])
     result.should(eq(['a','b','c']))
   end
 
   it "should sort a string" do
-    result = @scope.function_sort(["acb"])
+    result = scope.function_sort(["acb"])
     result.should(eq('abc'))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/squeeze_spec.rb
+++ b/spec/unit/puppet/parser/functions/squeeze_spec.rb
@@ -2,30 +2,23 @@
 require 'spec_helper'
 
 describe "the squeeze function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("squeeze").should == "function_squeeze"
   end
 
   it "should raise a ParseError if there is less than 2 arguments" do
-    lambda { @scope.function_squeeze([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_squeeze([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should squeeze a string" do
-    result = @scope.function_squeeze(["aaabbbbcccc"])
+    result = scope.function_squeeze(["aaabbbbcccc"])
     result.should(eq('abc'))
   end
 
   it "should squeeze all elements in an array" do
-    result = @scope.function_squeeze([["aaabbbbcccc","dddfff"]])
+    result = scope.function_squeeze([["aaabbbbcccc","dddfff"]])
     result.should(eq(['abc','df']))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/str2bool_spec.rb
+++ b/spec/unit/puppet/parser/functions/str2bool_spec.rb
@@ -2,30 +2,23 @@
 require 'spec_helper'
 
 describe "the str2bool function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("str2bool").should == "function_str2bool"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_str2bool([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_str2bool([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should convert string 'true' to true" do
-    result = @scope.function_str2bool(["true"])
+    result = scope.function_str2bool(["true"])
     result.should(eq(true))
   end
 
   it "should convert string 'undef' to false" do
-    result = @scope.function_str2bool(["undef"])
+    result = scope.function_str2bool(["undef"])
     result.should(eq(false))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/strftime_spec.rb
+++ b/spec/unit/puppet/parser/functions/strftime_spec.rb
@@ -2,35 +2,28 @@
 require 'spec_helper'
 
 describe "the strftime function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("strftime").should == "function_strftime"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_strftime([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_strftime([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "using %s should be higher then when I wrote this test" do
-    result = @scope.function_strftime(["%s"])
+    result = scope.function_strftime(["%s"])
     result.to_i.should(be > 1311953157)
   end
 
   it "using %s should be lower then 1.5 trillion" do
-    result = @scope.function_strftime(["%s"])
+    result = scope.function_strftime(["%s"])
     result.to_i.should(be < 1500000000)
   end
 
   it "should return a date when given %Y-%m-%d" do
-    result = @scope.function_strftime(["%Y-%m-%d"])
+    result = scope.function_strftime(["%Y-%m-%d"])
     result.should =~ /^\d{4}-\d{2}-\d{2}$/
   end
-
 end

--- a/spec/unit/puppet/parser/functions/strip_spec.rb
+++ b/spec/unit/puppet/parser/functions/strip_spec.rb
@@ -2,25 +2,17 @@
 require 'spec_helper'
 
 describe "the strip function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
-
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
   it "should exist" do
     Puppet::Parser::Functions.function("strip").should == "function_strip"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_strip([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_strip([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should strip a string" do
-    result = @scope.function_strip([" ab cd "])
+    result = scope.function_strip([" ab cd "])
     result.should(eq('ab cd'))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/swapcase_spec.rb
+++ b/spec/unit/puppet/parser/functions/swapcase_spec.rb
@@ -2,25 +2,18 @@
 require 'spec_helper'
 
 describe "the swapcase function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("swapcase").should == "function_swapcase"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_swapcase([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_swapcase([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should swapcase a string" do
-    result = @scope.function_swapcase(["aaBBccDD"])
+    result = scope.function_swapcase(["aaBBccDD"])
     result.should(eq('AAbbCCdd'))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/time_spec.rb
+++ b/spec/unit/puppet/parser/functions/time_spec.rb
@@ -2,35 +2,28 @@
 require 'spec_helper'
 
 describe "the time function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("time").should == "function_time"
   end
 
   it "should raise a ParseError if there is more than 2 arguments" do
-    lambda { @scope.function_time(['','']) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_time(['','']) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return a number" do
-    result = @scope.function_time([])
+    result = scope.function_time([])
     result.should be_an(Integer)
   end
 
   it "should be higher then when I wrote this test" do
-    result = @scope.function_time([])
+    result = scope.function_time([])
     result.should(be > 1311953157)
   end
 
   it "should be lower then 1.5 trillion" do
-    result = @scope.function_time([])
+    result = scope.function_time([])
     result.should(be < 1500000000)
   end
-
 end

--- a/spec/unit/puppet/parser/functions/type_spec.rb
+++ b/spec/unit/puppet/parser/functions/type_spec.rb
@@ -2,50 +2,42 @@
 require 'spec_helper'
 
 describe "the type function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
-
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
   it "should exist" do
     Puppet::Parser::Functions.function("type").should == "function_type"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_type([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_type([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return string when given a string" do
-    result = @scope.function_type(["aaabbbbcccc"])
+    result = scope.function_type(["aaabbbbcccc"])
     result.should(eq('string'))
   end
 
   it "should return array when given an array" do
-    result = @scope.function_type([["aaabbbbcccc","asdf"]])
+    result = scope.function_type([["aaabbbbcccc","asdf"]])
     result.should(eq('array'))
   end
 
   it "should return hash when given a hash" do
-    result = @scope.function_type([{"a"=>1,"b"=>2}])
+    result = scope.function_type([{"a"=>1,"b"=>2}])
     result.should(eq('hash'))
   end
 
   it "should return integer when given an integer" do
-    result = @scope.function_type(["1"])
+    result = scope.function_type(["1"])
     result.should(eq('integer'))
   end
 
   it "should return float when given a float" do
-    result = @scope.function_type(["1.34"])
+    result = scope.function_type(["1.34"])
     result.should(eq('float'))
   end
 
   it "should return boolean when given a boolean" do
-    result = @scope.function_type([true])
+    result = scope.function_type([true])
     result.should(eq('boolean'))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/unique_spec.rb
+++ b/spec/unit/puppet/parser/functions/unique_spec.rb
@@ -2,30 +2,23 @@
 require 'spec_helper'
 
 describe "the unique function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("unique").should == "function_unique"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_unique([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_unique([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should remove duplicate elements in a string" do
-    result = @scope.function_unique(["aabbc"])
+    result = scope.function_unique(["aabbc"])
     result.should(eq('abc'))
   end
 
   it "should remove duplicate elements in an array" do
-    result = @scope.function_unique([["a","a","b","b","c"]])
+    result = scope.function_unique([["a","a","b","b","c"]])
     result.should(eq(['a','b','c']))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/upcase_spec.rb
+++ b/spec/unit/puppet/parser/functions/upcase_spec.rb
@@ -2,30 +2,23 @@
 require 'spec_helper'
 
 describe "the upcase function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("upcase").should == "function_upcase"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_upcase([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_upcase([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should upcase a string" do
-    result = @scope.function_upcase(["abc"])
+    result = scope.function_upcase(["abc"])
     result.should(eq('ABC'))
   end
 
   it "should do nothing if a string is already upcase" do
-    result = @scope.function_upcase(["ABC"])
+    result = scope.function_upcase(["ABC"])
     result.should(eq('ABC'))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/validate_array_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_array_spec.rb
@@ -1,41 +1,21 @@
-require 'puppet'
+#! /usr/bin/env ruby -S rspec
 
-# We don't need this for the basic tests we're doing
-# require 'spec_helper'
+require 'spec_helper'
 
-# Dan mentioned that Nick recommended the function method call
-# to return the string value for the test description.
-# this will not even try the test if the function cannot be
-# loaded.
 describe Puppet::Parser::Functions.function(:validate_array) do
-
-  # Pulled from Dan's create_resources function
-  def get_scope
-    @topscope = Puppet::Parser::Scope.new
-    # This is necessary so we don't try to use the compiler to discover our parent.
-    @topscope.parent = nil
-    @scope = Puppet::Parser::Scope.new
-    @scope.compiler = Puppet::Parser::Compiler.new(Puppet::Node.new("floppy", :environment => 'production'))
-    @scope.parent = @topscope
-    @compiler = @scope.compiler
-  end
-
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
   describe 'when calling validate_array from puppet' do
 
     %w{ true false }.each do |the_string|
-
       it "should not compile when #{the_string} is a string" do
         Puppet[:code] = "validate_array('#{the_string}')"
-        get_scope
-        expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not an Array/)
+        expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not an Array/)
       end
 
       it "should not compile when #{the_string} is a bare word" do
         Puppet[:code] = "validate_array(#{the_string})"
-        get_scope
-        expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not an Array/)
+        expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not an Array/)
       end
-
     end
 
     it "should compile when multiple array arguments are passed" do
@@ -44,8 +24,7 @@ describe Puppet::Parser::Functions.function(:validate_array) do
         $bar = [ 'one', 'two' ]
         validate_array($foo, $bar)
       ENDofPUPPETcode
-      get_scope
-      @scope.compiler.compile
+      scope.compiler.compile
     end
 
     it "should not compile when an undef variable is passed" do
@@ -53,11 +32,7 @@ describe Puppet::Parser::Functions.function(:validate_array) do
         $foo = undef
         validate_array($foo)
       ENDofPUPPETcode
-      get_scope
-      expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not an Array/)
+      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not an Array/)
     end
-
   end
-
 end
-

--- a/spec/unit/puppet/parser/functions/validate_bool_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_bool_spec.rb
@@ -1,53 +1,33 @@
-require 'puppet'
+#! /usr/bin/env/ruby -S rspec
 
-# We don't need this for the basic tests we're doing
-# require 'spec_helper'
+require 'spec_helper'
 
-# Dan mentioned that Nick recommended the function method call
-# to return the string value for the test description.
-# this will not even try the test if the function cannot be
-# loaded.
 describe Puppet::Parser::Functions.function(:validate_bool) do
-
-  # Pulled from Dan's create_resources function
-  def get_scope
-    @topscope = Puppet::Parser::Scope.new
-    # This is necessary so we don't try to use the compiler to discover our parent.
-    @topscope.parent = nil
-    @scope = Puppet::Parser::Scope.new
-    @scope.compiler = Puppet::Parser::Compiler.new(Puppet::Node.new("floppy", :environment => 'production'))
-    @scope.parent = @topscope
-    @compiler = @scope.compiler
-  end
-
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
   describe 'when calling validate_bool from puppet' do
 
     %w{ true false }.each do |the_string|
 
       it "should not compile when #{the_string} is a string" do
         Puppet[:code] = "validate_bool('#{the_string}')"
-        get_scope
-        expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a boolean/)
+        expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a boolean/)
       end
 
       it "should compile when #{the_string} is a bare word" do
         Puppet[:code] = "validate_bool(#{the_string})"
-        get_scope
-        @scope.compiler.compile
+        scope.compiler.compile
       end
 
     end
 
     it "should not compile when an arbitrary string is passed" do
       Puppet[:code] = 'validate_bool("jeff and dan are awesome")'
-      get_scope
-      expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a boolean/)
+      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a boolean/)
     end
 
     it "should not compile when no arguments are passed" do
       Puppet[:code] = 'validate_bool()'
-      get_scope
-      expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
+      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
     end
 
     it "should compile when multiple boolean arguments are passed" do
@@ -56,8 +36,7 @@ describe Puppet::Parser::Functions.function(:validate_bool) do
         $bar = false
         validate_bool($foo, $bar, true, false)
       ENDofPUPPETcode
-      get_scope
-      @scope.compiler.compile
+      scope.compiler.compile
     end
 
     it "should compile when multiple boolean arguments are passed" do
@@ -66,11 +45,7 @@ describe Puppet::Parser::Functions.function(:validate_bool) do
         $bar = false
         validate_bool($foo, $bar, true, false, 'jeff')
       ENDofPUPPETcode
-      get_scope
-      expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a boolean/)
+      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a boolean/)
     end
-
   end
-
 end
-

--- a/spec/unit/puppet/parser/functions/validate_hash_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_hash_spec.rb
@@ -1,24 +1,9 @@
-require 'puppet'
+#! /usr/bin/env ruby -S rspec
 
-# We don't need this for the basic tests we're doing
-# require 'spec_helper'
+require 'spec_helper'
 
-# Dan mentioned that Nick recommended the function method call
-# to return the string value for the test description.
-# this will not even try the test if the function cannot be
-# loaded.
 describe Puppet::Parser::Functions.function(:validate_hash) do
-
-  # Pulled from Dan's create_resources function
-  def get_scope
-    @topscope = Puppet::Parser::Scope.new
-    # This is necessary so we don't try to use the compiler to discover our parent.
-    @topscope.parent = nil
-    @scope = Puppet::Parser::Scope.new
-    @scope.compiler = Puppet::Parser::Compiler.new(Puppet::Node.new("floppy", :environment => 'production'))
-    @scope.parent = @topscope
-    @compiler = @scope.compiler
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   describe 'when calling validate_hash from puppet' do
 
@@ -26,14 +11,12 @@ describe Puppet::Parser::Functions.function(:validate_hash) do
 
       it "should not compile when #{the_string} is a string" do
         Puppet[:code] = "validate_hash('#{the_string}')"
-        get_scope
-        expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a Hash/)
+        expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a Hash/)
       end
 
       it "should not compile when #{the_string} is a bare word" do
         Puppet[:code] = "validate_hash(#{the_string})"
-        get_scope
-        expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a Hash/)
+        expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a Hash/)
       end
 
     end
@@ -44,8 +27,7 @@ describe Puppet::Parser::Functions.function(:validate_hash) do
         $bar = { 'one' => 'two' }
         validate_hash($foo, $bar)
       ENDofPUPPETcode
-      get_scope
-      @scope.compiler.compile
+      scope.compiler.compile
     end
 
     it "should not compile when an undef variable is passed" do
@@ -53,8 +35,7 @@ describe Puppet::Parser::Functions.function(:validate_hash) do
         $foo = undef
         validate_hash($foo)
       ENDofPUPPETcode
-      get_scope
-      expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a Hash/)
+      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a Hash/)
     end
 
   end

--- a/spec/unit/puppet/parser/functions/validate_string_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_string_spec.rb
@@ -1,24 +1,9 @@
-require 'puppet'
+#! /usr/bin/env ruby -S rspec
 
-# We don't need this for the basic tests we're doing
-# require 'spec_helper'
+require 'spec_helper'
 
-# Dan mentioned that Nick recommended the function method call
-# to return the string value for the test description.
-# this will not even try the test if the function cannot be
-# loaded.
 describe Puppet::Parser::Functions.function(:validate_string) do
-
-  # Pulled from Dan's create_resources function
-  def get_scope
-    @topscope = Puppet::Parser::Scope.new
-    # This is necessary so we don't try to use the compiler to discover our parent.
-    @topscope.parent = nil
-    @scope = Puppet::Parser::Scope.new
-    @scope.compiler = Puppet::Parser::Compiler.new(Puppet::Node.new("floppy", :environment => 'production'))
-    @scope.parent = @topscope
-    @compiler = @scope.compiler
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   describe 'when calling validate_string from puppet' do
 
@@ -26,14 +11,12 @@ describe Puppet::Parser::Functions.function(:validate_string) do
 
       it "should compile when #{the_string} is a string" do
         Puppet[:code] = "validate_string('#{the_string}')"
-        get_scope
-        @scope.compiler.compile
+        scope.compiler.compile
       end
 
       it "should compile when #{the_string} is a bare word" do
         Puppet[:code] = "validate_string(#{the_string})"
-        get_scope
-        @scope.compiler.compile
+        scope.compiler.compile
       end
 
     end
@@ -41,14 +24,12 @@ describe Puppet::Parser::Functions.function(:validate_string) do
     %w{ true false }.each do |the_string|
       it "should compile when #{the_string} is a string" do
         Puppet[:code] = "validate_string('#{the_string}')"
-        get_scope
-        @scope.compiler.compile
+        scope.compiler.compile
       end
 
       it "should not compile when #{the_string} is a bare word" do
         Puppet[:code] = "validate_string(#{the_string})"
-        get_scope
-        expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a string/)
+        expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a string/)
       end
     end
 
@@ -58,8 +39,7 @@ describe Puppet::Parser::Functions.function(:validate_string) do
         $bar = 'two'
         validate_string($foo, $bar)
       ENDofPUPPETcode
-      get_scope
-      @scope.compiler.compile
+      scope.compiler.compile
     end
 
     it "should compile when an explicitly undef variable is passed (NOTE THIS MAY NOT BE DESIRABLE)" do
@@ -67,16 +47,14 @@ describe Puppet::Parser::Functions.function(:validate_string) do
         $foo = undef
         validate_string($foo)
       ENDofPUPPETcode
-      get_scope
-      @scope.compiler.compile
+      scope.compiler.compile
     end
 
     it "should compile when an undefined variable is passed (NOTE THIS MAY NOT BE DESIRABLE)" do
       Puppet[:code] = <<-'ENDofPUPPETcode'
         validate_string($foobarbazishouldnotexist)
       ENDofPUPPETcode
-      get_scope
-      @scope.compiler.compile
+      scope.compiler.compile
     end
   end
 end

--- a/spec/unit/puppet/parser/functions/values_at_spec.rb
+++ b/spec/unit/puppet/parser/functions/values_at_spec.rb
@@ -2,44 +2,37 @@
 require 'spec_helper'
 
 describe "the values_at function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("values_at").should == "function_values_at"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_values_at([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_values_at([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should raise a ParseError if you try to use a range where stop is greater then start" do
-    lambda { @scope.function_values_at([['a','b'],["3-1"]]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_values_at([['a','b'],["3-1"]]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should return a value at from an array" do
-    result = @scope.function_values_at([['a','b','c'],"1"])
+    result = scope.function_values_at([['a','b','c'],"1"])
     result.should(eq(['b']))
   end
 
   it "should return a value at from an array when passed a range" do
-    result = @scope.function_values_at([['a','b','c'],"0-1"])
+    result = scope.function_values_at([['a','b','c'],"0-1"])
     result.should(eq(['a','b']))
   end
 
   it "should return chosen values from an array when passed number of indexes" do
-    result = @scope.function_values_at([['a','b','c'],["0","2"]])
+    result = scope.function_values_at([['a','b','c'],["0","2"]])
     result.should(eq(['a','c']))
   end
 
   it "should return chosen values from an array when passed ranges and multiple indexes" do
-    result = @scope.function_values_at([['a','b','c','d','e','f','g'],["0","2","4-5"]])
+    result = scope.function_values_at([['a','b','c','d','e','f','g'],["0","2","4-5"]])
     result.should(eq(['a','c','e','f']))
   end
-
 end

--- a/spec/unit/puppet/parser/functions/values_spec.rb
+++ b/spec/unit/puppet/parser/functions/values_spec.rb
@@ -2,11 +2,7 @@
 require 'spec_helper'
 
 describe "the values function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  let(:scope) { Puppet::Parser::Scope.new }
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("values").should == "function_values"

--- a/spec/unit/puppet/parser/functions/zip_spec.rb
+++ b/spec/unit/puppet/parser/functions/zip_spec.rb
@@ -2,25 +2,14 @@
 require 'spec_helper'
 
 describe "the zip function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
-
-  it "should exist" do
-    Puppet::Parser::Functions.function("zip").should == "function_zip"
-  end
+  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_zip([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_zip([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should be able to zip an array" do
-    result = @scope.function_zip([['1','2','3'],['4','5','6']])
+    result = scope.function_zip([['1','2','3'],['4','5','6']])
     result.should(eq([["1", "4"], ["2", "5"], ["3", "6"]]))
   end
-
 end


### PR DESCRIPTION
Without this patch all of the spec tests for parser functions in stdlib
would instantiate their own scope instances.  This is a problem because
the standard library is tightly coupled with the internal behavior of
Puppet.  Tight coupling like this creates failures when we change the
internal behavior of Puppet.  This is exactly what happened recently when
we changed the method signature for the initializer of
Puppet::Parser::Scope instances.

This patch fixes the problem by creating scope instances using the puppet
labs spec helper.  The specific method that provides scope instances in
Puppet-version-independent way is something like this:

```
let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
```

This patch simply implements this across the board.
