### PR TITLE
Add a count function

### DIFF
--- a/lib/puppet/parser/functions/count.rb
+++ b/lib/puppet/parser/functions/count.rb
@@ -1,0 +1,22 @@
+module Puppet::Parser::Functions
+  newfunction(:count, :type => :rvalue, :arity => -2, :doc => <<-EOS
+Takes an array as first argument and an optional second argument.
+Count the number of elements in array that matches second argument.
+If called with only an array it counts the number of elements that are not nil/undef.
+    EOS
+  ) do |args|
+
+    if (args.size > 2) then
+      raise(ArgumentError, "count(): Wrong number of arguments "+
+        "given #{args.size} for 1 or 2.")
+    end
+
+    collection, item = args
+
+    if item then
+      collection.count item
+    else
+      collection.count { |obj| obj != nil && obj != :undef && obj != '' }
+    end
+  end
+end

--- a/spec/unit/puppet/parser/functions/count_spec.rb
+++ b/spec/unit/puppet/parser/functions/count_spec.rb
@@ -1,0 +1,27 @@
+#! /usr/bin/env ruby -S rspec
+
+require 'spec_helper'
+
+describe "the count function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    Puppet::Parser::Functions.function("count").should == "function_count"
+  end
+
+  it "should raise a ArgumentError if there is more than 2 arguments" do
+    lambda { scope.function_count(['foo', 'bar', 'baz']) }.should( raise_error(ArgumentError))
+  end
+
+  it "should be able to count arrays" do
+    scope.function_count([["1","2","3"]]).should(eq(3))
+  end
+
+  it "should be able to count matching elements in arrays" do
+    scope.function_count([["1", "2", "2"], "2"]).should(eq(2))
+  end
+
+  it "should not count :undef, nil or empty strings" do
+    scope.function_count([["foo","bar",:undef,nil,""]]).should(eq(2))
+  end
+end


### PR DESCRIPTION
Similar to the ruby count method on arrays.

Can be useful if for example for defines that have two or more arguments that it needs but are mutually exclusive. For example defines that wrap the file type and passes on content, source and/or target.

So instead of doing:

``` puppet
unless ($source and not ($content or $target)) or ($target and not ($content or $source)) or ($content and not ($source or $target)) { fail() }
```

You can do:

``` puppet
unless count([$source,$target,$content])==1 { fail() }
```
