### PR TITLE
update merge function to accept an Array of Hashes as last argument

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -623,6 +623,15 @@ For example:
 
 When there is a duplicate key, the key in the rightmost hash will "win."
 
+If the last argument is an array of hashes, it performs the merge described above on all of them.
+For example:
+
+    $arr = {'one' => 1, 'two' => 2}
+    $hash2 = [ {'two' => 'dos', 'three' => 'tres'}, { 'two' => 'due' } ]
+    $merged_hash = merge($hash1, $arr)
+    # The result is:
+    # $result =  [ {'one' => 1, 'two' => 'dos', 'three' => 'tres'}, {'one' => 1, 'two' => 'due', 'three' => 'tres'} ]
+
 - *Type*: rvalue
 
 min

--- a/lib/puppet/parser/functions/merge.rb
+++ b/lib/puppet/parser/functions/merge.rb
@@ -4,13 +4,22 @@ module Puppet::Parser::Functions
 
     For example:
 
-        $hash1 = {'one' => 1, 'two', => 2}
-        $hash2 = {'two' => 'dos', 'three', => 'tres'}
+        $hash1 = {'one' => 1, 'two' => 2}
+        $hash2 = {'two' => 'dos', 'three' => 'tres'}
         $merged_hash = merge($hash1, $hash2)
         # The resulting hash is equivalent to:
         # $merged_hash =  {'one' => 1, 'two' => 'dos', 'three' => 'tres'}
 
     When there is a duplicate key, the key in the rightmost hash will "win."
+
+    If the last argument is an array of hashes, it performs the merge described above on all of them.
+    For example:
+
+        $arr = {'one' => 1, 'two' => 2}
+        $hash2 = [ {'two' => 'dos', 'three' => 'tres'}, { 'two' => 'due' } ]
+        $merged_hash = merge($hash1, $arr)
+        # The result is:
+        # $result =  [ {'one' => 1, 'two' => 'dos', 'three' => 'tres'}, {'one' => 1, 'two' => 'due', 'three' => 'tres'} ]
 
     ENDHEREDOC
 
@@ -18,17 +27,26 @@ module Puppet::Parser::Functions
       raise Puppet::ParseError, ("merge(): wrong number of arguments (#{args.length}; must be at least 2)")
     end
 
-    # The hash we accumulate into
-    accumulator = Hash.new
-    # Merge into the accumulator hash
-    args.each do |arg|
-      next if arg.is_a? String and arg.empty? # empty string is synonym for puppet's undef
-      unless arg.is_a?(Hash)
-        raise Puppet::ParseError, "merge: unexpected argument type #{arg.class}, only expects hash arguments"
+    final_arg = args.pop
+
+    result = [final_arg].flatten.collect do |x|
+      # The hash we accumulate into
+      accumulator = Hash.new
+      # Merge into the accumulator hash
+      (args + [x]).each do |arg|
+        next if arg.is_a? String and arg.empty? # empty string is synonym for puppet's undef
+        unless arg.is_a?(Hash)
+          raise Puppet::ParseError, "merge: unexpected argument type #{arg.class}, only expects hash arguments"
+        end
+        accumulator.merge!(arg)
       end
-      accumulator.merge!(arg)
+      accumulator
     end
-    # Return the fully merged hash
-    accumulator
+
+    if final_arg.is_a? Array
+      return result
+    else
+      return result[0]
+    end
   end
 end

--- a/spec/unit/puppet/parser/functions/merge_spec.rb
+++ b/spec/unit/puppet/parser/functions/merge_spec.rb
@@ -48,5 +48,21 @@ describe Puppet::Parser::Functions.function(:merge) do
     it 'should accept empty hashes' do
       scope.function_merge([{},{},{}]).should == {}
     end
+
+    it 'should be able to merge multiple hashes into each hash in the array passed as last argument' do
+      def1 = {'one' => '1', 'two' => '1'}
+      def2 = {'one' => '2'}
+      
+      arr = [ { 'one' => '3' }, { 'two' => '3' }, {} ]
+
+      new_hashes = scope.function_merge([ def1, def2, arr ])
+
+      new_hashes[0]['one'].should == '3'
+      new_hashes[0]['two'].should == '1'
+      new_hashes[1]['one'].should == '2'
+      new_hashes[1]['two'].should == '3'
+      new_hashes[2]['one'].should == '2'
+      new_hashes[2]['two'].should == '1'
+    end
   end
 end


### PR DESCRIPTION
Each Hash in the Array is merged into separately and all the results are
returned in an Array. If the last argument is a Hash, the previous
behaviour is preserved.
