### PR TITLE
(#14422) Update README to include the bug tracker URL.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,9 @@ This module is officially curated and provided by Puppet Labs.  The modules
 Puppet Labs writes and distributes will make heavy use of this standard
 library.
 
+To report or research a bug with any part of this module, please go to 
+[http://projects.puppetlabs.com/projects/stdlib](http://projects.puppetlabs.com/projects/stdlib)
+
 # Versions #
 
 This module follows semver.org (v1.0.0) versioning guidelines.  The standard


### PR DESCRIPTION
As reported, it is indeed difficult to navigate directly to the correct
part of Redmine for a particular sub-project. This commit puts the
issue tracker URL front and center.
