### PR TITLE
Trivial documentation fix for upcase function.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -934,7 +934,7 @@ Converts a string or an array of strings to uppercase.
 
 Will return:
 
-    ASDF
+    ABCD
 
 
 - *Type*: rvalue


### PR DESCRIPTION
upcase on the example will return ABCD, not ASDF.
