### PR TITLE
ensure_resource: fix documentation typo

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -258,7 +258,7 @@ resource.
 
 This example only creates the resource if it does not already exist:
 
-    ensure_resource('user, 'dan', {'ensure' => 'present' })
+    ensure_resource('user', 'dan', {'ensure' => 'present' })
 
 If the resource already exists but does not match the specified parameters,
 this function will attempt to recreate the resource leading to a duplicate

--- a/lib/puppet/parser/functions/ensure_resource.rb
+++ b/lib/puppet/parser/functions/ensure_resource.rb
@@ -13,7 +13,7 @@ resource.
 
 This example only creates the resource if it does not already exist:
 
-    ensure_resource('user, 'dan', {'ensure' => 'present' })
+    ensure_resource('user', 'dan', {'ensure' => 'present' })
 
 If the resource already exists but does not match the specified parameters,
 this function will attempt to recreate the resource leading to a duplicate


### PR DESCRIPTION
The documentation for ensure_resource() is missing a quote character. This commit adds the missing quote mark.
