### PR TITLE
(Maint) Don't mock with mocha

### DIFF
--- a/spec/unit/puppet/parser/functions/get_module_path_spec.rb
+++ b/spec/unit/puppet/parser/functions/get_module_path_spec.rb
@@ -3,6 +3,12 @@ require 'spec_helper'
 
 describe Puppet::Parser::Functions.function(:get_module_path) do
   Internals = PuppetlabsSpec::PuppetInternals
+  class StubModule
+    attr_reader :path
+    def initialize(path)
+      @path = path
+    end
+  end
 
   def scope(environment = "production")
     Internals.scope(:compiler => Internals.compiler(:node => Internals.node(:environment => environment)))
@@ -17,11 +23,7 @@ describe Puppet::Parser::Functions.function(:get_module_path) do
   end
   describe 'when locating a module' do
     let(:modulepath) { "/tmp/does_not_exist" }
-    let(:path_of_module_foo) do
-      mod = mock("Puppet::Module")
-      mod.stubs(:path).returns("/tmp/does_not_exist/foo")
-      mod
-    end
+    let(:path_of_module_foo) { StubModule.new("/tmp/does_not_exist/foo") }
 
     before(:each) { Puppet[:modulepath] = modulepath }
 


### PR DESCRIPTION
Without this patch applied the stdlib module has load-order issues with mocha 
and rspec-puppet.  The root cause has yet to be determined, but we've
narrowed it down to this description:

  "If any rspec-puppet example groups run before parser function example
groups
  and the parser function example groups use mock() then you'll get this
error:"

You can exercise this explicitly with:

```
rspec -fd spec/unit/puppet/{provider,type,parser}
```

This will ensure rspec runs all of the provider and type spec tests, which
are rspec-puppet ones, before the parser function specs are run.  I should
also note we empted out the test in the file_line provider to be nothing
except an empty describe block and this was still sufficient to trigger the
load order error described here.

<pre>
    Failures:

      1) function_get_module_path when locating a module should be able to find module paths from the modulepath setting
        Failure/Error: mod = mock("Puppet::Module")
        NoMethodError:
          undefined method `mock' for #<RSpec::Core::ExampleGroup::Nested_14::Nested_1:0x107b946c0>
        # ./spec/unit/puppet/parser/functions/get_module_path_spec.rb:21
        # ./spec/unit/puppet/parser/functions/get_module_path_spec.rb:29

      2) function_get_module_path when locating a module should be able to find module paths when the modulepath is a list
        Failure/Error: mod = mock("Puppet::Module")
        NoMethodError:
          undefined method `mock' for #<RSpec::Core::ExampleGroup::Nested_14::Nested_1:0x107b81ea8>
        # ./spec/unit/puppet/parser/functions/get_module_path_spec.rb:21
        # ./spec/unit/puppet/parser/functions/get_module_path_spec.rb:34

      3) function_get_module_path when locating a module should respect the environment
        Failure/Error: mod = mock("Puppet::Module")
        NoMethodError:
          undefined method `mock' for #<RSpec::Core::ExampleGroup::Nested_14::Nested_1:0x107b6e808>
        # ./spec/unit/puppet/parser/functions/get_module_path_spec.rb:21
        # ./spec/unit/puppet/parser/functions/get_module_path_spec.rb:40

    Finished in 1.53 seconds
   326 examples, 3 failures, 1 pending
</pre>


Paired-with: Andrew Parker andy@puppetlabs.com
