### PR TITLE
Disable tests that fail on 2.6.x due to #15912

### DIFF
--- a/spec/unit/puppet/parser/functions/getvar_spec.rb
+++ b/spec/unit/puppet/parser/functions/getvar_spec.rb
@@ -23,11 +23,13 @@ describe Puppet::Parser::Functions.function(:getvar) do
   describe 'when calling getvar from puppet' do
 
     it "should not compile when no arguments are passed" do
+      pending("Fails on 2.6.x, see bug #15912") if Puppet.version =~ /^2\.6\./
       Puppet[:code] = '$rval = getvar()'
       get_scope
       expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
     end
     it "should not compile when too many arguments are passed" do
+      pending("Fails on 2.6.x, see bug #15912") if Puppet.version =~ /^2\.6\./
       Puppet[:code] = '$rval = getvar("foo::bar", "baz")'
       get_scope
       expect { @scope.compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)

--- a/spec/unit/puppet/parser/functions/has_key_spec.rb
+++ b/spec/unit/puppet/parser/functions/has_key_spec.rb
@@ -22,14 +22,17 @@ describe Puppet::Parser::Functions.function(:has_key) do
 
   describe 'when calling has_key from puppet' do
     it "should not compile when no arguments are passed" do
+      pending("Fails on 2.6.x, see bug #15912") if Puppet.version =~ /^2\.6\./
       Puppet[:code] = '$rval = has_key()'
       expect { compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
     end
     it "should not compile when 1 argument is passed" do
+      pending("Fails on 2.6.x, see bug #15912") if Puppet.version =~ /^2\.6\./
       Puppet[:code] = "$rval = has_key('foo')"
       expect { compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
     end
     it "should require the first value to be a Hash" do
+      pending("Fails on 2.6.x, see bug #15912") if Puppet.version =~ /^2\.6\./
       Puppet[:code] = "$rval = has_key('foo', 'bar')"
       expect { compiler.compile }.should raise_error(Puppet::ParseError, /expects the first argument to be a hash/)
     end

--- a/spec/unit/puppet/parser/functions/merge_spec.rb
+++ b/spec/unit/puppet/parser/functions/merge_spec.rb
@@ -22,33 +22,38 @@ describe Puppet::Parser::Functions.function(:merge) do
 
   describe 'when calling merge from puppet' do
     it "should not compile when no arguments are passed" do
+      pending("Fails on 2.6.x, see bug #15912") if Puppet.version =~ /^2\.6\./
       Puppet[:code] = '$rval = merge()'
       expect { compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
     end
+
     it "should not compile when 1 argument is passed" do
+      pending("Fails on 2.6.x, see bug #15912") if Puppet.version =~ /^2\.6\./
       Puppet[:code] = "$my_hash={'one' => 1}\n$rval = merge($my_hash)"
       expect { compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
     end
   end
+
   describe 'when calling merge on the scope instance' do
     it 'should require all parameters are hashes' do
       expect { new_hash = scope.function_merge([{}, '2'])}.should raise_error(Puppet::ParseError, /unexpected argument type String/)
 
     end
+
     it 'should be able to merge two hashes' do
       new_hash = scope.function_merge([{'one' => '1', 'two' => '1'}, {'two' => '2', 'three' => '2'}])
       new_hash['one'].should   == '1'
       new_hash['two'].should   == '2'
       new_hash['three'].should == '2'
     end
+
     it 'should merge multiple hashes' do
       hash = scope.function_merge([{'one' => 1}, {'one' => '2'}, {'one' => '3'}])
       hash['one'].should == '3'
     end
+
     it 'should accept empty hashes' do
       scope.function_merge([{},{},{}]).should == {}
     end
-
   end
-
 end


### PR DESCRIPTION
In Puppet 2.6.x there is a bug where a function may be incorrectly detected
as an rvalue when it is not, or not detected when it is. This means that in
tests the correct syntax for calling a function will be rejected. This
disables those tests on 2.6.x, as there is no straightforward way to write
them to be compatible with both 2.6.x and newer versions of Puppet.

Conflicts:
spec/unit/puppet/parser/functions/getvar_spec.rb
spec/unit/puppet/parser/functions/has_key_spec.rb
spec/unit/puppet/parser/functions/merge_spec.rb

This patch was constructed by cherry-picking e27eccb and resolving the merge
conflicts to only include the `pending` statements.  This resolves the
problem by disabling these tests in Puppet 2.6.
