### PR TITLE
Future proof travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,16 @@ notifications:
 rvm:
   - 1.9.3
   - 1.8.7
+  - ruby-head
 env:
-  - PUPPET_GEM_VERSION="~> 2.7.0"
-  - PUPPET_GEM_VERSION=">= 3.0.0"
+  - PUPPET_GEM_VERSION="~> 2.7"
+  - PUPPET_GEM_VERSION="~> 3"
 matrix:
+  allow_failures:
+    - rvm: ruby-head
   exclude:
     - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
+      env: PUPPET_GEM_VERSION="~> 2.7"
+  exclude:
+    - rvm: ruby-head
+      env: PUPPET_GEM_VERSION="~> 2.7"


### PR DESCRIPTION
Without this patch we're not building against ruby head.  This is a
problem because we need to know if standard lib works with the latest
version of MRI.

This patch builds against ruby head but also allows the build to pass if
there are failures with ruby-head.
