### PR TITLE
#22214: close content file before executing checkscript

### DIFF
--- a/lib/puppet/parser/functions/validate_cmd.rb
+++ b/lib/puppet/parser/functions/validate_cmd.rb
@@ -32,6 +32,7 @@ module Puppet::Parser::Functions
     tmpfile = Tempfile.new("validate_cmd")
     begin
       tmpfile.write(content)
+      tmpfile.close
       if Puppet::Util::Execution.respond_to?('execute')
         Puppet::Util::Execution.execute("#{checkscript} #{tmpfile.path}")
       else


### PR DESCRIPTION
Right now validation seems to be done against zero byte generated temp files. We need to close the file before executing validation against it. See: https://projects.puppetlabs.com/issues/22214
