### PR TITLE
ammend .should raise_error to .to raise_error

### DIFF
--- a/spec/unit/puppet/parser/functions/get_module_path_spec.rb
+++ b/spec/unit/puppet/parser/functions/get_module_path_spec.rb
@@ -15,11 +15,11 @@ describe Puppet::Parser::Functions.function(:get_module_path) do
   end
 
   it 'should only allow one argument' do
-    expect { scope.function_get_module_path([]) }.should raise_error(Puppet::ParseError, /Wrong number of arguments, expects one/)
-    expect { scope.function_get_module_path(['1','2','3']) }.should raise_error(Puppet::ParseError, /Wrong number of arguments, expects one/)
+    expect { scope.function_get_module_path([]) }.to raise_error(Puppet::ParseError, /Wrong number of arguments, expects one/)
+    expect { scope.function_get_module_path(['1','2','3']) }.to raise_error(Puppet::ParseError, /Wrong number of arguments, expects one/)
   end
   it 'should raise an exception when the module cannot be found' do
-    expect { scope.function_get_module_path(['foo']) }.should raise_error(Puppet::ParseError, /Could not find module/)
+    expect { scope.function_get_module_path(['foo']) }.to raise_error(Puppet::ParseError, /Could not find module/)
   end
   describe 'when locating a module' do
     let(:modulepath) { "/tmp/does_not_exist" }

--- a/spec/unit/puppet/parser/functions/merge_spec.rb
+++ b/spec/unit/puppet/parser/functions/merge_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::Parser::Functions.function(:merge) do
 
   describe 'when calling merge on the scope instance' do
     it 'should require all parameters are hashes' do
-      expect { new_hash = scope.function_merge([{}, '2'])}.should raise_error(Puppet::ParseError, /unexpected argument type String/)
+      expect { new_hash = scope.function_merge([{}, '2'])}.to raise_error(Puppet::ParseError, /unexpected argument type String/)
     end
 
     it 'should be able to merge two hashes' do

--- a/spec/unit/puppet/parser/functions/str2saltedsha512_spec.rb
+++ b/spec/unit/puppet/parser/functions/str2saltedsha512_spec.rb
@@ -9,11 +9,11 @@ describe "the str2saltedsha512 function" do
   end
 
   it "should raise a ParseError if there is less than 1 argument" do
-    expect { scope.function_str2saltedsha512([]) }.should( raise_error(Puppet::ParseError) )
+    expect { scope.function_str2saltedsha512([]) }.to( raise_error(Puppet::ParseError) )
   end
 
   it "should raise a ParseError if there is more than 1 argument" do
-    expect { scope.function_str2saltedsha512(['foo', 'bar', 'baz']) }.should( raise_error(Puppet::ParseError) )
+    expect { scope.function_str2saltedsha512(['foo', 'bar', 'baz']) }.to( raise_error(Puppet::ParseError) )
   end
 
   it "should return a salted-sha512 password hash 136 characters in length" do
@@ -22,7 +22,7 @@ describe "the str2saltedsha512 function" do
   end
 
   it "should raise an error if you pass a non-string password" do
-    expect { scope.function_str2saltedsha512([1234]) }.should( raise_error(Puppet::ParseError) )
+    expect { scope.function_str2saltedsha512([1234]) }.to( raise_error(Puppet::ParseError) )
   end
 
   it "should generate a valid password" do

--- a/spec/unit/puppet/parser/functions/validate_array_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_array_spec.rb
@@ -9,12 +9,12 @@ describe Puppet::Parser::Functions.function(:validate_array) do
     %w{ true false }.each do |the_string|
       it "should not compile when #{the_string} is a string" do
         Puppet[:code] = "validate_array('#{the_string}')"
-        expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not an Array/)
+        expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not an Array/)
       end
 
       it "should not compile when #{the_string} is a bare word" do
         Puppet[:code] = "validate_array(#{the_string})"
-        expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not an Array/)
+        expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not an Array/)
       end
     end
 
