### PR TITLE
Add a validate_url function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1203,6 +1203,33 @@ The following values will fail, causing compilation to abort:
 
 - *Type*: statement
 
+validate_url
+---------------
+Validate that the passed argument is a valid URL string.
+The first argument is the URL to validate. The second (optional) argument 
+is the scheme or schemes that will be accepted for this call to validate_url.
+Catalog compilation if this check fails.
+
+The following values will pass:
+
+    validate_url('http://puppetlabs.com')
+    $my_url = "http://forge.puppetlabs.com"
+    validate_url($my_url)
+    validate_url("http://puppetlabs.com",["puppetlabs"])
+
+The following values will fail, causing compilation to abort:
+
+    validate_url('puppetlabs.com')
+    validate_url('mailto:example@puppetlabs.com')
+    validate_url('000:111')
+    validate_url('http://puppetlabs.com', 'gopher')
+    validate_url('http://puppetlabs.com', ['gopher', 'rsync'])
+    validate_url([ 'http://puppetlabs.com', 'http://forge.puppetlabs.com' ])
+    $undefined = undef
+    validate_url($undefined)
+
+- *Type*: statement
+
 values
 ------
 When given a hash this function will return the values of that hash.

--- a/lib/puppet/parser/functions/validate_url.rb
+++ b/lib/puppet/parser/functions/validate_url.rb
@@ -1,0 +1,59 @@
+require 'uri'
+module Puppet::Parser::Functions
+
+  newfunction(:validate_url, :doc => <<-'ENDHEREDOC') do |args|
+    Validate that the passed argument is a valid URL string.
+    The first argument is the URL to validate. The second (optional) argument 
+    is the scheme or schemes that will be accepted for this call to validate_url.
+    Catalog compilation if this check fails.
+
+    The following values will pass:
+
+        validate_url('http://puppetlabs.com')
+        $my_url = "http://forge.puppetlabs.com"
+        validate_url($my_url)
+        validate_url("http://puppetlabs.com",["puppetlabs"])
+
+    The following values will fail, causing compilation to abort:
+
+        validate_url('puppetlabs.com')
+        validate_url('mailto:example@puppetlabs.com')
+        validate_url('000:111')
+        validate_url('http://puppetlabs.com', 'gopher')
+        validate_url('http://puppetlabs.com', ['gopher', 'rsync'])
+        validate_url([ 'http://puppetlabs.com', 'http://forge.puppetlabs.com' ])
+        $undefined = undef
+        validate_url($undefined)
+
+    ENDHEREDOC
+
+    unless args.length == 1 or args.length == 2 then
+      raise Puppet::ParseError, ("validate_url(): wrong number of arguments (#{args.length}); must be 1 or 2)")
+    end
+
+    if (args[1] and not
+        (args[1].is_a?(String) or
+         (args[1].is_a?(Array) and args[1].reduce(true){|cum, cur| cum and cur.is_a?(String)})))
+      raise Puppet::ParseError, ("validate_url(): the second argument must be a string or array of strings")
+    end
+
+    begin
+      uri = URI::parse(args[0])
+    rescue
+      raise Puppet::ParseError, ("#{args[0].inspect} is not a valid URL")
+    end
+
+    unless uri and uri.host and uri.scheme
+      raise Puppet::ParseError, ("#{args[0].inspect} is not a valid URL")
+    end
+
+    if args[1]
+      schemes = args[1].is_a?(Array) ? args[1] : [args[1]]
+      unless schemes.member? uri.scheme
+        raise Puppet::ParseError, ("#{args[0].inspect} is not an accepted type of URL")
+      end
+    end
+
+  end
+
+end

