### PR TITLE
delete_at added spec to check against bug #20681

### DIFF
--- a/spec/unit/puppet/parser/functions/delete_at_spec.rb
+++ b/spec/unit/puppet/parser/functions/delete_at_spec.rb
@@ -16,4 +16,10 @@ describe "the delete_at function" do
     result = scope.function_delete_at([['a','b','c'],1])
     result.should(eq(['a','c']))
   end
+
+  it "should not change origin array passed as argument" do 
+    origin_array = ['a','b','c','d']
+    result = scope.function_delete_at([origin_array, 1])
+    origin_array.should(eq(['a','b','c','d']))
+  end 
 end


### PR DESCRIPTION
   (#20681) delete_at function unit test against issue

```
The issue #20681 describe the error of delete() function
removing the elements from the origin array/hash/string.

This issue affected the other delete functions.

The delete_at function is not afected by this bug, but
it did not had the unit test to check against it.

I had added the unit test so we could prevent regressions
on the future and also have better test coverage.
```
