### PR TITLE
(Maint) Rename PuppetlabsSpec::Puppet{Seams,Internals}

### DIFF
--- a/spec/unit/puppet/parser/functions/abs_spec.rb
+++ b/spec/unit/puppet/parser/functions/abs_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe "the abs function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("abs").should == "function_abs"

--- a/spec/unit/puppet/parser/functions/bool2num_spec.rb
+++ b/spec/unit/puppet/parser/functions/bool2num_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the bool2num function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("bool2num").should == "function_bool2num"

--- a/spec/unit/puppet/parser/functions/capitalize_spec.rb
+++ b/spec/unit/puppet/parser/functions/capitalize_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the capitalize function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("capitalize").should == "function_capitalize"

--- a/spec/unit/puppet/parser/functions/chomp_spec.rb
+++ b/spec/unit/puppet/parser/functions/chomp_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the chomp function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("chomp").should == "function_chomp"

--- a/spec/unit/puppet/parser/functions/chop_spec.rb
+++ b/spec/unit/puppet/parser/functions/chop_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the chop function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("chop").should == "function_chop"

--- a/spec/unit/puppet/parser/functions/delete_at_spec.rb
+++ b/spec/unit/puppet/parser/functions/delete_at_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the delete_at function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("delete_at").should == "function_delete_at"

--- a/spec/unit/puppet/parser/functions/delete_spec.rb
+++ b/spec/unit/puppet/parser/functions/delete_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the delete function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("delete").should == "function_delete"

--- a/spec/unit/puppet/parser/functions/downcase_spec.rb
+++ b/spec/unit/puppet/parser/functions/downcase_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the downcase function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("downcase").should == "function_downcase"

--- a/spec/unit/puppet/parser/functions/empty_spec.rb
+++ b/spec/unit/puppet/parser/functions/empty_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the empty function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
   it "should exist" do
     Puppet::Parser::Functions.function("empty").should == "function_empty"
   end

--- a/spec/unit/puppet/parser/functions/flatten_spec.rb
+++ b/spec/unit/puppet/parser/functions/flatten_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the flatten function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
   it "should exist" do
     Puppet::Parser::Functions.function("flatten").should == "function_flatten"
   end

--- a/spec/unit/puppet/parser/functions/getvar_spec.rb
+++ b/spec/unit/puppet/parser/functions/getvar_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe Puppet::Parser::Functions.function(:getvar) do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
   describe 'when calling getvar from puppet' do
 
     it "should not compile when no arguments are passed" do

--- a/spec/unit/puppet/parser/functions/grep_spec.rb
+++ b/spec/unit/puppet/parser/functions/grep_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the grep function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("grep").should == "function_grep"

--- a/spec/unit/puppet/parser/functions/has_key_spec.rb
+++ b/spec/unit/puppet/parser/functions/has_key_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe Puppet::Parser::Functions.function(:has_key) do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   describe 'when calling has_key from puppet' do
     it "should not compile when no arguments are passed" do

--- a/spec/unit/puppet/parser/functions/hash_spec.rb
+++ b/spec/unit/puppet/parser/functions/hash_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the hash function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("hash").should == "function_hash"

--- a/spec/unit/puppet/parser/functions/is_array_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_array_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the is_array function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_array").should == "function_is_array"

--- a/spec/unit/puppet/parser/functions/is_domain_name_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_domain_name_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the is_domain_name function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_domain_name").should == "function_is_domain_name"

--- a/spec/unit/puppet/parser/functions/is_float_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_float_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the is_float function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_float").should == "function_is_float"

--- a/spec/unit/puppet/parser/functions/is_hash_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_hash_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the is_hash function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_hash").should == "function_is_hash"

--- a/spec/unit/puppet/parser/functions/is_integer_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_integer_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the is_integer function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_integer").should == "function_is_integer"

--- a/spec/unit/puppet/parser/functions/is_ip_address_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_ip_address_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the is_ip_address function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_ip_address").should == "function_is_ip_address"

--- a/spec/unit/puppet/parser/functions/is_mac_address_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_mac_address_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the is_mac_address function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_mac_address").should == "function_is_mac_address"

--- a/spec/unit/puppet/parser/functions/is_numeric_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_numeric_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the is_numeric function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_numeric").should == "function_is_numeric"

--- a/spec/unit/puppet/parser/functions/is_string_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_string_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the is_string function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("is_string").should == "function_is_string"

--- a/spec/unit/puppet/parser/functions/join_spec.rb
+++ b/spec/unit/puppet/parser/functions/join_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the join function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("join").should == "function_join"

--- a/spec/unit/puppet/parser/functions/keys_spec.rb
+++ b/spec/unit/puppet/parser/functions/keys_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the keys function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("keys").should == "function_keys"

--- a/spec/unit/puppet/parser/functions/lstrip_spec.rb
+++ b/spec/unit/puppet/parser/functions/lstrip_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the lstrip function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("lstrip").should == "function_lstrip"

--- a/spec/unit/puppet/parser/functions/member_spec.rb
+++ b/spec/unit/puppet/parser/functions/member_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the member function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("member").should == "function_member"

--- a/spec/unit/puppet/parser/functions/merge_spec.rb
+++ b/spec/unit/puppet/parser/functions/merge_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Puppet::Parser::Functions.function(:merge) do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   describe 'when calling merge from puppet' do
     it "should not compile when no arguments are passed" do

--- a/spec/unit/puppet/parser/functions/num2bool_spec.rb
+++ b/spec/unit/puppet/parser/functions/num2bool_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the num2bool function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("num2bool").should == "function_num2bool"

--- a/spec/unit/puppet/parser/functions/parsejson_spec.rb
+++ b/spec/unit/puppet/parser/functions/parsejson_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the parsejson function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("parsejson").should == "function_parsejson"

