### PR TITLE
(maint) Fix spec failures resulting from Facter API changes between 1.x and 2.x

### DIFF
--- a/spec/unit/facter/pe_version_spec.rb
+++ b/spec/unit/facter/pe_version_spec.rb
@@ -4,7 +4,15 @@ require 'spec_helper'
 
 describe "PE Version specs" do
   before :each do
-    Facter.collection.loader.load(:pe_version)
+    # Explicitly load the pe_version.rb file which contains generated facts
+    # that cannot be automatically loaded.  Puppet 2.x implements
+    # Facter.collection.load while Facter 1.x markes Facter.collection.load as
+    # a private method.
+    if Facter.collection.respond_to? :load
+      Facter.collection.load(:pe_version)
+    else
+      Facter.collection.loader.load(:pe_version)
+    end
   end
 
   context "If PE is installed" do


### PR DESCRIPTION
Without this patch stdlib tests fail against Facter 2.x and master but not
1.6.x.

This patch fixes the problem by initializing the example group differently
depending on the version of Facter integrating into the system.  The adjusted
methods are:

```
1.x - Facter.collection.loader.load
2.x - Facter.collection.load
```

The collection actually implements the load method in both version, it's
simply marked as private in 1.x.
