### PR TITLE
Add predicate functions for interface facts

### DIFF
--- a/lib/puppet/parser/functions/has_interface_with.rb
+++ b/lib/puppet/parser/functions/has_interface_with.rb
@@ -1,0 +1,52 @@
+#
+# has_interface_with
+#
+
+module Puppet::Parser::Functions
+  newfunction(:has_interface_with, :type => :rvalue, :doc => <<-EOS
+Returns boolean based on kind and value:
+  * macaddress
+  * netmask
+  * ipaddress
+  * network
+
+has_interface_with("macaddress", "x:x:x:x:x:x")
+has_interface_with("ipaddress", "127.0.0.1")    => true
+etc.
+
+If no "kind" is given, then the presence of the interface is checked:
+has_interface_with("lo")                        => true
+    EOS
+  ) do |args|
+
+    raise(Puppet::ParseError, "has_interface_with(): Wrong number of arguments " +
+          "given (#{args.size} for 1 or 2)") if args.size < 1 or args.size > 2
+
+    interfaces = lookupvar('interfaces')
+
+    # If we do not have any interfaces, then there are no requested attributes
+    return false if (interfaces == :undefined)
+
+    interfaces = interfaces.split(',')
+
+    if args.size == 1
+      return interfaces.member?(args[0])
+    end
+
+    kind, value = args
+
+    if lookupvar(kind) == value
+      return true
+    end
+
+    result = false
+    interfaces.each do |iface|
+      if value == lookupvar("#{kind}_#{iface}")
+        result = true
+        break
+      end
+    end
+
+    result
+  end
+end

--- a/lib/puppet/parser/functions/has_ip_address.rb
+++ b/lib/puppet/parser/functions/has_ip_address.rb
@@ -1,0 +1,25 @@
+#
+# has_ip_address
+#
+
+module Puppet::Parser::Functions
+  newfunction(:has_ip_address, :type => :rvalue, :doc => <<-EOS
+Returns true if the client has the requested IP address on some interface.
+
+This function iterates through the 'interfaces' fact and checks the
+'ipaddress_IFACE' facts, performing a simple string comparison.
+    EOS
+  ) do |args|
+
+    raise(Puppet::ParseError, "has_ip_address(): Wrong number of arguments " +
+          "given (#{args.size} for 1)") if args.size != 1
+
+    Puppet::Parser::Functions.autoloader.load(:has_interface_with) \
+      unless Puppet::Parser::Functions.autoloader.loaded?(:has_interface_with)
+
+    function_has_interface_with(['ipaddress', args[0]])
+
+  end
+end
+
+# vim:sts=2 sw=2

--- a/lib/puppet/parser/functions/has_ip_network.rb
+++ b/lib/puppet/parser/functions/has_ip_network.rb
@@ -1,0 +1,25 @@
+#
+# has_ip_network
+#
+
+module Puppet::Parser::Functions
+  newfunction(:has_ip_network, :type => :rvalue, :doc => <<-EOS
+Returns true if the client has an IP address within the requested network.
+
+This function iterates through the 'interfaces' fact and checks the
+'network_IFACE' facts, performing a simple string comparision.
+    EOS
+  ) do |args|
+
+    raise(Puppet::ParseError, "has_ip_network(): Wrong number of arguments " +
+          "given (#{args.size} for 1)") if args.size != 1
+
+    Puppet::Parser::Functions.autoloader.load(:has_interface_with) \
+      unless Puppet::Parser::Functions.autoloader.loaded?(:has_interface_with)
+
+    function_has_interface_with(['network', args[0]])
+
+  end
+end
+
+# vim:sts=2 sw=2

--- a/spec/unit/puppet/parser/functions/has_interface_with_spec.rb
+++ b/spec/unit/puppet/parser/functions/has_interface_with_spec.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe Puppet::Parser::Functions.function(:has_interface_with) do
+
+  let(:scope) do
+    PuppetlabsSpec::PuppetInternals.scope
+  end
+
+  # The subject of these examples is the method itself.
+  subject do
+    function_name = Puppet::Parser::Functions.function(:has_interface_with)
+    scope.method(function_name)
+  end
+
+  # We need to mock out the Facts so we can specify how we expect this function
+  # to behave on different platforms.
+  context "On Mac OS X Systems" do
+    before :each do
+      scope.stubs(:lookupvar).with("interfaces").returns('lo0,gif0,stf0,en1,p2p0,fw0,en0,vmnet1,vmnet8,utun0')
+    end
+    it 'should have loopback (lo0)' do
+      subject.call(['lo0']).should be_true
+    end
+    it 'should not have loopback (lo)' do
+      subject.call(['lo']).should be_false
+    end
+  end
+  context "On Linux Systems" do
+    before :each do
+      scope.stubs(:lookupvar).with("interfaces").returns('eth0,lo')
+      scope.stubs(:lookupvar).with("ipaddress").returns('10.0.0.1')
+      scope.stubs(:lookupvar).with("ipaddress_lo").returns('127.0.0.1')
+      scope.stubs(:lookupvar).with("ipaddress_eth0").returns('10.0.0.1')
+      scope.stubs(:lookupvar).with('muppet').returns('kermit')
+      scope.stubs(:lookupvar).with('muppet_lo').returns('mspiggy')
+      scope.stubs(:lookupvar).with('muppet_eth0').returns('kermit')
+    end
+    it 'should have loopback (lo)' do
+      subject.call(['lo']).should be_true
+    end
+    it 'should not have loopback (lo0)' do
+      subject.call(['lo0']).should be_false
+    end
+    it 'should have ipaddress with 127.0.0.1' do
+      subject.call(['ipaddress', '127.0.0.1']).should be_true
+    end
+    it 'should have ipaddress with 10.0.0.1' do
+      subject.call(['ipaddress', '10.0.0.1']).should be_true
+    end
+    it 'should not have ipaddress with 10.0.0.2' do
+      subject.call(['ipaddress', '10.0.0.2']).should be_false
+    end
+    it 'should have muppet named kermit' do
+      subject.call(['muppet', 'kermit']).should be_true
+    end
+    it 'should have muppet named mspiggy' do
+      subject.call(['muppet', 'mspiggy']).should be_true
+    end
+    it 'should not have muppet named bigbird' do
+      subject.call(['muppet', 'bigbird']).should be_false
+    end
+  end
+end

