### PR TITLE
#22805: Add metadata.json to all modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 pkg/
 .DS_Store
-metadata.json
 coverage/
 spec/fixtures/
 Gemfile.lock

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,17 @@
+{
+    "name": "puppetlabs/stdlib",
+    "version": "4.1.0",
+    "summary": "Standard Library for Puppet Modules",
+    "source": "git://github.com/puppetlabs/puppetlabs-stdlib.git",
+    "project_page": "http://github.com/puppetlabs/puppetlabs-stdlib",
+    "author": "Puppet Labs",
+    "license": "Apache-2.0",
+    "puppet_version": [
+        "2.7",
+        "3.0",
+        "3.1",
+        "3.2",
+        "3.3"
+    ],
+    "dependencies": []
+}


### PR DESCRIPTION
We're adding this to all modules to be a long term Modulefile replacement.  We have puppet_version and operatingsystem_support now but as this module works on all operating systems we support I left that out for now.
