### PR TITLE
Add default provider fact and make stdlib file_line default.

### DIFF
--- a/lib/facter/default_provider.rb
+++ b/lib/facter/default_provider.rb
@@ -1,0 +1,5 @@
+Facter.add("default_provider") do
+  setcode do
+    true
+  end
+end

--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -1,5 +1,6 @@
-
 Puppet::Type.type(:file_line).provide(:ruby) do
+  # Always default
+  defaultfor :default_provider => 'true'
 
   def exists?
     lines.find do |line|


### PR DESCRIPTION
We can only use facts for puppet provider defaultfor, and in this
case stdlib ruby file_line should be the default provider.
