### PR TITLE
(maint) Add Travis CI Support

### DIFF
--- a/.gemfile
+++ b/.gemfile
@@ -1,5 +1,0 @@
-source :rubygems
-
-puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 2.7']
-gem 'puppet', puppetversion
-gem 'puppetlabs_spec_helper', '>= 0.1.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: ruby
-rvm:
-  - 1.8.7
-before_script:
-after_script:
-script: "rake spec_full"
-branches:
-  only:
-    - master
-env:
-  - PUPPET_VERSION=2.7.13
-  - PUPPET_VERSION=2.7.6
-  - PUPPET_VERSION=2.6.9
+bundler_args: --without development
+script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
 notifications:
   email: false
-gemfile: .gemfile
+rvm:
+  - 1.9.3
+  - 1.8.7
+env:
+  - PUPPET_GEM_VERSION="~> 2.7.0"
+  - PUPPET_GEM_VERSION=">= 3.0.0"
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 2.7.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,21 @@
+source :rubygems
+
+group :development do
+  gem 'watchr'
+end
+
+group :development, :test do
+  gem 'rake'
+  gem 'rspec', "~> 2.11.0", :require => false
+  gem 'mocha', "~> 0.10.5", :require => false
+  gem 'puppetlabs_spec_helper', :require => false
+  gem 'rspec-puppet', :require => false
+end
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
+# vim:ft=ruby

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,7 @@
 # Puppet Labs Standard Library #
 
+[![Build Status](https://travis-ci.org/puppetlabs/puppetlabs-stdlib.png?branch=master)](https://travis-ci.org/puppetlabs/puppetlabs-stdlib)
+
 This module provides a "standard library" of resources for developing Puppet
 Modules.  This modules will include the following additions to Puppet
 


### PR DESCRIPTION
Without this patch stdlib has Travis CI configuration files, but they
don't seem to completely specify the dependency versions and the build
matrix.  This patch addresses the problem by putting the dependency
information in the conventional Gemfile location.

This patch should coincide with enabling Travis CI support for pull
requests.