@@ -32,7 +32,7 @@ describe Puppet::Parser::Functions.function(:validate_array) do
         $foo = undef
         validate_array($foo)
       ENDofPUPPETcode
-      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not an Array/)
+      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not an Array/)
     end
   end
 end

--- a/spec/unit/puppet/parser/functions/validate_bool_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_bool_spec.rb
@@ -10,7 +10,7 @@ describe Puppet::Parser::Functions.function(:validate_bool) do
 
       it "should not compile when #{the_string} is a string" do
         Puppet[:code] = "validate_bool('#{the_string}')"
-        expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a boolean/)
+        expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a boolean/)
       end
 
       it "should compile when #{the_string} is a bare word" do
@@ -22,12 +22,12 @@ describe Puppet::Parser::Functions.function(:validate_bool) do
 
     it "should not compile when an arbitrary string is passed" do
       Puppet[:code] = 'validate_bool("jeff and dan are awesome")'
-      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a boolean/)
+      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a boolean/)
     end
 
     it "should not compile when no arguments are passed" do
       Puppet[:code] = 'validate_bool()'
-      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /wrong number of arguments/)
+      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
     end
 
     it "should compile when multiple boolean arguments are passed" do
@@ -45,7 +45,7 @@ describe Puppet::Parser::Functions.function(:validate_bool) do
         $bar = false
         validate_bool($foo, $bar, true, false, 'jeff')
       ENDofPUPPETcode
-      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a boolean/)
+      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a boolean/)
     end
   end
 end

--- a/spec/unit/puppet/parser/functions/validate_hash_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_hash_spec.rb
@@ -11,12 +11,12 @@ describe Puppet::Parser::Functions.function(:validate_hash) do
 
       it "should not compile when #{the_string} is a string" do
         Puppet[:code] = "validate_hash('#{the_string}')"
-        expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a Hash/)
+        expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a Hash/)
       end
 
       it "should not compile when #{the_string} is a bare word" do
         Puppet[:code] = "validate_hash(#{the_string})"
-        expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a Hash/)
+        expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a Hash/)
       end
 
     end
@@ -35,7 +35,7 @@ describe Puppet::Parser::Functions.function(:validate_hash) do
         $foo = undef
         validate_hash($foo)
       ENDofPUPPETcode
-      expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a Hash/)
+      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a Hash/)
     end
 
   end

--- a/spec/unit/puppet/parser/functions/validate_string_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_string_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::Parser::Functions.function(:validate_string) do
 
       it "should not compile when #{the_string} is a bare word" do
         Puppet[:code] = "validate_string(#{the_string})"
-        expect { scope.compiler.compile }.should raise_error(Puppet::ParseError, /is not a string/)
+        expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a string/)
       end
     end
 

--- a/spec/unit/puppet/type/file_line_spec.rb
+++ b/spec/unit/puppet/type/file_line_spec.rb
@@ -37,13 +37,13 @@ describe Puppet::Type.type(:file_line) do
     file_line[:path].should == '/tmp/path'
   end
   it 'should not accept unqualified path' do
-    expect { file_line[:path] = 'file' }.should raise_error(Puppet::Error, /File paths must be fully qualified/)
+    expect { file_line[:path] = 'file' }.to raise_error(Puppet::Error, /File paths must be fully qualified/)
   end
   it 'should require that a line is specified' do
-    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :path => '/tmp/file') }.should raise_error(Puppet::Error, /Both line and path are required attributes/)
+    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :path => '/tmp/file') }.to raise_error(Puppet::Error, /Both line and path are required attributes/)
   end
   it 'should require that a file is specified' do
-    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :line => 'path') }.should raise_error(Puppet::Error, /Both line and path are required attributes/)
+    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :line => 'path') }.to raise_error(Puppet::Error, /Both line and path are required attributes/)
   end
   it 'should default to ensure => present' do
     file_line[:ensure].should eq :present


### PR DESCRIPTION
Will fail in rspec 2.11. These tests need to be rewritten to use the proper rspec constructs and not something that worked by accident in previous rspec versions.

http://projects.puppetlabs.com/issues/15572
