### PR TITLE
PUP-1724 Don't modify the paramaters to deep_merge

### DIFF
--- a/lib/puppet/parser/functions/deep_merge.rb
+++ b/lib/puppet/parser/functions/deep_merge.rb
@@ -20,7 +20,7 @@ module Puppet::Parser::Functions
     end
 
     deep_merge = Proc.new do |hash1,hash2|
-      hash1.merge!(hash2) do |key,old_value,new_value|
+      hash1.merge(hash2) do |key,old_value,new_value|
         if old_value.is_a?(Hash) && new_value.is_a?(Hash)
           deep_merge.call(old_value, new_value)
         else
@@ -37,7 +37,7 @@ module Puppet::Parser::Functions
         raise Puppet::ParseError, "deep_merge: unexpected argument type #{arg.class}, only expects hash arguments"
       end
 
-      deep_merge.call(result, arg)
+      result = deep_merge.call(result, arg)
     end
     return( result )
   end

--- a/spec/unit/puppet/parser/functions/deep_merge_spec.rb
+++ b/spec/unit/puppet/parser/functions/deep_merge_spec.rb
@@ -73,5 +73,33 @@ describe Puppet::Parser::Functions.function(:deep_merge) do
       hash['key1'].should == { 'a' => 1, 'b' => 99 }
       hash['key2'].should == { 'c' => 3 }
     end
+
+    it 'should not change the original hashes' do
+      hash1 = {'one' => { 'two' => 2 } }
+      hash2 = { 'one' => { 'three' => 3 } }
+      hash = scope.function_deep_merge([hash1, hash2])
+      hash1.should == {'one' => { 'two' => 2 } }
+      hash2.should == { 'one' => { 'three' => 3 } }
+      hash['one'].should == { 'two' => 2, 'three' => 3 }
+    end
+
+    it 'should not change the original hashes 2' do
+      hash1 = {'one' => { 'two' => [1,2] } }
+      hash2 = { 'one' => { 'three' => 3 } }
+      hash = scope.function_deep_merge([hash1, hash2])
+      hash1.should == {'one' => { 'two' => [1,2] } }
+      hash2.should == { 'one' => { 'three' => 3 } }
+      hash['one'].should == { 'two' => [1,2], 'three' => 3 }
+    end
+
+    it 'should not change the original hashes 3' do
+      hash1 = {'one' => { 'two' => [1,2, {'two' => 2} ] } }
+      hash2 = { 'one' => { 'three' => 3 } }
+      hash = scope.function_deep_merge([hash1, hash2])
+      hash1.should == {'one' => { 'two' => [1,2, {'two' => 2}] } }
+      hash2.should == { 'one' => { 'three' => 3 } }
+      hash['one'].should == { 'two' => [1,2, {'two' => 2} ], 'three' => 3 }
+      hash['one']['two'].should == [1,2, {'two' => 2}]
+    end
   end
 end


### PR DESCRIPTION
Instead of modifying the first paramater of deep_merge due to the
use of the merge! function, instead use merge to return a copy of
the merged object. This allows one to continue to use the original
first parameter after the call to deep_merge.

Example:

``` puppet
class foo {
  $bar = { foo => { bar => 1 } }
}
include foo
$bar_updates = { foo => { baz => 1 } }
alert $foo::bar
$baz = deep_merge( $foo::bar, $bar_updates )
alert $foo::bar
```

Current output:

``` puppet
alert: Scope(Class[main]): foobar1
alert: Scope(Class[main]): foobaz1bar1
```

Expected:

``` puppet
alert: Scope(Class[main]): foobar1
alert: Scope(Class[main]): foobar1
```
