### PR TITLE
(#15872) Add to_bytes function

### DIFF
--- a/lib/puppet/parser/functions/to_bytes.rb
+++ b/lib/puppet/parser/functions/to_bytes.rb
@@ -1,0 +1,29 @@
+module Puppet::Parser::Functions
+  newfunction(:to_bytes, :type => :rvalue, :doc => <<-EOS
+    Converts the argument into bytes, for example 4 kB becomes 4096.
+    Takes a single string value as an argument.
+    EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "to_bytes(): Wrong number of arguments " +
+          "given (#{arguments.size} for 1)") if arguments.size != 1
+
+    arg = arguments[0]
+
+    return arg if arg.is_a? Numeric
+
+    value,prefix = */([0-9.e+-]*)\s*([^bB]?)/.match(arg)[1,2]
+
+    value = value.to_f
+    case prefix
+    when '' then return value.to_i
+    when 'k' then return (value*(1<<10)).to_i
+    when 'M' then return (value*(1<<20)).to_i
+    when 'G' then return (value*(1<<30)).to_i
+    when 'T' then return (value*(1<<40)).to_i
+    when 'E' then return (value*(1<<50)).to_i
+    else raise Puppet::ParseError, "to_bytes(): Unknown prefix #{prefix}"
+    end
+  end
+end
+

--- a/spec/unit/puppet/parser/functions/to_bytes_spec.rb
+++ b/spec/unit/puppet/parser/functions/to_bytes_spec.rb
@@ -1,0 +1,58 @@
+#! /usr/bin/env ruby -S rspec
+
+require 'spec_helper'
+
+describe "the to_bytes function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    Puppet::Parser::Functions.function("to_bytes").should == "function_to_bytes"
+  end
+
+  it "should raise a ParseError if there is less than 1 arguments" do
+    lambda { scope.function_to_bytes([]) }.should( raise_error(Puppet::ParseError))
+  end
+
+  it "should convert kB to B" do
+    result = scope.function_to_bytes(["4 kB"])
+    result.should(eq(4096))
+  end
+
+  it "should work without B in unit" do
+    result = scope.function_to_bytes(["4 k"])
+    result.should(eq(4096))
+  end
+
+  it "should work without a space before unit" do
+    result = scope.function_to_bytes(["4k"])
+    result.should(eq(4096))
+  end
+
+  it "should work without a unit" do
+    result = scope.function_to_bytes(["5678"])
+    result.should(eq(5678))
+  end
+
+  it "should convert fractions" do
+    result = scope.function_to_bytes(["1.5 kB"])
+    result.should(eq(1536))
+  end
+
+  it "should convert scientific notation" do
+    result = scope.function_to_bytes(["1.5e2 B"])
+    result.should(eq(150))
+  end
+
+  it "should do nothing with a positive number" do
+    result = scope.function_to_bytes([5678])
+    result.should(eq(5678))
+  end
+
+  it "should should raise a ParseError if input isn't a number" do
+    lambda { scope.function_to_bytes(["foo"]) }.should( raise_error(Puppet::ParseError))
+  end
+
+  it "should should raise a ParseError if prefix is unknown" do
+    lambda { scope.function_to_bytes(["5 uB"]) }.should( raise_error(Puppet::ParseError))
+  end
+end


### PR DESCRIPTION
Converts a string like "2 MB" to the value in bytes. Useful for
comparisons on facts that return a human readable number instead of
machine readable.
