### PR TITLE
Pin rspec-puppet to 0.1.6 for now as the change to 1.0.0 has broken

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development, :test do
   gem 'rspec', "~> 2.11.0", :require => false
   gem 'mocha', "~> 0.10.5", :require => false
   gem 'puppetlabs_spec_helper', :require => false
-  gem 'rspec-puppet', :require => false
+  gem 'rspec-puppet', "~> 0.1.6", :require => false
 end
 
 facterversion = ENV['GEM_FACTER_VERSION']


### PR DESCRIPTION
things involving Mocha badly.
