### PR TITLE
Fix prefix exception message (Closes #23364)

### DIFF
--- a/lib/puppet/parser/functions/prefix.rb
+++ b/lib/puppet/parser/functions/prefix.rb
@@ -28,7 +28,7 @@ Will return: ['pa','pb','pc']
 
     if prefix
       unless prefix.is_a?(String)
-        raise Puppet::ParseError, "prefix(): expected second argument to be a String, got #{suffix.inspect}"
+        raise Puppet::ParseError, "prefix(): expected second argument to be a String, got #{prefix.inspect}"
       end
     end
 


### PR DESCRIPTION
Prefix exception message uses a variable name _suffix_

I assume this is due some copy / paste between the functions… I submit a patch to Github
