### PR TITLE
Add rake tasks to validate and lint files and check with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 bundler_args: --without development
-script: "bundle exec rake spec SPEC_OPTS='--color --format documentation'"
+script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--color --format documentation'"
 rvm:
   - 1.8.7
   - 1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -39,4 +39,6 @@ else
   gem 'puppet', :require => false
 end
 
+gem 'puppet-lint', '>= 0.3.2'
+
 # vim:ft=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,18 @@
 require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+
+desc "Validate manifests, templates, and ruby files in lib."
+task :validate do
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['lib/**/*.rb'].each do |lib_file|
+    sh "ruby -c #{lib_file}"
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
+end


### PR DESCRIPTION
This patch adds the ability to validate syntax of manifests, templates,
and ruby files in lib/ via `rake validate` and the linting of manifests
with puppet-lint via `rake lint`. These two commands are chained with
running the spec tests in Travis to ensure there are no syntax or style
issues.
