### PR TITLE
(Maint) use PuppetlabsSpec::PuppetInternals.scope (master)

### DIFF
--- a/spec/unit/puppet/parser/functions/fqdn_rotate_spec.rb
+++ b/spec/unit/puppet/parser/functions/fqdn_rotate_spec.rb
@@ -1,40 +1,33 @@
-#!/usr/bin/env rspec
+#! /usr/bin/env ruby -S rspec
 require 'spec_helper'
 
 describe "the fqdn_rotate function" do
-  before :all do
-    Puppet::Parser::Functions.autoloader.loadall
-  end
-
-  before :each do
-    @scope = Puppet::Parser::Scope.new
-  end
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should exist" do
     Puppet::Parser::Functions.function("fqdn_rotate").should == "function_fqdn_rotate"
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { @scope.function_fqdn_rotate([]) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_fqdn_rotate([]) }.should( raise_error(Puppet::ParseError))
   end
 
   it "should rotate a string and the result should be the same size" do
-    @scope.expects(:lookupvar).with("::fqdn").returns("127.0.0.1")
-    result = @scope.function_fqdn_rotate(["asdf"])
+    scope.expects(:lookupvar).with("::fqdn").returns("127.0.0.1")
+    result = scope.function_fqdn_rotate(["asdf"])
     result.size.should(eq(4))
   end
 
   it "should rotate a string to give the same results for one host" do
-    @scope.expects(:lookupvar).with("::fqdn").returns("127.0.0.1").twice 
-    @scope.function_fqdn_rotate(["abcdefg"]).should eql(@scope.function_fqdn_rotate(["abcdefg"]))
+    scope.expects(:lookupvar).with("::fqdn").returns("127.0.0.1").twice 
+    scope.function_fqdn_rotate(["abcdefg"]).should eql(scope.function_fqdn_rotate(["abcdefg"]))
   end
 
   it "should rotate a string to give different values on different hosts" do
-     @scope.expects(:lookupvar).with("::fqdn").returns("127.0.0.1")
-     val1 = @scope.function_fqdn_rotate(["abcdefghijklmnopqrstuvwxyz01234567890987654321"])
-     @scope.expects(:lookupvar).with("::fqdn").returns("127.0.0.2")
-     val2 = @scope.function_fqdn_rotate(["abcdefghijklmnopqrstuvwxyz01234567890987654321"])
+     scope.expects(:lookupvar).with("::fqdn").returns("127.0.0.1")
+     val1 = scope.function_fqdn_rotate(["abcdefghijklmnopqrstuvwxyz01234567890987654321"])
+     scope.expects(:lookupvar).with("::fqdn").returns("127.0.0.2")
+     val2 = scope.function_fqdn_rotate(["abcdefghijklmnopqrstuvwxyz01234567890987654321"])
      val1.should_not eql(val2)
   end
-
 end


### PR DESCRIPTION
This patch is the same approach as the one that want into 2.3.x.  It covers
the functions in master that do not exist in 2.3.x.

Without this patch all of the spec tests for parser functions in stdlib would
instantiate their own scope instances.  This is a problem because the
standard library is tightly coupled with the internal behavior of Puppet. 
Tight coupling like this creates failures when we change the internal
behavior of Puppet.  This is exactly what happened recently when we changed
the method signature for the initializer of Puppet::Parser::Scope instances.

This patch fixes the problem by creating scope instances using the puppet
labs spec helper.  The specific method that provides scope instances in
Puppet-version-independent way is something like this:

```
let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
```

This patch simply implements this across the board.

Paired-with: Andrew Parker andy@puppetlabs.com