--- a/spec/unit/puppet/parser/functions/validate_url_spec.rb
+++ b/spec/unit/puppet/parser/functions/validate_url_spec.rb
@@ -1,0 +1,100 @@
+#! /usr/bin/env ruby -S rspec
+
+require 'spec_helper'
+
+describe Puppet::Parser::Functions.function(:validate_url) do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  describe 'when calling validate_url from puppet' do
+
+    %w{ http://puppetlabs.com http://forge.puppetlabs.com ftp://puppetlabs.com:21 }.each do |the_string|
+
+      it "should compile when #{the_string} is a valid url" do
+        Puppet[:code] = "validate_url('#{the_string}')"
+        scope.compiler.compile
+      end
+    end
+
+    %w{ http://puppetlabs.com http://forge.puppetlabs.com ftp://puppetlabs.com:21 }.each do |the_string|
+      it "should compile when #{the_string} is a valid url, and the scheme of the url is within the accepted set" do
+        Puppet[:code] = "validate_url('#{the_string}', ['http','ftp'])"
+        scope.compiler.compile
+      end
+    end
+
+    %w{ puppetlabs mailto:test@puppetlabs.com http:///example 1111::0000 }.each do |the_string|
+      it "should not compile when #{the_string} is a not a valid url with a host and scheme" do
+        Puppet[:code] = "validate_url('#{the_string}')"
+        expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a valid URL/)
+      end
+    end
+
+    %w{ http://puppetlabs.com http://forge.puppetlabs.com ftp://puppetlabs.com:21 }.each do |the_string|
+      it "should not compile when #{the_string} is a valid url but not with an accepted scheme" do
+        Puppet[:code] = "validate_url('#{the_string}', ['gopher','rsync'])"
+        expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not an accepted type of URL/)
+      end
+    end
+
+    %w{ http://puppetlabs.com http://forge.puppetlabs.com ftp://puppetlabs.com:21 }.each do |the_string|
+      it "should not compile when #{the_string} is a valid url but an accepted scheme is not a string" do
+        Puppet[:code] = "validate_url('#{the_string}', ['gopher', []])"
+        expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /the second argument must be a string or array of strings/)
+      end
+    end
+
+    %w{ true false }.each do |the_string|
+      it "should not compile when #{the_string} is a string" do
+        Puppet[:code] = "validate_url('#{the_string}')"
+        expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a valid URL/)
+      end
+
+      it "should not compile when #{the_string} is a bare word" do
+        Puppet[:code] = "validate_url(#{the_string})"
+        expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a valid URL/)
+      end
+    end
+
+    it "should not compile when an array is passed" do
+      Puppet[:code] = <<-'ENDofPUPPETcode'
+        $foo = 'http://puppetlabs.com'
+        $bar = 'http://forge.puppetlabs.com'
+        validate_url( [$foo, $bar] )
+      ENDofPUPPETcode
+      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a valid URL/)
+    end
+
+    it "should not compile when a number is passed" do
+      Puppet[:code] = <<-'ENDofPUPPETcode'
+        $foo = 'http://puppetlabs.com'
+        $bar = 'http://forge.puppetlabs.com'
+        validate_url( 3 )
+      ENDofPUPPETcode
+      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a valid URL/)
+    end
+
+    it "should not compile when a hash is passed" do
+      Puppet[:code] = <<-'ENDofPUPPETcode'
+        $foo = 'http://puppetlabs.com'
+        $bar = 'http://forge.puppetlabs.com'
+        validate_url( { foo => "bar" } )
+      ENDofPUPPETcode
+      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a valid URL/)
+    end
+
+    it "should not compile when an explicitly undef variable is passed (NOTE THIS MAY NOT BE DESIRABLE)" do
+      Puppet[:code] = <<-'ENDofPUPPETcode'
+        $foo = undef
+        validate_url($foo)
+      ENDofPUPPETcode
+      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a valid URL/)
+    end
+
+    it "should not compile when an undefined variable is passed (NOTE THIS MAY NOT BE DESIRABLE)" do
+      Puppet[:code] = <<-'ENDofPUPPETcode'
+        validate_url($foobarbazishouldnotexist)
+      ENDofPUPPETcode
+      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /is not a valid URL/)
+    end
+  end
+end


### PR DESCRIPTION
Currently there is no way in puppet to verify that a value is a proper URL string. Consequently values that are assumed to be URLs are passed on to applications that are expecting URLs, causing unexpected or undesired behavior. This patch provides a puppet function that can be called to verify that its argument is a proper URL string.

Was originally a validate_uri function, but URIs are flexible enough that validating that something was a URI string didn't always give the expected behavior.
