### PR TITLE
Allow concat to take non-array second parameters

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -145,6 +145,11 @@ Would result in:
 
   ['1','2','3','4','5','6']
 
+  concat(['1','2','3'],'4')
+
+Would result in:
+
+  ['1','2','3','4']
 
 - *Type*: rvalue
 

--- a/lib/puppet/parser/functions/concat.rb
+++ b/lib/puppet/parser/functions/concat.rb
@@ -23,12 +23,16 @@ Would result in:
     a = arguments[0]
     b = arguments[1]
 
-    # Check that both args are arrays.
-    unless a.is_a?(Array) and b.is_a?(Array)
+    # Check that the first parameter is an array
+    unless a.is_a?(Array)
       raise(Puppet::ParseError, 'concat(): Requires array to work with')
     end
 
-    result = a.concat(b)
+    if b.is_a?(Array)
+      result = a.concat(b)
+    else
+      result = a << b
+    end
 
     return result
   end

--- a/spec/unit/puppet/parser/functions/concat_spec.rb
+++ b/spec/unit/puppet/parser/functions/concat_spec.rb
@@ -4,12 +4,27 @@ require 'spec_helper'
 describe "the concat function" do
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
-  it "should raise a ParseError if there is less than 1 arguments" do
-    lambda { scope.function_concat([]) }.should( raise_error(Puppet::ParseError))
+  it "should raise a ParseError if the client does not provide two arguments" do
+    lambda { scope.function_concat([]) }.should(raise_error(Puppet::ParseError))
+  end
+
+  it "should raise a ParseError if the first parameter is not an array" do
+    lambda { scope.function_concat([1, []])}.should(raise_error(Puppet::ParseError))
   end
 
   it "should be able to concat an array" do
     result = scope.function_concat([['1','2','3'],['4','5','6']])
     result.should(eq(['1','2','3','4','5','6']))
   end
+
+  it "should be able to concat a primitive to an array" do
+    result = scope.function_concat([['1','2','3'],'4'])
+    result.should(eq(['1','2','3','4']))
+  end
+
+  it "should not accidentally flatten nested arrays" do
+    result = scope.function_concat([['1','2','3'],[['4','5'],'6']])
+    result.should(eq(['1','2','3',['4','5'],'6']))
+  end
+
 end


### PR DESCRIPTION
This allows the concat command to take any object type as the second parameter. It should preserve existing functionality.

I have also expanded upon the existing tests to lock down the current functionality.

I initially used `.concat(x).flatten!`, but realised that if somebody is passing nested arrays as the second parameter then this change will break their existing functionality. A test case was added to ensure this behaviour is preserved for future changes.

As per the contributing guidelines I have signed the contributing agreement and signed up to JIRA, but see no JIRA project for puppet-stdlib. I raised a question about this on the freenode IRC channel but got no response.

Please advise if I've missed anything.
