### PR TITLE
Add delete_values() and delete_undef_values() functions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -204,6 +204,33 @@ Would return: ['a','c']
 
 - *Type*: rvalue
 
+delete_values
+-------------
+Deletes all instances of a given value from a hash.
+
+*Examples:*
+
+    delete_values({'a'=>'A','b'=>'B','c'=>'C','B'=>'D'}, 'B')
+
+Would return: {'a'=>'A','c'=>'C','B'=>'D'}
+
+
+delete_undef_values
+-------------------
+Deletes all instances of the undef value from an array or hash.
+
+*Examples:*
+    
+    $hash = delete_undef_values({a=>'A', b=>'', c=>undef, d => false})
+
+Would return: {a => 'A', b => '', d => false}
+
+    $array = delete_undef_values(['A','',undef,false])
+
+Would return: ['A','',false]
+
+- *Type*: rvalue
+
 difference
 ----------
 This function returns the difference between two arrays.

--- a/lib/puppet/parser/functions/delete_undef_values.rb
+++ b/lib/puppet/parser/functions/delete_undef_values.rb
@@ -1,0 +1,34 @@
+module Puppet::Parser::Functions
+  newfunction(:delete_undef_values, :type => :rvalue, :doc => <<-EOS
+Returns a copy of input hash or array with all undefs deleted.
+
+*Examples:*
+    
+    $hash = delete_undef_values({a=>'A', b=>'', c=>undef, d => false})
+
+Would return: {a => 'A', b => '', d => false}
+
+    $array = delete_undef_values(['A','',undef,false])
+
+Would return: ['A','',false]
+    
+      EOS
+    ) do |args|
+
+    raise(Puppet::ParseError,
+          "delete_undef_values(): Wrong number of arguments given " +
+          "(#{args.size})") if args.size < 1
+
+    result = args[0]
+    if result.is_a?(Hash)
+      result.delete_if {|key, val| val.equal? :undef}
+    elsif result.is_a?(Array)
+      result.delete :undef
+    else
+      raise(Puppet::ParseError, 
+            "delete_undef_values(): Wrong argument type #{args[0].class} " +
+            "for first argument")
+    end
+    result
+  end
+end

--- a/lib/puppet/parser/functions/delete_values.rb
+++ b/lib/puppet/parser/functions/delete_values.rb
@@ -1,0 +1,27 @@
+module Puppet::Parser::Functions
+  newfunction(:delete_values, :type => :rvalue, :doc => <<-EOS
+Deletes all instances of a given value from a hash.
+
+*Examples:*
+
+    delete_values({'a'=>'A','b'=>'B','c'=>'C','B'=>'D'}, 'B')
+
+Would return: {'a'=>'A','c'=>'C','B'=>'D'}
+
+      EOS
+    ) do |arguments|
+
+    raise(Puppet::ParseError,
+          "delete_values(): Wrong number of arguments given " +
+          "(#{arguments.size} of 2)") if arguments.size != 2
+
+    hash = arguments[0]
+    item = arguments[1]
+
+    if not hash.is_a?(Hash)
+      raise(TypeError, "delete_values(): First argument must be a Hash. " + \
+                       "Given an" " argument of class #{hash.class}.") 
+    end
+    hash.delete_if { |key, val| item == val }
+  end
+end

--- a/spec/unit/puppet/parser/functions/delete_undef_values_spec.rb
+++ b/spec/unit/puppet/parser/functions/delete_undef_values_spec.rb
@@ -1,0 +1,29 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe "the delete_undef_values function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    Puppet::Parser::Functions.function("delete_undef_values").should == "function_delete_undef_values"
+  end
+
+  it "should raise a ParseError if there is less than 1 argument" do
+    lambda { scope.function_delete_undef_values([]) }.should( raise_error(Puppet::ParseError))
+  end
+
+  it "should raise a ParseError if the argument is not Array nor Hash" do
+    lambda { scope.function_delete_undef_values(['']) }.should( raise_error(Puppet::ParseError))
+    lambda { scope.function_delete_undef_values([nil]) }.should( raise_error(Puppet::ParseError))
+  end
+
+  it "should delete all undef items from Array and only these" do
+    result = scope.function_delete_undef_values([['a',:undef,'c','undef']])
+    result.should(eq(['a','c','undef']))
+  end
+
+  it "should delete all undef items from Hash and only these" do
+    result = scope.function_delete_undef_values([{'a'=>'A','b'=>:undef,'c'=>'C','d'=>'undef'}])
+    result.should(eq({'a'=>'A','c'=>'C','d'=>'undef'}))
+  end
+end

--- a/spec/unit/puppet/parser/functions/delete_values_spec.rb
+++ b/spec/unit/puppet/parser/functions/delete_values_spec.rb
@@ -1,0 +1,30 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe "the delete_values function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    Puppet::Parser::Functions.function("delete_values").should == "function_delete_values"
+  end
+
+  it "should raise a ParseError if there are fewer than 2 arguments" do
+    lambda { scope.function_delete_values([]) }.should( raise_error(Puppet::ParseError))
+  end
+
+  it "should raise a ParseError if there are greater than 2 arguments" do
+    lambda { scope.function_delete([[], 'foo', 'bar']) }.should( raise_error(Puppet::ParseError))
+  end
+
+  it "should raise a TypeError if the argument is not a hash" do
+    lambda { scope.function_delete_values([1,'bar']) }.should( raise_error(TypeError))
+    lambda { scope.function_delete_values(['foo','bar']) }.should( raise_error(TypeError))
+    lambda { scope.function_delete_values([[],'bar']) }.should( raise_error(TypeError))
+  end
+
+  it "should delete all instances of a value from a hash" do
+    result = scope.function_delete_values([{ 'a'=>'A', 'b'=>'B', 'B'=>'C', 'd'=>'B' },'B'])
+    result.should(eq({ 'a'=>'A', 'B'=>'C' }))
+  end
+
+end


### PR DESCRIPTION
Hi, 
`delete_values()` complements `delete()` for hashes - deletion is based on hash values, not keys,
`delete_undef_values()`  may be used to filter-out "unset" parameters from hash. It then plays nicely with `ensure_resource()` or `create_resources()` - see motivating example in README.markdown. I leave this pull request if you consider this function useful enough. Tell me if i've reinvented the wheel.

Regards.
