### PR TITLE
add sha1_passwd parser function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -487,6 +487,13 @@ Strips leading spaces to the right of the string.
 
 - *Type*: rvalue
 
+sha1_passwd
+------
+Converts string to a base64 encoded sha1 digest suitable for Apache SHA1 htpasswd files
+
+
+- *Type*: rvalue
+
 shuffle
 -------
 Randomizes the order of a string or array elements.

--- a/lib/puppet/parser/functions/sha1_passwd.rb
+++ b/lib/puppet/parser/functions/sha1_passwd.rb
@@ -1,0 +1,18 @@
+require 'sha1'
+require 'base64'
+
+module Puppet::Parser::Functions
+    newfunction(:sha1_passwd, :type => :rvalue, :doc => <<-EOS
+      Create a base64 encoded sha1 digest of the argument. This is suitable to create for example apache SHA1 passwords.
+    EOS
+    ) do |args|
+      raise(Puppet::ParseError, "sha1_passwd(): Wrong number of arguments " +
+        "given (#{args.size} for 1)") if args.size != 1
+
+      value = args[0]
+
+      raise(Puppet::ParseError, 'sha1_passwd(): Requires a string to work with') unless value.class == String
+
+      "{SHA}"+Base64.encode64(Digest::SHA1.digest(value)).chomp!
+    end
+end

--- a/spec/unit/puppet/parser/functions/sha1_passwd_spec.rb
+++ b/spec/unit/puppet/parser/functions/sha1_passwd_spec.rb
@@ -1,0 +1,32 @@
+#! /usr/bin/env ruby -S rspec
+
+require 'spec_helper'
+
+describe "the sha1_passwd function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    Puppet::Parser::Functions.function("sha1_passwd").should == "function_sha1_passwd"
+  end
+
+  it "should raise a ParseError if there is less than 1 argument" do
+    lambda { scope.function_sha1_passwd([]) }.should( raise_error(Puppet::ParseError))
+  end
+
+  it "should raise a ParseError if there is more than 1 argument" do
+    lambda { scope.function_sha1_passwd(['foo', 'bar']) }.should( raise_error(Puppet::ParseError))
+  end
+
+  it "should raise a ParseError if passed a number" do
+    lambda { scope.function_sha1_passwd([42]) }.should( raise_error(Puppet::ParseError))
+  end
+
+  it "should raise a ParseError if passed a hash" do
+    lambda { scope.function_sha1_passwd([{:a => '42', }]) }.should( raise_error(Puppet::ParseError))
+  end
+
+  it "should return a SHA1 password" do
+    result = scope.function_sha1_passwd(['testpassword'])
+    result.should(eq('{SHA}i7YRj4/Wk1rQh2o740pxfTJwj/0='))
+  end
+end


### PR DESCRIPTION
the sha1_passwd converts a string to a base64 encoded sha1 digest suitable for Apache SHA1 htpasswd files