--- a/spec/unit/puppet/parser/functions/has_ip_address_spec.rb
+++ b/spec/unit/puppet/parser/functions/has_ip_address_spec.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe Puppet::Parser::Functions.function(:has_ip_address) do
+
+  let(:scope) do
+    PuppetlabsSpec::PuppetInternals.scope
+  end
+
+  subject do
+    function_name = Puppet::Parser::Functions.function(:has_ip_address)
+    scope.method(function_name)
+  end
+
+  context "On Linux Systems" do
+    before :each do
+      scope.stubs(:lookupvar).with('interfaces').returns('eth0,lo')
+      scope.stubs(:lookupvar).with('ipaddress').returns('10.0.2.15')
+      scope.stubs(:lookupvar).with('ipaddress_eth0').returns('10.0.2.15')
+      scope.stubs(:lookupvar).with('ipaddress_lo').returns('127.0.0.1')
+    end
+
+    it 'should have primary address (10.0.2.15)' do
+      subject.call(['10.0.2.15']).should be_true
+    end
+
+    it 'should have lookupback address (127.0.0.1)' do
+      subject.call(['127.0.0.1']).should be_true
+    end
+
+    it 'should not have other address' do
+      subject.call(['192.1681.1.1']).should be_false
+    end
+
+    it 'should not have "mspiggy" on an interface' do
+      subject.call(['mspiggy']).should be_false
+    end
+  end
+end

--- a/spec/unit/puppet/parser/functions/has_ip_network_spec.rb
+++ b/spec/unit/puppet/parser/functions/has_ip_network_spec.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe Puppet::Parser::Functions.function(:has_ip_network) do
+
+  let(:scope) do
+    PuppetlabsSpec::PuppetInternals.scope
+  end
+
+  subject do
+    function_name = Puppet::Parser::Functions.function(:has_ip_network)
+    scope.method(function_name)
+  end
+
+  context "On Linux Systems" do
+    before :each do
+      scope.stubs(:lookupvar).with('interfaces').returns('eth0,lo')
+      scope.stubs(:lookupvar).with('network').returns(:undefined)
+      scope.stubs(:lookupvar).with('network_eth0').returns('10.0.2.0')
+      scope.stubs(:lookupvar).with('network_lo').returns('127.0.0.1')
+    end
+
+    it 'should have primary network (10.0.2.0)' do
+      subject.call(['10.0.2.0']).should be_true
+    end
+
+    it 'should have loopback network (127.0.0.0)' do
+      subject.call(['127.0.0.1']).should be_true
+    end
+
+    it 'should not have other network' do
+      subject.call(['192.168.1.0']).should be_false
+    end
+  end
+end
+

--- a/tests/has_interface_with.pp
+++ b/tests/has_interface_with.pp
@@ -1,0 +1,10 @@
+include stdlib
+info("has_interface_with('lo'):", has_interface_with('lo'))
+info("has_interface_with('loX'):", has_interface_with('loX'))
+info("has_interface_with('ipaddress', '127.0.0.1'):", has_interface_with('ipaddress', '127.0.0.1'))
+info("has_interface_with('ipaddress', '127.0.0.100'):", has_interface_with('ipaddress', '127.0.0.100'))
+info("has_interface_with('network', '127.0.0.0'):", has_interface_with('network', '127.0.0.0'))
+info("has_interface_with('network', '128.0.0.0'):", has_interface_with('network', '128.0.0.0'))
+info("has_interface_with('netmask', '255.0.0.0'):", has_interface_with('netmask', '255.0.0.0'))
+info("has_interface_with('netmask', '256.0.0.0'):", has_interface_with('netmask', '256.0.0.0'))
+

--- a/tests/has_ip_address.pp
+++ b/tests/has_ip_address.pp
@@ -1,0 +1,3 @@
+include stdlib
+info("has_ip_address('192.168.1.256'):", has_ip_address('192.168.1.256'))
+info("has_ip_address('127.0.0.1'):", has_ip_address('127.0.0.1'))

--- a/tests/has_ip_network.pp
+++ b/tests/has_ip_network.pp
@@ -1,0 +1,4 @@
+include stdlib
+info("has_ip_network('127.0.0.0'):", has_ip_network('127.0.0.0'))
+info("has_ip_network('128.0.0.0'):", has_ip_network('128.0.0.0'))
+


### PR DESCRIPTION
https://projects.puppetlabs.com/issues/13974

If one wishes to test if a host has a particular IP address (such as a floating
virtual address) or has an interface on a particular network (such as a
secondary management network), the facts that provide this information are
difficult to use within Puppet.

This patch addresses these needs by implementing functions
`has_ip_address(value)` and `has_ip_network(value)`. These functions look
through all interfaces for `ipaddress_<interface>` and `network_<interface>`
(respectively) having the requested `<value>`.

These functions are implemented on top of a lower-level predicate
function, `has_interface_with(kind, value)`, which iterates through the
interfaces in the `interfaces` fact and checks the facts `<kind>_<interface>`
looking for `<value>`.

Additionally, the existence of a particular named interface can be checked for
by calling with only a single argument: `has_interface_with(interface)`.

A Boolean is returned in all cases.