--- a/spec/unit/puppet/parser/functions/parseyaml_spec.rb
+++ b/spec/unit/puppet/parser/functions/parseyaml_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the parseyaml function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("parseyaml").should == "function_parseyaml"

--- a/spec/unit/puppet/parser/functions/prefix_spec.rb
+++ b/spec/unit/puppet/parser/functions/prefix_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the prefix function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("prefix").should == "function_prefix"

--- a/spec/unit/puppet/parser/functions/range_spec.rb
+++ b/spec/unit/puppet/parser/functions/range_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the range function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("range").should == "function_range"

--- a/spec/unit/puppet/parser/functions/reverse_spec.rb
+++ b/spec/unit/puppet/parser/functions/reverse_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the reverse function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("reverse").should == "function_reverse"

--- a/spec/unit/puppet/parser/functions/rstrip_spec.rb
+++ b/spec/unit/puppet/parser/functions/rstrip_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the rstrip function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("rstrip").should == "function_rstrip"

--- a/spec/unit/puppet/parser/functions/shuffle_spec.rb
+++ b/spec/unit/puppet/parser/functions/shuffle_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the shuffle function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("shuffle").should == "function_shuffle"

--- a/spec/unit/puppet/parser/functions/size_spec.rb
+++ b/spec/unit/puppet/parser/functions/size_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the size function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("size").should == "function_size"

--- a/spec/unit/puppet/parser/functions/sort_spec.rb
+++ b/spec/unit/puppet/parser/functions/sort_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the sort function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("sort").should == "function_sort"

--- a/spec/unit/puppet/parser/functions/squeeze_spec.rb
+++ b/spec/unit/puppet/parser/functions/squeeze_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the squeeze function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("squeeze").should == "function_squeeze"

--- a/spec/unit/puppet/parser/functions/str2bool_spec.rb
+++ b/spec/unit/puppet/parser/functions/str2bool_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the str2bool function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("str2bool").should == "function_str2bool"

--- a/spec/unit/puppet/parser/functions/strftime_spec.rb
+++ b/spec/unit/puppet/parser/functions/strftime_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the strftime function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("strftime").should == "function_strftime"

--- a/spec/unit/puppet/parser/functions/strip_spec.rb
+++ b/spec/unit/puppet/parser/functions/strip_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the strip function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
   it "should exist" do
     Puppet::Parser::Functions.function("strip").should == "function_strip"
   end

--- a/spec/unit/puppet/parser/functions/swapcase_spec.rb
+++ b/spec/unit/puppet/parser/functions/swapcase_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the swapcase function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("swapcase").should == "function_swapcase"

--- a/spec/unit/puppet/parser/functions/time_spec.rb
+++ b/spec/unit/puppet/parser/functions/time_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the time function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("time").should == "function_time"

--- a/spec/unit/puppet/parser/functions/type_spec.rb
+++ b/spec/unit/puppet/parser/functions/type_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the type function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
   it "should exist" do
     Puppet::Parser::Functions.function("type").should == "function_type"
   end

--- a/spec/unit/puppet/parser/functions/unique_spec.rb
+++ b/spec/unit/puppet/parser/functions/unique_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the unique function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("unique").should == "function_unique"

--- a/spec/unit/puppet/parser/functions/upcase_spec.rb
+++ b/spec/unit/puppet/parser/functions/upcase_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the upcase function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("upcase").should == "function_upcase"

--- a/spec/unit/puppet/parser/functions/validate_array_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_array_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Puppet::Parser::Functions.function(:validate_array) do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
   describe 'when calling validate_array from puppet' do
 
     %w{ true false }.each do |the_string|

--- a/spec/unit/puppet/parser/functions/validate_bool_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_bool_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Puppet::Parser::Functions.function(:validate_bool) do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
   describe 'when calling validate_bool from puppet' do
 
     %w{ true false }.each do |the_string|

--- a/spec/unit/puppet/parser/functions/validate_hash_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_hash_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Puppet::Parser::Functions.function(:validate_hash) do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   describe 'when calling validate_hash from puppet' do
 

--- a/spec/unit/puppet/parser/functions/validate_string_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_string_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Puppet::Parser::Functions.function(:validate_string) do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   describe 'when calling validate_string from puppet' do
 

--- a/spec/unit/puppet/parser/functions/values_at_spec.rb
+++ b/spec/unit/puppet/parser/functions/values_at_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the values_at function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("values_at").should == "function_values_at"

--- a/spec/unit/puppet/parser/functions/values_spec.rb
+++ b/spec/unit/puppet/parser/functions/values_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the values function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("values").should == "function_values"

--- a/spec/unit/puppet/parser/functions/zip_spec.rb
+++ b/spec/unit/puppet/parser/functions/zip_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe "the zip function" do
-  let(:scope) { PuppetlabsSpec::PuppetSeams.parser_scope }
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should raise a ParseError if there is less than 1 arguments" do
     lambda { scope.function_zip([]) }.should( raise_error(Puppet::ParseError))


### PR DESCRIPTION
The module PuppetlabsSpec::PuppetSeams has been renamed in the 
puppetlabs_spec_helper gem to PuppetlabsSpec::PuppetInternals.

The method to obtain a scope object has also changed slightly.  Without this
patch the spec tests will fail because the stdlib module is not aligned with
the spec helper gem.  This patch fixes the problem by matching up messages
with their receivers in the spec helper library.

Paired-with: Andrew Parker andy@puppetlabs.com
## Requirements

Merging this into 2.2.x should be coordinated with the spec helper pull
request that renames these module methods:

https://github.com/puppetlabs/puppetlabs_spec_helper/pull/18
