### PR TITLE
Update gemspec, Modulefile, CHANGELOG for 4.0.2

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -4,24 +4,30 @@
 Gem::Specification.new do |s|
   s.name = "puppetmodule-stdlib"
 
-  s.version = "4.0.1"
+  s.version = "4.0.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Puppet Labs"]
-  s.date = "2013-04-10"
-  s.description = "Puppet Labs Standard Library module"
-  s.email = "support@puppetlabs.com"
+  s.date = "2013-04-12"
+  s.description = [ 'This Gem format of the stdlib module is intended to make',
+                    'it easier for _module authors_ to resolve dependencies',
+                    'using a Gemfile when running automated testing jobs like',
+                    'Travis or Jenkins.  The recommended best practice for',
+                    'installation by end users is to use the `puppet module',
+                    'install` command to install stdlib from the [Puppet',
+                    'Forge](http://forge.puppetlabs.com/puppetlabs/stdlib).' ].join(' ')
+  s.email = "puppet-dev@puppetlabs.com"
   s.executables = []
   s.files = [ 'CHANGELOG', 'CONTRIBUTING.md', 'Gemfile', 'LICENSE', 'Modulefile',
               'README.markdown', 'README_DEVELOPER.markdown', 'RELEASE_PROCESS.markdown',
               'Rakefile', 'spec/spec.opts' ]
   s.files += Dir['lib/**/*.rb'] + Dir['manifests/**/*.pp'] + Dir['tests/**/*.pp'] + Dir['spec/**/*.rb']
-  s.homepage = "https://github.com/puppetlabs/puppetlabs-stdlib"
-  s.rdoc_options = ["--title", "Puppet Standard Library Module", "--main", "README.markdown", "--line-numbers"]
+  s.homepage = "http://forge.puppetlabs.com/puppetlabs/stdlib"
+  s.rdoc_options = ["--title", "Puppet Standard Library Development Gem", "--main", "README.markdown", "--line-numbers"]
   s.require_paths = ["lib"]
   s.rubyforge_project = "puppetmodule-stdlib"
   s.rubygems_version = "1.8.24"
-  s.summary = "This module provides a standard library of resources for developing Puppet Modules."
+  s.summary = "This gem provides a way to make the standard library available for other module spec testing tasks."
 
   if s.respond_to? :specification_version then
     s.specification_version = 3

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2013-04-12 - Jeff McCune <jeff@puppetlabs.com> - 4.0.2
+ * Update user information in gemspec to make the intent of the Gem clear.
+
 2013-04-11 - Jeff McCune <jeff@puppetlabs.com> - 4.0.1
  * Fix README function documentation (ab3e30c)
 

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-stdlib'
-version '4.0.1'
+version '4.0.2'
 source 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
 author 'puppetlabs'
 license 'Apache 2.0'


### PR DESCRIPTION
Without this patch the information displayed on rubygems.org does not
clearly convey the intent of the Gem format of stdlib from the official
puppet module format of stdlib.  This is a problem because end users
might get confused and start installing stdlib from rubygems.org

This patch addresses the problem by making it clear that the gem version
of stdlib is not intended for end users, but rather is specifically
intended to make it easier for other module authors to depend on stdlib
and have that dependency automatically resolved using a Gemfile.
