### PR TITLE
(maint) Fix getparam() spec failure on MRI 1.8

### DIFF
--- a/lib/puppet/parser/functions/getparam.rb
+++ b/lib/puppet/parser/functions/getparam.rb
@@ -25,6 +25,8 @@ ENDOFDOC
   raise(ArgumentError, 'Must specify a reference') unless reference
   raise(ArgumentError, 'Must specify name of a parameter') unless param and param.instance_of? String
 
+  return '' if param.empty?
+
   if resource = findresource(reference.to_s)
     return resource[param] if resource[param]
   end


### PR DESCRIPTION
Without this patch applied we're getting the following spec failure, but
only in the MRI 1.8 matrix cells.

```
Failures:

  1) getparam when compared against a resource with params
    Failure/Error: should run.with_params('User[dan]', '').and_return('')
    ArgumentError:
      interning empty string
```

This patch addresses the problem by explicitly returning an empty string if
the string itself is empty.  This avoids trying to convert an empty string to
a symbol which is the root cause of the problem.
