### PR TITLE
Add an ensure_packages function.

### DIFF
--- a/lib/puppet/parser/functions/ensure_packages.rb
+++ b/lib/puppet/parser/functions/ensure_packages.rb
@@ -1,0 +1,24 @@
+#
+# ensure_packages.rb
+#
+require 'puppet/parser/functions'
+
+module Puppet::Parser::Functions
+  newfunction(:ensure_packages, :type => :statement, :doc => <<-EOS
+Takes a list of packages and only installs them if they don't already exist.
+    EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "ensure_packages(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size != 1
+    raise(Puppet::ParseError, "ensure_packages(): Requires array " +
+      "given (#{arguments[0].type})") if !arguments[0].kind_of?(Array)
+
+    Puppet::Parser::Functions.function(:ensure_resource)
+    arguments[0].each { |package_name|
+      function_ensure_resource(['package', package_name, {'ensure' => 'present' } ])
+    }
+  end
+end
+
+# vim: set ts=2 sw=2 et :


### PR DESCRIPTION
Its often the case that modules need to install a handful of packages. In
some cases its worth breaking these dependencies out into their own modules
(e.g., Java). In others it makes more sense to keep them in the module. This
can be problematic when multiple modules depend on common packages (git,
python ruby, etc). ensure_resource was a good first step towards solving this
problem. ensure_resource does not handle arrays and for 3 or more packages
stamping out ensure_resource declarations is tedious.

ensure_packages is a convenience function that takes an array of packages and
wraps calls to ensure_resource. Currently users cannot specify package
versions. But the function could be extended to use a hash if that
functionality would be useful.
