### PR TITLE
Remove unintentional link from README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -702,8 +702,8 @@ Will return: [0,1,2,3,4,5,6,7,8,9]
 
     range("00", "09")
 
-Will return: [0,1,2,3,4,5,6,7,8,9] (Zero padded strings are converted to
-integers automatically)
+Will return: [0,1,2,3,4,5,6,7,8,9] - Zero padded strings are converted to
+integers automatically
 
     range("a", "c")
 


### PR DESCRIPTION
Markdown interprets [] folowed by () as a link, which was a 404 and not
the intention of the original author. This patch ensures that the
document reads as intended, without the link.
