### PR TITLE
Release version 4.1.0

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-stdlib'
-version '4.0.2'
+version '4.1.0'
 source 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
 author 'puppetlabs'
 license 'Apache 2.0'


### PR DESCRIPTION
Tests are passing and both Jeff and my smoke testing look good. I'm ready to make the release to Forge. I also have a signed 4.1.0 tag waiting to be pushed once this is merged.

This commit alters the module metadata to indicate a 4.1.0 version
release for the Puppet Forge. It contains backwards compatible
features, refactors and bug fixes.
