### PR TITLE
(#19272) Add has_element() function

### DIFF
--- a/lib/puppet/parser/functions/has_element.rb
+++ b/lib/puppet/parser/functions/has_element.rb
@@ -1,0 +1,28 @@
+module Puppet::Parser::Functions
+
+  newfunction(:has_element, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
+    Determine if an array has an element with a matching value.
+
+    Example:
+
+        $my_array = ['key_one']
+        if has_element($my_array, 'key_two') {
+          notice('we will not reach here')
+        }
+        if has_element($my_array, 'key_one') {
+          notice('this will be printed')
+        }
+
+    ENDHEREDOC
+
+    unless args.length == 2
+      raise Puppet::ParseError, ("has_element(): wrong number of arguments (#{args.length}; must be 2)")
+    end
+    unless args[0].is_a?(Array)
+      raise Puppet::ParseError, "has_element(): expects the first argument to be an array, got #{args[0].inspect} which is of type #{args[0].class}"
+    end
+    args[0].include?(args[1])
+
+  end
+
+end

--- a/spec/unit/puppet/parser/functions/has_element_spec.rb
+++ b/spec/unit/puppet/parser/functions/has_element_spec.rb
@@ -1,0 +1,42 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe Puppet::Parser::Functions.function(:has_element) do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  describe 'when calling has_element from puppet' do
+    it "should not compile when no arguments are passed" do
+      pending("Fails on 2.6.x, see bug #15912") if Puppet.version =~ /^2\.6\./
+      Puppet[:code] = '$x = has_element()'
+      expect {
+        scope.compiler.compile
+      }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
+    end
+
+    it "should not compile when 1 argument is passed" do
+      pending("Fails on 2.6.x, see bug #15912") if Puppet.version =~ /^2\.6\./
+      Puppet[:code] = "$x = has_element('foo')"
+      expect {
+        scope.compiler.compile
+      }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
+    end
+
+    it "should require the first value to be an Array" do
+      pending("Fails on 2.6.x, see bug #15912") if Puppet.version =~ /^2\.6\./
+      Puppet[:code] = "$x = has_element('foo', 'bar')"
+      expect {
+        scope.compiler.compile
+      }.to raise_error(Puppet::ParseError, /expects the first argument to be an array/)
+    end
+  end
+
+  describe 'when calling the function has_element from a scope instance' do
+    it 'should detect existing elements' do
+      scope.function_has_element([['one'], 'one']).should be_true
+    end
+
+    it 'should detect existing elements' do
+      scope.function_has_element([['one'], 'two']).should be_false
+    end
+  end
+end

--- a/tests/has_element.pp
+++ b/tests/has_element.pp
@@ -1,0 +1,9 @@
+include stdlib
+
+$my_array = ['key_one']
+if has_element($my_array, 'key_two') {
+  notice('we will not reach here')
+}
+if has_element($my_array, 'key_one') {
+  notice('this will be printed')
+}


### PR DESCRIPTION
It is exceptionally difficult to determine if an array contains an element matching a specific value without an iteration or loop construct.

This function is the Puppet equivalent of Array.includes?(foo) in Ruby.  The implementation is a verbatim copy of has_key() with the minor modifications needed to support arrays instead of hashes.
