### PR TITLE
Add default_content function to reduce module boilerplate code

### DIFF
--- a/lib/puppet/parser/functions/default_content.rb
+++ b/lib/puppet/parser/functions/default_content.rb
@@ -1,0 +1,32 @@
+Puppet::Parser::Functions.newfunction(:default_content,
+                                      :type => :rvalue,
+                                      :doc => <<-'ENDOFDOC'
+Takes an optional content and an optional template name to calculate the actual
+contents of a file. The following two statements are equivalent:
+
+    $real_content = default_content($content, $template_name)
+
+    if $content {
+      $real_content = $content
+    } elsif $template_name {
+      $real_content = template($template_name)
+    } else {
+      $real_content = undef
+    }
+
+This small function abbreviates the default initialisation boilerplate of
+modules.
+ENDOFDOC
+) do |args|
+    content = args[0]
+    template_name = args[1]
+
+    Puppet::Parser::Functions.autoloader.loadall
+
+    return content if content
+    return function_template(template_name) if template_name
+
+    return nil
+  end
+end
+


### PR DESCRIPTION
Hi,

please consider including this function to reduce the amount of boilerplate code one has to write when creating modules.

Also, I'm not sure whether I translated the undef handling correctly from pp to rb. It'd be great if someone more experienced could look over that. Especially whether returning `nil` really means undef as claimed in the docstring.

Regards, DavidS
