### PR TITLE
delete_values() fix bug #20681.

### DIFF
--- a/lib/puppet/parser/functions/delete_values.rb
+++ b/lib/puppet/parser/functions/delete_values.rb
@@ -21,6 +21,6 @@ Would return: {'a'=>'A','c'=>'C','B'=>'D'}
       raise(TypeError, "delete_values(): First argument must be a Hash. " + \
                        "Given an argument of class #{hash.class}.") 
     end
-    hash.delete_if { |key, val| item == val }
+    hash.dup.delete_if { |key, val| item == val }
   end
 end

--- a/spec/unit/puppet/parser/functions/delete_values_spec.rb
+++ b/spec/unit/puppet/parser/functions/delete_values_spec.rb
@@ -27,4 +27,10 @@ describe "the delete_values function" do
     result.should(eq({ 'a'=>'A', 'B'=>'C' }))
   end
 
+  it "should not change origin hash passed as argument" do 
+    origin_hash = { 'a' => 1, 'b' => 2, 'c' => 3 } 
+    result = scope.function_delete_values([origin_hash, 2])
+    origin_hash.should(eq({ 'a' => 1, 'b' => 2, 'c' => 3 }))
+  end 
+
 end


### PR DESCRIPTION
```
(#20681) fix behaviour of delete_values

The issue #20681 describe the error of delete() function
removing the elements from the origin array/hash/string.

This issue affected other delete functions. Because
ruby delete and delete_if functions make destructive
changes to the origin array/hash.

The delete_undef_values removed elements from the
origin hash and this is not the desired behaviour.

To solve this, we should dup or clone the hash
before using the delete or delete_if ruby functions.

This fix the problem and add unit tests, so we could
enforce this behaviour and prevent regressions.
```
