### PR TITLE
concat was changing puppet variable

### DIFF
--- a/lib/puppet/parser/functions/concat.rb
+++ b/lib/puppet/parser/functions/concat.rb
@@ -28,7 +28,7 @@ Would result in:
       raise(Puppet::ParseError, 'concat(): Requires array to work with')
     end
 
-    result = a.concat(b)
+    result = a.clone.concat(b)
 
     return result
   end


### PR DESCRIPTION
if you tried something like this:

$somevar  = [ 'a', 'b' ]
$othervar = [ '1', '2' ]

$combined = concat($somevar, $othervar)

then this would change $somevar as well:

fail(inline_template('<%= @somevar.inspect %>'))

would become

['a', 'b', '1', '2']

that's violating the "non changeable variable approach" of puppet.. (and was in our case an unexpected behavior)
