### PR TITLE
(PUP-1459) Add support for root_home on OS X 10.9

### DIFF
--- a/lib/facter/root_home.rb
+++ b/lib/facter/root_home.rb
@@ -17,3 +17,16 @@ end
 Facter.add(:root_home) do
   setcode { Facter::Util::RootHome.get_root_home }
 end
+
+Facter.add(:root_home) do
+  confine :kernel => :darwin
+  setcode do
+    str = Facter::Util::Resolution.exec("dscacheutil -q user -a name root")
+    hash = {}
+    str.split("\n").each do |pair|
+      key,value = pair.split(/:/)
+      hash[key] = value
+    end
+    hash['dir'].strip
+  end
+end

--- a/spec/fixtures/dscacheutil/root
+++ b/spec/fixtures/dscacheutil/root
@@ -1,0 +1,8 @@
+name: root
+password: *
+uid: 0
+gid: 0
+dir: /var/root
+shell: /bin/bash
+gecos: rawr Root
+

--- a/spec/unit/facter/root_home_spec.rb
+++ b/spec/unit/facter/root_home_spec.rb
@@ -20,15 +20,6 @@ describe Facter::Util::RootHome do
       Facter::Util::RootHome.get_root_home.should == expected_root_home
     end
   end
-  context "macosx" do
-    let(:root_ent) { "root:*:0:0:System Administrator:/var/root:/bin/sh" }
-    let(:expected_root_home) { "/var/root" }
-
-    it "should return /var/root" do
-      Facter::Util::Resolution.expects(:exec).with("getent passwd root").returns(root_ent)
-      Facter::Util::RootHome.get_root_home.should == expected_root_home
-    end
-  end
   context "windows" do
     before :each do
       Facter::Util::Resolution.expects(:exec).with("getent passwd root").returns(nil)
@@ -37,4 +28,24 @@ describe Facter::Util::RootHome do
       Facter::Util::RootHome.get_root_home.should be_nil
     end
   end
+end
+
+describe 'root_home', :type => :fact do
+  before { Facter.clear }
+  after { Facter.clear }
+
+  context "macosx" do
+    before do
+      Facter.fact(:kernel).stubs(:value).returns("Darwin")
+      Facter.fact(:osfamily).stubs(:value).returns("Darwin")
+    end
+    let(:expected_root_home) { "/var/root" }
+    sample_dscacheutil = File.read(fixtures('dscacheutil','root'))
+
+    it "should return /var/root" do
+      Facter::Util::Resolution.stubs(:exec).with("dscacheutil -q user -a name root").returns(sample_dscacheutil)
+      Facter.fact(:root_home).value.should == expected_root_home
+    end
+  end
+
 end


### PR DESCRIPTION
getent does not exist on 10.9 so this commit uses
dscacheutil to query the homedir for the root user.
