### PR TITLE
Don't return nil in validate_re

### DIFF
--- a/lib/puppet/parser/functions/validate_re.rb
+++ b/lib/puppet/parser/functions/validate_re.rb
@@ -35,6 +35,8 @@ module Puppet::Parser::Functions
     raise Puppet::ParseError, (msg) unless [args[1]].flatten.any? do |re_str|
       args[0] =~ Regexp.compile(re_str)
     end
+    # If we got this far it's all fine
+    true
 
   end
 end


### PR DESCRIPTION
validate_re currently seems to return `nil` for success, and `false` when one of them fails (in addition to the `raise`). This patch changes it to return `true` on success, which as a bit more sane.
