### PR TITLE
Fix validate_slength, arg.length should be args[0].length

### DIFF
--- a/lib/puppet/parser/functions/validate_slength.rb
+++ b/lib/puppet/parser/functions/validate_slength.rb
@@ -49,7 +49,7 @@ module Puppet::Parser::Functions
 
     case args[0]
       when String
-        raise Puppet::ParseError, ("validate_slength(): #{args[0].inspect} is #{args[0].length} characters.  It should have been between #{min_length} and #{max_length} characters") unless args[0].length <= max_length and min_length <= arg.length
+        raise Puppet::ParseError, ("validate_slength(): #{args[0].inspect} is #{args[0].length} characters.  It should have been between #{min_length} and #{max_length} characters") unless args[0].length <= max_length and min_length <= args[0].length
       when Array
         args[0].each do |arg|
           if arg.is_a?(String)


### PR DESCRIPTION
During a puppet run an error will be thrown and a puppet run will fail completely (when using validate_slength):
undefined local variable or method `arg' for #Puppet::Parser::Scope:0x7f243c236948
