### PR TITLE
(Maint) Remove core function documentation from README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ This module is officially curated and provided by Puppet Labs.  The modules
 Puppet Labs writes and distributes will make heavy use of this standard
 library.
 
-To report or research a bug with any part of this module, please go to 
+To report or research a bug with any part of this module, please go to
 [http://projects.puppetlabs.com/projects/stdlib](http://projects.puppetlabs.com/projects/stdlib)
 
 # Versions #
@@ -52,8 +52,8 @@ supports Puppet 2.7.
 
 abs
 ---
-Returns the absolute value of a number, for example -34.56 becomes 
-34.56. Takes a single integer and float value as an argument.
+Returns the absolute value of a number, for example -34.56 becomes 34.56. Takes
+a single integer and float value as an argument.
 
 
 - *Type*: rvalue
@@ -78,104 +78,21 @@ Requires either a single string or an array as an input.
 
 chomp
 -----
-Removes the record separator from the end of a string or an array of 
-strings, for example `hello\n` becomes `hello`.
-Requires a single string or array as an input.
+Removes the record separator from the end of a string or an array of strings,
+for example `hello\n` becomes `hello`.  Requires a single string or array as an
+input.
 
 
 - *Type*: rvalue
 
 chop
 ----
-Returns a new string with the last character removed. If the string ends 
-with `\r\n`, both characters are removed. Applying chop to an empty 
-string returns an empty string. If you wish to merely remove record 
+Returns a new string with the last character removed. If the string ends
+with `\r\n`, both characters are removed. Applying chop to an empty
+string returns an empty string. If you wish to merely remove record
 separators then you should use the `chomp` function.
 Requires a string or array of strings as input.
 
-
-- *Type*: rvalue
-
-create_resources
-----------------
-Converts a hash into a set of resources and adds them to the catalog.
-
-This function takes two mandatory arguments: a resource type, and a hash describing
-a set of resources. The hash should be in the form `{title => {parameters} }`:
-
-    # A hash of user resources:
-    $myusers = {
-      'nick' => { uid    => '1330',
-                  group  => allstaff,
-                  groups => ['developers', 'operations', 'release'], }
-      'dan'  => { uid    => '1308',
-                  group  => allstaff,
-                  groups => ['developers', 'prosvc', 'release'], }
-    }
-
-    create_resources(user, $myusers)
-
-A third, optional parameter may be given, also as a hash:
-
-    $defaults => {
-      'ensure'   => present,
-      'provider' => 'ldap',
-    }
-
-    create_resources(user, $myusers, $defaults)
-
-The values given on the third argument are added to the parameters of each resource
-present in the set given on the second argument. If a parameter is present on both
-the second and third arguments, the one on the second argument takes precedence.
-
-This function can be used to create defined resources and classes, as well
-as native resources.
-
-
-- *Type*: statement
-
-crit
-----
-Log a message on the server at level crit.
-
-- *Type*: statement
-
-debug
------
-Log a message on the server at level debug.
-
-- *Type*: statement
-
-defined
--------
-Determine whether
-a given class or resource type is defined. This function can also determine whether a
-specific resource has been declared. Returns true or false. Accepts class names,
-type names, and resource references.
-
-The `defined` function checks both native and defined types, including types
-provided as plugins via modules. Types and classes are both checked using their names:
-
-    defined("file")
-    defined("customtype")
-    defined("foo")
-    defined("foo::bar")
-
-Resource declarations are checked using resource references, e.g.
-`defined( File['/tmp/myfile'] )`. Checking whether a given resource
-has been declared is, unfortunately, dependent on the parse order of
-the configuration, and the following code will not work:
-
-    if defined(File['/tmp/foo']) {
-        notify("This configuration includes the /tmp/foo file.")
-    }
-    file {"/tmp/foo":
-        ensure => present,
-    }
-
-However, this order requirement refers to parse order only, and ordering of
-resources in the configuration graph (e.g. with `before` or `require`) does not
-affect the behavior of `defined`.
 
 - *Type*: rvalue
 
@@ -230,12 +147,6 @@ Converts the case of a string or all strings in an array to lower case.
 
 - *Type*: rvalue
 
-emerg
------
-Log a message on the server at level emerg.
-
-- *Type*: statement
-
 empty
 -----
 Returns true if the variable is empty.
@@ -264,110 +175,6 @@ resource definition error.
 
 - *Type*: statement
 
-err
----
-Log a message on the server at level err.
-
-- *Type*: statement
-
-extlookup
----------
-This is a parser function to read data from external files, this version
-uses CSV files but the concept can easily be adjust for databases, yaml
-or any other queryable data source.
-
-The object of this is to make it obvious when it's being used, rather than
-magically loading data in when an module is loaded I prefer to look at the code
-and see statements like:
-
-    $snmp_contact = extlookup("snmp_contact")
-
-The above snippet will load the snmp_contact value from CSV files, this in its
-own is useful but a common construct in puppet manifests is something like this:
-
-    case $domain {
-      "myclient.com": { $snmp_contact = "John Doe <john@myclient.com>" }
-      default:        { $snmp_contact = "My Support <support@my.com>" }
-    }
-
-Over time there will be a lot of this kind of thing spread all over your manifests
-and adding an additional client involves grepping through manifests to find all the
-places where you have constructs like this.
-
-This is a data problem and shouldn't be handled in code, a using this function you
-can do just that.
-
-First you configure it in site.pp:
-
-    $extlookup_datadir = "/etc/puppet/manifests/extdata"
-    $extlookup_precedence = ["%{fqdn}", "domain_%{domain}", "common"]
-
-The array tells the code how to resolve values, first it will try to find it in
-web1.myclient.com.csv then in domain_myclient.com.csv and finally in common.csv
-
-Now create the following data files in /etc/puppet/manifests/extdata:
-
-    domain_myclient.com.csv:
-      snmp_contact,John Doe <john@myclient.com>
-      root_contact,support@%{domain}
-      client_trusted_ips,192.168.1.130,192.168.10.0/24
-
-    common.csv:
-      snmp_contact,My Support <support@my.com>
-      root_contact,support@my.com
-
-Now you can replace the case statement with the simple single line to achieve
-the exact same outcome:
-
-   $snmp_contact = extlookup("snmp_contact")
-
-The above code shows some other features, you can use any fact or variable that
-is in scope by simply using %{varname} in your data files, you can return arrays
-by just having multiple values in the csv after the initial variable name.
-
-In the event that a variable is nowhere to be found a critical error will be raised
-that will prevent your manifest from compiling, this is to avoid accidentally putting
-in empty values etc.  You can however specify a default value:
-
-   $ntp_servers = extlookup("ntp_servers", "1.${country}.pool.ntp.org")
-
-In this case it will default to "1.${country}.pool.ntp.org" if nothing is defined in
-any data file.
-
-You can also specify an additional data file to search first before any others at use
-time, for example:
-
-    $version = extlookup("rsyslog_version", "present", "packages")
-    package{"rsyslog": ensure => $version }
-
-This will look for a version configured in packages.csv and then in the rest as configured
-by $extlookup_precedence if it's not found anywhere it will default to `present`, this kind
-of use case makes puppet a lot nicer for managing large amounts of packages since you do not
-need to edit a load of manifests to do simple things like adjust a desired version number.
-
-Precedence values can have variables embedded in them in the form %{fqdn}, you could for example do:
-
-    $extlookup_precedence = ["hosts/%{fqdn}", "common"]
-
-This will result in /path/to/extdata/hosts/your.box.com.csv being searched.
-
-This is for back compatibility to interpolate variables with %. % interpolation is a workaround for a problem that has been fixed: Puppet variable interpolation at top scope used to only happen on each run.
-
-- *Type*: rvalue
-
-fail
-----
-Fail with a parse error.
-
-- *Type*: statement
-
-file
-----
-Return the contents of a file.  Multiple files
-can be passed, and the first file that exists will be read in.
-
-- *Type*: rvalue
-
 flatten
 -------
 This function flattens any deeply nested arrays and returns a single flat array
@@ -382,36 +189,10 @@ Would return: ['a','b','c']
 
 - *Type*: rvalue
 
-fqdn_rand
----------
-Generates random numbers based on the node's fqdn. Generated random values
-will be a range from 0 up to and excluding n, where n is the first parameter.
-The second argument specifies a number to add to the seed and is optional, for example:
-
-    $random_number = fqdn_rand(30)
-    $random_number_seed = fqdn_rand(30,30)
-
-- *Type*: rvalue
-
 fqdn_rotate
 -----------
 Rotates an array a random number of times based on a nodes fqdn.
 
-
-- *Type*: rvalue
-
-generate
---------
-Calls an external command on the Puppet master and returns
-the results of the command.  Any arguments are passed to the external command as
-arguments.  If the generator does not exit with return code of 0,
-the generator is considered to have failed and a parse error is
-thrown.  Generators can only have file separators, alphanumerics, dashes,
-and periods in them.  This function will attempt to protect you from
-malicious generator calls (e.g., those with '..' in them), but it can
-never be entirely safe.  No subshell is used to execute
-generators, so all shell metacharacters are passed directly to
-the generator.
 
 - *Type*: rvalue
 
@@ -488,27 +269,6 @@ This function converts and array into a hash.
 
 Would return: {'a'=>1,'b'=>2,'c'=>3}
 
-
-- *Type*: rvalue
-
-include
--------
-Evaluate one or more classes.
-
-- *Type*: statement
-
-info
-----
-Log a message on the server at level info.
-
-- *Type*: statement
-
-inline_template
----------------
-Evaluate a template string and return its value.  See 
-[the templating docs](http://docs.puppetlabs.com/guides/templating.html) for 
-more information.  Note that if multiple template strings are specified, their 
-output is all concatenated and returned as the output of the function.
 
 - *Type*: rvalue
 
@@ -614,12 +374,6 @@ Strips leading spaces to the left of a string.
 
 - *Type*: rvalue
 
-md5
----
-Returns a MD5 hash value from a provided string.
-
-- *Type*: rvalue
-
 member
 ------
 This function determines if a variable is a member of an array.
@@ -655,12 +409,6 @@ When there is a duplicate key, the key in the rightmost hash will "win."
 
 - *Type*: rvalue
 
-notice
-------
-Log a message on the server at level notice.
-
-- *Type*: statement
-
 num2bool
 --------
 This function converts a number into a true boolean. Zero becomes false. Numbers
@@ -679,7 +427,7 @@ structure.
 
 parseyaml
 ---------
-This function accepts YAML as a string and converts it into the correct 
+This function accepts YAML as a string and converts it into the correct
 Puppet structure.
 
 
@@ -725,78 +473,6 @@ Will return: ["host01", "host02", ..., "host09", "host10"]
 
 - *Type*: rvalue
 
-realize
--------
-Make a virtual object real.  This is useful
-when you want to know the name of the virtual object and don't want to
-bother with a full collection.  It is slightly faster than a collection,
-and, of course, is a bit shorter.  You must pass the object using a
-reference; e.g.: `realize User[luke]`.
-
-- *Type*: statement
-
-regsubst
---------
-Perform regexp replacement on a string or array of strings.
-
-* *Parameters* (in order):
-    * _target_  The string or array of strings to operate on.  If an array, the replacement will be performed on each of the elements in the array, and the return value will be an array.
-    * _regexp_  The regular expression matching the target string.  If you want it anchored at the start and or end of the string, you must do that with ^ and $ yourself.
-    * _replacement_  Replacement string. Can contain backreferences to what was matched using \0 (whole match), \1 (first set of parentheses), and so on.
-    * _flags_  Optional. String of single letter flags for how the regexp is interpreted:
-        - *E*         Extended regexps
-        - *I*         Ignore case in regexps
-        - *M*         Multiline regexps
-        - *G*         Global replacement; all occurrences of the regexp in each target string will be replaced.  Without this, only the first occurrence will be replaced.
-    * _encoding_  Optional.  How to handle multibyte characters.  A single-character string with the following values:
-        - *N*         None
-        - *E*         EUC
-        - *S*         SJIS
-        - *U*         UTF-8
-
-* *Examples*
-
-Get the third octet from the node's IP address:
-
-    $i3 = regsubst($ipaddress,'^(\d+)\.(\d+)\.(\d+)\.(\d+)$','\3')
-
-Put angle brackets around each octet in the node's IP address:
-
-    $x = regsubst($ipaddress, '([0-9]+)', '<\1>', 'G')
-
-
-- *Type*: rvalue
-
-require
--------
-Evaluate one or more classes,  adding the required class as a dependency.
-
-The relationship metaparameters work well for specifying relationships
-between individual resources, but they can be clumsy for specifying
-relationships between classes.  This function is a superset of the
-'include' function, adding a class relationship so that the requiring
-class depends on the required class.
-
-Warning: using require in place of include can lead to unwanted dependency cycles.
-
-For instance the following manifest, with 'require' instead of 'include' would produce a nasty dependence cycle, because notify imposes a before between File[/foo] and Service[foo]:
-
-    class myservice {
-      service { foo: ensure => running }
-    }
-
-    class otherstuff {
-      include myservice
-      file { '/foo': notify => Service[foo] }
-    }
-
-Note that this function only works with clients 0.25 and later, and it will
-fail if used with earlier clients.
-
-
-
-- *Type*: statement
-
 reverse
 -------
 Reverses the order of a string or array.
@@ -811,25 +487,6 @@ Strips leading spaces to the right of the string.
 
 - *Type*: rvalue
 
-search
-------
-Add another namespace for this class to search.
-This allows you to create classes with sets of definitions and add
-those classes to another class's search path.
-
-- *Type*: statement
-
-sha1
-----
-Returns a SHA1 hash value from a provided string.
-
-- *Type*: rvalue
-
-shellquote
-----------
-Quote and concatenate arguments for use in Bourne shell.
-
-Each argument is quoted separately, and then all are concatenated
 shuffle
 -------
 Randomizes the order of a string or array elements.
@@ -853,14 +510,15 @@ Sorts strings and arrays lexically.
 
 squeeze
 -------
-Returns a new string where runs of the same character that occur in this set are replaced by a single character.
+Returns a new string where runs of the same character that occur in this set
+are replaced by a single character.
 
 
 - *Type*: rvalue
 
 str2bool
 --------
-This converts a string to a boolean. This attempt to convert strings that 
+This converts a string to a boolean. This attempt to convert strings that
 contain things like: y, 1, t, true to 'true' and strings that contain things
 like: 0, f, n, false, no to 'false'.
 
@@ -869,10 +527,10 @@ like: 0, f, n, false, no to 'false'.
 
 str2saltedsha512
 ----------------
-This converts a string to a salted-SHA512 password hash (which is used for
-OS X versions >= 10.7). Given any simple string, you will get a hex version
-of a salted-SHA512 password hash that can be inserted into your Puppet
-manifests as a valid password attribute.
+This converts a string to a salted-SHA512 password hash (which is used for OS X
+versions >= 10.7). Given any simple string, you will get a hex version of a
+salted-SHA512 password hash that can be inserted into your Puppet manifests as
+a valid password attribute.
 
 
 - *Type*: rvalue
@@ -924,7 +582,7 @@ To return the date:
     %R - time, 24-hour (%H:%M)
     %s - Number of seconds since 1970-01-01 00:00:00 UTC.
     %S - Second of the minute (00..60)
-    %t - Tab character (  )
+    %t - Tab character (	)
     %T - time, 24-hour (%H:%M:%S)
     %u - Day of the week as a decimal, Monday being 1. (1..7)
     %U - Week  number  of the current year,
@@ -1269,10 +927,3 @@ Would result in:
 
 
 - *Type*: rvalue
-
-
-
-----------------
-
-*This page autogenerated on Thu Aug 16 10:53:05 -0700 2012*
-


### PR DESCRIPTION
Without this patch the README contains the documentation for core functions
shipped in Puppet in addition to the functions shipped in stdlib.

This is a problem because it's confusing for end users trying to get started
with puppet.

This patch makes it so only the stdlib functions are included.
