### PR TITLE
add hash_compact function

### DIFF
--- a/lib/puppet/parser/functions/hash_compact.rb
+++ b/lib/puppet/parser/functions/hash_compact.rb
@@ -1,8 +1,13 @@
-# Removes keys from the supplied hash if the value of that key is `undef`
+# Removes keys from the supplied hash if the value of that key is `:undef`
 module Puppet::Parser::Functions
   newfunction(:hash_compact, :type => :rvalue) do |args|
+    raise "you can only compact a hash" unless args.first.is_a?(Hash)
     hash = args.first
-    hash.keys.each { |key| hash.delete(key) if hash[key].nil? }
+
+    hash.keys.each do |key|
+      hash.delete(key) if hash[key] == :undef
+    end
+
     hash
   end
 end

--- a/spec/functions/hash_compact_spec.rb
+++ b/spec/functions/hash_compact_spec.rb
@@ -3,19 +3,22 @@ require 'spec_helper'
 describe 'hash_compact' do
   context "given truthy values" do
     it "returns keys with truthy values" do
-      subject.should run.with_params(true_key: true).and_return(true_key: true)
+      subject.should run.with_params(:true_key => true).
+        and_return(:true_key => true)
     end
   end
 
-  context "given nil values" do
-    it "removes keys with nil values" do
-      subject.should run.with_params(nil_key: nil).and_return({})
+  context "given :undef values" do
+    it "removes keys with :undef values" do
+      subject.should run.with_params(:undef_key => :undef).
+        and_return({})
     end
   end
 
-  context "given a mix of truthy and nily values" do
-    it "returns the keys with truthy values but not the keys with nily values" do
-      subject.should run.with_params(true_key: true, nil_key: nil).and_return(true_key: true)
+  context "given a mix of truthy and :undef values" do
+    it "returns the keys with truthy values but not the keys with :undef values" do
+      subject.should run.with_params(:true_key => true, :undef_key => :undef).
+        and_return(:true_key => true)
     end
   end
 end


### PR DESCRIPTION
When wrapping a resource in a defined type, it is extremely useful
to be able to accept the same parameters as the wrapped class. If
the parameters are optional, it is necessary to remove the keys
with unset values from the hash, because explicit `undef` values
will overwrite defaults in the wrapped resource. For example, in a
situation where resource defaults have been set like this:

```
Wrapped {
  extra => ['--some-option']
}
```

Here is a wrapper that overwrites default values:

```
define wrapper($name, $extra = undef) {
  wrapped { $name: extra => $extra }
}
```

And here is a wrapper that does not overwrite default values:

```
define wrapper($name, $extra = undef) {
  $options = hash_compact({extra => $extra})
  ensure_resource('wrapped', $name, $options})
}
```
