### PR TITLE
Bump version and add metadata.json for forge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 pkg/
 .DS_Store
-metadata.json
 coverage/
 spec/fixtures/
 Gemfile.lock
 .bundle/
 vendor/bundle/
-/metadata.json

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-stdlib'
-version '4.1.0'
+version '4.1.1'
 source 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
 author 'puppetlabs'
 license 'Apache 2.0'

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,72 @@
+{
+    "operatingsystem_support": [
+      {
+        "operatingsystem": "RedHat",
+        "operatingsystemrelease": [
+          "5",
+          "6"
+        ]
+      },
+      {
+        "operatingsystem": "CentOS",
+        "operatingsystemrelease": [
+          "5",
+          "6"
+        ]
+      },
+      {
+        "operatingsystem": "OracleLinux",
+        "operatingsystemrelease": [
+          "5",
+          "6"
+        ]
+      },
+      {
+        "operatingsystem": "Scientific",
+        "operatingsystemrelease": [
+          "5",
+          "6"
+        ]
+      },
+      {
+        "operatingsystem": "SLES",
+        "operatingsystemrelease": [
+          "11 SP1"
+        ]
+      },
+      {
+        "operatingsystem": "Debian",
+        "operatingsystemrelease": [
+          "6",
+          "7"
+        ]
+      },
+      {
+        "operatingsystem": "Ubuntu",
+        "operatingsystemrelease": [
+          "10.04",
+          "12.04"
+        ]
+      },
+      {
+        "operatingsystem": "Solaris",
+        "operatingsystemrelease": [
+          "10"
+        ]
+      },
+      {
+        "operatingsystem": "Windows",
+        "operatingsystemrelease": [
+          "Server 2003 R2",
+          "Server 2008 R2",
+          "Server 2012",
+          "Server 2012 R2",
+          "7"
+        ]
+      }
+    ],
+    "requirements": [
+      { "name": "pe", "version_requirement": "3.2.x" },
+      { "name": "puppet", "version_requirement": ">=2.7.20 <4.0.0" }
+    ]
+}


### PR DESCRIPTION
Is this based off the right branch?
What should the earliest version of Puppet in the requirements be? I included pre 3.x since we can't merge breaking changes anyway.
