### PR TITLE
.count method not supported in older ruby versions

### DIFF
--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:file_line).provide(:ruby) do
 
   def handle_create_with_match()
     regex = resource[:match] ? Regexp.new(resource[:match]) : nil
-    match_count = lines.select { |l| regex.match(l) }.count
+    match_count = lines.select { |l| regex.match(l) }.size
     if match_count > 1
       raise Puppet::Error, "More than one line in file '#{resource[:path]}' matches pattern '#{resource[:match]}'"
     end


### PR DESCRIPTION
I changed the .count method used in file-line/ruby.rb to .size in order to support older ruby versions.

Notably Scientific Linux 5.X only sports a 1.8.5 ruby version, where .count does not exist.
