### PR TITLE
(doc) Fixed 'separator' typos

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -544,7 +544,7 @@ Returns true if the variable passed to this function is a string.
 
 join
 ----
-This function joins an array into a string using a seperator.
+This function joins an array into a string using a separator.
 
 *Examples:*
 

--- a/lib/puppet/parser/functions/join.rb
+++ b/lib/puppet/parser/functions/join.rb
@@ -4,7 +4,7 @@
 
 module Puppet::Parser::Functions
   newfunction(:join, :type => :rvalue, :doc => <<-EOS
-This function joins an array into a string using a seperator.
+This function joins an array into a string using a separator.
 
 *Examples:*
 


### PR DESCRIPTION
(doc) Fixed 'separator' typos
