### PR TITLE
Allow comparisons of Numeric and number as String

### DIFF
--- a/lib/puppet/parser/functions/max.rb
+++ b/lib/puppet/parser/functions/max.rb
@@ -8,6 +8,14 @@ module Puppet::Parser::Functions
     raise(Puppet::ParseError, "max(): Wrong number of arguments " +
           "need at least one") if args.size == 0
 
-    return args.max
+    # Sometimes we get numbers as numerics and sometimes as strings.
+    # We try to compare them as numbers when possible
+    return args.max do |a,b|
+      if a.to_s =~ /\A-?\d+(.\d+)?\z/ and b.to_s =~ /\A-?\d+(.\d+)?\z/ then
+        a.to_f <=> b.to_f
+      else
+        a.to_s <=> b.to_s
+      end
+    end
   end
 end

--- a/lib/puppet/parser/functions/min.rb
+++ b/lib/puppet/parser/functions/min.rb
@@ -8,6 +8,14 @@ module Puppet::Parser::Functions
     raise(Puppet::ParseError, "min(): Wrong number of arguments " +
           "need at least one") if args.size == 0
 
-    return args.min
+    # Sometimes we get numbers as numerics and sometimes as strings.
+    # We try to compare them as numbers when possible
+    return args.min do |a,b|
+      if a.to_s =~ /\A^-?\d+(.\d+)?\z/ and b.to_s =~ /\A-?\d+(.\d+)?\z/ then
+        a.to_f <=> b.to_f
+      else
+        a.to_s <=> b.to_s
+      end
+    end
   end
 end

--- a/spec/unit/puppet/parser/functions/max_spec.rb
+++ b/spec/unit/puppet/parser/functions/max_spec.rb
@@ -20,4 +20,8 @@ describe "the max function" do
   it "should be able to compare numbers" do
     scope.function_max([6,8,4]).should(eq(8))
   end
+
+  it "should be able to compare a number with a stringified number" do
+    scope.function_max([1,"2"]).should(eq("2"))
+  end
 end

--- a/spec/unit/puppet/parser/functions/min_spec.rb
+++ b/spec/unit/puppet/parser/functions/min_spec.rb
@@ -20,4 +20,8 @@ describe "the min function" do
   it "should be able to compare numbers" do
     scope.function_min([6,8,4]).should(eq(4))
   end
+
+  it "should be able to compare a number with a stringified number" do
+    scope.function_min([1,"2"]).should(eq(1))
+  end
 end


### PR DESCRIPTION
Puppet passes numbers as String to functions, but it makes more sense to
compare them as Numeric.
But sometimes Puppet passes them as the wrong type, see:
https://projects.puppetlabs.com/issues/19812
