### PR TITLE
Add join_keys_to_values function

### DIFF
--- a/lib/puppet/parser/functions/join_keys_to_values.rb
+++ b/lib/puppet/parser/functions/join_keys_to_values.rb
@@ -1,0 +1,47 @@
+#
+# join.rb
+#
+
+module Puppet::Parser::Functions
+  newfunction(:join_keys_to_values, :type => :rvalue, :doc => <<-EOS
+This function joins each key of a hash to that key's corresponding value with a
+separator. Keys and values are cast to strings. The return value is an array in
+which each element is one joined key/value pair.
+
+*Examples:*
+
+    join_keys_to_values({'a'=>1,'b'=>2}, " is ")
+
+Would result in: ["a is 1","b is 2"]
+    EOS
+  ) do |arguments|
+
+    # Validate the number of arguments.
+    if arguments.size != 2
+      raise(Puppet::ParseError, "join_keys_to_values(): Takes exactly two " +
+            "arguments, but #{arguments.size} given.")
+    end
+
+    # Validate the first argument.
+    hash = arguments[0]
+    if not hash.is_a?(Hash)
+      raise(TypeError, "join_keys_to_values(): The first argument must be a " +
+            "hash, but a #{hash.class} was given.")
+    end
+
+    # Validate the second argument.
+    separator = arguments[1]
+    if not separator.is_a?(String)
+      raise(TypeError, "join_keys_to_values(): The second argument must be a " +
+            "string, but a #{separator.class} was given.")
+    end
+
+    # Join the keys to their values.
+    hash.map do |k,v|
+      String(k) + separator + String(v)
+    end
+
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/spec/unit/puppet/parser/functions/join_keys_to_values_spec.rb
+++ b/spec/unit/puppet/parser/functions/join_keys_to_values_spec.rb
@@ -1,0 +1,40 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe "the join_keys_to_values function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    Puppet::Parser::Functions.function("join_keys_to_values").should == "function_join_keys_to_values"
+  end
+
+  it "should raise a ParseError if there are fewer than two arguments" do
+    lambda { scope.function_join_keys_to_values([{}]) }.should raise_error Puppet::ParseError
+  end
+
+  it "should raise a ParseError if there are greater than two arguments" do
+    lambda { scope.function_join_keys_to_values([{}, 'foo', 'bar']) }.should raise_error Puppet::ParseError
+  end
+
+  it "should raise a TypeError if the first argument is an array" do
+    lambda { scope.function_join_keys_to_values([[1,2], ',']) }.should raise_error TypeError
+  end
+
+  it "should raise a TypeError if the second argument is an array" do
+    lambda { scope.function_join_keys_to_values([{}, [1,2]]) }.should raise_error TypeError
+  end
+
+  it "should raise a TypeError if the second argument is a number" do
+    lambda { scope.function_join_keys_to_values([{}, 1]) }.should raise_error TypeError
+  end
+
+  it "should return an empty array given an empty hash" do
+    result = scope.function_join_keys_to_values([{}, ":"])
+    result.should == []
+  end
+
+  it "should join hash's keys to its values" do
+    result = scope.function_join_keys_to_values([{'a'=>1,2=>'foo',:b=>nil}, ":"])
+    result.should =~ ['a:1','2:foo','b:']
+  end
+end


### PR DESCRIPTION
This commit adds a function that joins each of a hash's keys with that key's corresponding value, separated by a separator string. The arguments are a hash and separator string. The return value is an array of joined key/value pairs. Rspec tests are included in this commit and all Rspec tests pass.
