### PR TITLE
enhanced the error message of pick function.

### DIFF
--- a/lib/puppet/parser/functions/pick.rb
+++ b/lib/puppet/parser/functions/pick.rb
@@ -21,7 +21,7 @@ EOS
    args.delete(:undefined)
    args.delete("")
    if args[0].to_s.empty? then
-     fail "Must provide non empty value."
+     fail Puppet::ParseError, "pick(): must receive at last one non empty value"
    else
      return args[0]
    end

--- a/spec/unit/puppet/parser/functions/pick_spec.rb
+++ b/spec/unit/puppet/parser/functions/pick_spec.rb
@@ -29,6 +29,6 @@ describe "the pick function" do
   end
 
   it 'should error if no values are passed' do
-    expect { scope.function_pick([]) }.to raise_error(Puppet::Error, /Must provide non empty value./)
+    expect { scope.function_pick([]) }.to( raise_error(Puppet::ParseError, "pick(): must receive at last one non empty value"))
   end
 end


### PR DESCRIPTION
When pick function fail return a better error message like
the other stdlib functions, indicating that the error
is on function pick.

This would help people that see the error to identity it is
related to a incorrect use of stdlib function pick, instead of having
to grep all puppet libraries and manifests source for the old message.

I had also changed the spec test.
