### PR TITLE
Add the pick() function

### DIFF
--- a/lib/puppet/parser/functions/pick.rb
+++ b/lib/puppet/parser/functions/pick.rb
@@ -1,0 +1,29 @@
+module Puppet::Parser::Functions
+ newfunction(:pick, :type => :rvalue, :doc => <<-EOS
+
+This function is similar to a coalesce function in SQL in that it will return
+the first value in a list of values that is not undefined or an empty string
+(two things in Puppet that will return a boolean false value). Typically,
+this function is used to check for a value in the Puppet Dashboard/Enterprise
+Console, and failover to a default value like the following:
+
+  $real_jenkins_version = pick($::jenkins_version, '1.449')
+
+The value of $real_jenkins_version will first look for a top-scope variable
+called 'jenkins_version' (note that parameters set in the Puppet Dashboard/
+Enterprise Console are brought into Puppet as top-scope variables), and,
+failing that, will use a default value of 1.449.
+
+EOS
+) do |args|
+   args = args.compact
+   args.delete(:undef)
+   args.delete(:undefined)
+   args.delete("")
+   if args[0].to_s.empty? then
+     fail "Must provide non empty value."
+   else
+     return args[0]
+   end
+ end
+end

--- a/spec/unit/puppet/parser/functions/pick_spec.rb
+++ b/spec/unit/puppet/parser/functions/pick_spec.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe "the pick function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    Puppet::Parser::Functions.function("pick").should == "function_pick"
+  end
+
+  it 'should return the correct value' do
+    scope.function_pick(['first', 'second']).should == 'first'
+  end
+
+  it 'should return the correct value if the first value is empty' do
+    scope.function_pick(['', 'second']).should == 'second'
+  end
+
+  it 'should remove empty string values' do
+    scope.function_pick(['', 'first']).should == 'first'
+  end
+
+  it 'should remove :undef values' do
+    scope.function_pick([:undef, 'first']).should == 'first'
+  end
+
+  it 'should remove :undefined values' do
+    scope.function_pick([:undefined, 'first']).should == 'first'
+  end
+
+  it 'should error if no values are passed' do
+    expect { scope.function_pick([]) }.to raise_error(Puppet::Error, /Must provide non empty value./)
+  end
+end


### PR DESCRIPTION
This function is similar to a coalesce function in SQL in that it will
return
the first value in a list of values that is not undefined or an empty
string
(two things in Puppet that will return a boolean false value).
Typically,
this function is used to check for a value in the Puppet
Dashboard/Enterprise
Console, and failover to a default value like the following:

  $real_jenkins_version = pick($::jenkins_version, '1.449')

The value of $real_jenkins_version will first look for a top-scope
variable
called 'jenkins_version' (note that parameters set in the Puppet
Dashboard/
Enterprise Console are brought into Puppet as top-scope variables), and,
failing that, will use a default value of 1.449.
