### PR TITLE
calling rspec directly makes is_function_available.rb not pass ruby -c

### DIFF
--- a/spec/unit/puppet/parser/functions/is_function_available.rb
+++ b/spec/unit/puppet/parser/functions/is_function_available.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/env ruby -S rspec
 require 'spec_helper'
 
 describe "the is_function_available function" do


### PR DESCRIPTION
This is just a quick adjustment so this specfile passes ruby -c; ran into it when I ran a broad sweep across my codebase. Brings it in line with the rest of the unit tests here.
