### PR TITLE
extend the validate_slength function to accept a minimum length

### DIFF
--- a/lib/puppet/parser/functions/validate_slength.rb
+++ b/lib/puppet/parser/functions/validate_slength.rb
@@ -2,23 +2,26 @@ module Puppet::Parser::Functions
 
   newfunction(:validate_slength, :doc => <<-'ENDHEREDOC') do |args|
     Validate that the first argument is a string (or an array of strings), and
-    less/equal to than the length of the second argument.  It fails if the first
-    argument is not a string or array of strings, and if arg 2 is not convertable
-    to a number.
+    less/equal to than the length of the second argument. An optional third
+    parameter can be given a the minimum length. It fails if the first
+    argument is not a string or array of strings, and if arg 2 and arg 3 are
+    not convertable to a number.
 
     The following values will pass:
 
       validate_slength("discombobulate",17)
       validate_slength(["discombobulate","moo"],17)
+      validate_slength(["discombobulate","moo"],17,3)
 
     The following valueis will not:
 
       validate_slength("discombobulate",1)
       validate_slength(["discombobulate","thermometer"],5)
+      validate_slength(["discombobulate","moo"],17,10)
 
     ENDHEREDOC
 
-    raise Puppet::ParseError, ("validate_slength(): Wrong number of arguments (#{args.length}; must be = 2)") unless args.length == 2
+    raise Puppet::ParseError, ("validate_slength(): Wrong number of arguments (#{args.length}; must be 2 or 3)") unless args.length == 2 or args.length == 3
 
     unless (args[0].is_a?(String) or args[0].is_a?(Array))
       raise Puppet::ParseError, ("validate_slength(): please pass a string, or an array of strings - what you passed didn't work for me at all - #{args[0].class}")
@@ -27,19 +30,31 @@ module Puppet::Parser::Functions
     begin
       max_length = args[1].to_i
     rescue NoMethodError => e
-      raise Puppet::ParseError, ("validate_slength(): Couldn't convert whatever you passed as the length parameter to an integer  - sorry: " + e.message )
+      raise Puppet::ParseError, ("validate_slength(): Couldn't convert whatever you passed as the max length parameter to an integer  - sorry: " + e.message )
+    end
+
+    unless args.length == 2
+      begin
+        min_length = Integer(args[2])
+      rescue StandardError => e
+        raise Puppet::ParseError, ("validate_slength(): Couldn't convert whatever you passed as the min length parameter to an integer  - sorry: " + e.message )
+      end
+    else
+      min_length = 0
     end
 
     raise Puppet::ParseError, ("validate_slength(): please pass a positive number as max_length") unless max_length > 0
+    raise Puppet::ParseError, ("validate_slength(): please pass a positive number as min_length") unless min_length >= 0
+    raise Puppet::ParseError, ("validate_slength(): please pass a min length that is smaller than the maximum") unless min_length <= max_length
 
     case args[0]
       when String
-        raise Puppet::ParseError, ("validate_slength(): #{args[0].inspect} is #{args[0].length} characters.  It should have been less than or equal to #{max_length} characters") unless args[0].length <= max_length
+        raise Puppet::ParseError, ("validate_slength(): #{args[0].inspect} is #{args[0].length} characters.  It should have been between #{min_length} and #{max_length} characters") unless args[0].length <= max_length and min_length <= arg.length
       when Array
         args[0].each do |arg|
           if arg.is_a?(String)
-            unless ( arg.is_a?(String) and arg.length <= max_length )
-              raise Puppet::ParseError, ("validate_slength(): #{arg.inspect} is #{arg.length} characters.  It should have been less than or equal to #{max_length} characters")
+            unless ( arg.is_a?(String) and arg.length <= max_length and min_length <= arg.length)
+              raise Puppet::ParseError, ("validate_slength(): #{arg.inspect} is #{arg.length} characters.  It should have been between #{min_length} and #{max_length} characters")
             end
           else
             raise Puppet::ParseError, ("validate_slength(): #{arg.inspect} is not a string, it's a #{arg.class}")

--- a/spec/unit/puppet/parser/functions/validate_slength_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_slength_spec.rb
@@ -26,8 +26,20 @@ describe "the validate_slength function" do
     expect { scope.function_validate_slength(["moo","0"]) }.to(raise_error(Puppet::ParseError, /please pass a positive number as max_length/))
   end
 
+  it "should raise a ParseError if argument 3 doesn't convert to a fixnum" do
+    expect { scope.function_validate_slength(["moo",2,["3"]]) }.to(raise_error(Puppet::ParseError, /Couldn't convert whatever you passed/))
+  end
+
+  it "should raise a ParseError if argument 3 converted, but to 0, e.g. a string" do
+    expect { scope.function_validate_slength(["moo",2,"monkey"]) }.to(raise_error(Puppet::ParseError, /Couldn't convert whatever you passed/))
+  end
+
   it "should fail if string greater then size" do
-    expect { scope.function_validate_slength(["test", 2]) }.to(raise_error(Puppet::ParseError, /It should have been less than or equal to/))
+    expect { scope.function_validate_slength(["test", 2]) }.to(raise_error(Puppet::ParseError, /It should have been between 0 and 2/))
+  end
+
+  it "should fail if the min length is larger than the max length" do
+    expect { scope.function_validate_slength(["test", 10, 15]) }.to(raise_error(Puppet::ParseError, /pass a min length that is smaller than the max/))
   end
 
   it "should fail if you pass an array of something other than strings" do


### PR DESCRIPTION
I extended the function to accept a third parameter giving a minimum length of the string. This parameter is optional.
I also updated the tests functions. The error messages change a bit in that they now say "should be between x and y characters", if the string has not the right size.

The default for the min length is zero.

My use case was a security token, which had to be of a certain format (min length and max length).
