### PR TITLE
Tell Travis CI to notify the PDC WebHook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
 language: ruby
 bundler_args: --without development
 script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
-notifications:
-  email: false
 rvm:
   - 1.9.3
   - 1.8.7
   - ruby-head
 env:
   - PUPPET_GEM_VERSION="~> 2.7"
-  - PUPPET_GEM_VERSION="~> 3"
+  - PUPPET_GEM_VERSION=">= 3.0.0"
 matrix:
   allow_failures:
     - rvm: ruby-head
@@ -19,6 +17,7 @@ matrix:
     - rvm: ruby-head
       env: PUPPET_GEM_VERSION="~> 2.7"
 notifications:
+  email: false
   webhooks:
     urls:
       - https://puppet-dev-community.herokuapp.com/event/travis-ci/


### PR DESCRIPTION
Without this patch the so-called "puppet development community" hook
service isn't being notified when Travis CI accepts jobs.  This is a
problem because we want the ability for Travis Bot to comment on pull
requests as a result of CI build results.  For example, if the build fails,
then Gepetto Bot could make some helpful suggestions on how to re-run the
build by amending a commit and force-pushing the branch.

This patch uses the notifications section of the travis.yml configuration
file, as documented at:
http://about.travis-ci.org/docs/user/notifications/#Webhook-notification
