### PR TITLE
 bug # 20681 delete() function should not remove elements from original list

### DIFF
--- a/lib/puppet/parser/functions/delete.rb
+++ b/lib/puppet/parser/functions/delete.rb
@@ -27,7 +27,7 @@ string, or key from a hash.
         "given #{arguments.size} for 2.")
     end
 
-    collection = arguments[0]
+    collection = arguments[0].dup
     item = arguments[1]
 
     case collection

--- a/spec/unit/puppet/parser/functions/delete_spec.rb
+++ b/spec/unit/puppet/parser/functions/delete_spec.rb
@@ -35,4 +35,22 @@ describe "the delete function" do
     result.should(eq({ 'a' => 1, 'c' => 3 }))
   end
 
+  it "should not change origin array passed as argument" do 
+    origin_array = ['a','b','c','d']
+    result = scope.function_delete([origin_array, 'b'])
+    origin_array.should(eq(['a','b','c','d']))
+  end
+
+  it "should not change the origin string passed as argument" do
+    origin_string = 'foobarbabarz'
+    result = scope.function_delete([origin_string,'bar'])
+    origin_string.should(eq('foobarbabarz'))
+  end
+
+  it "should not change origin hash passed as argument" do 
+    origin_hash = { 'a' => 1, 'b' => 2, 'c' => 3 } 
+    result = scope.function_delete([origin_hash, 'b'])
+    origin_hash.should(eq({ 'a' => 1, 'b' => 2, 'c' => 3 }))
+  end
+
 end


### PR DESCRIPTION
The setup: list with 3 elements, delete one:
$test_list = [‘a’, ‘b’, ‘c’]
$test_deleted = delete($test_list, ‘a’)

Print out the elements in ‘test_deleted’:
notify { ‘group_output2’:  withpath => true, name     => “$cfeng::test_deleted”, }
Notice: /Stage[main]/Syslog/Notify[group_output2]/message: bc

Good!  Run-on output shows that ‘a’ was deleted

Print out the elements in ‘test_list’:
notify { ‘group_output1’: withpath => true, name     => “$cfeng::test_list”, }
Notice: /Stage[main]/Syslog/Notify[group_output1]/message: bc

WHAT!?  'a' was deleted from ‘test_list’ as well! Expected abc as output!

This behaviour is confirmed for string, hash and array.
This is fixed on this commit, I had  added two spec tests to cover that cases.
