### PR TITLE
(MODULES-603) Add defaults arguments to ensure_packages()

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -275,6 +275,8 @@ Returns true if the variable is empty.
 ensure_packages
 ---------------
 Takes a list of packages and only installs them if they don't already exist.
+It optionally takes a hash as a second parameter that will be passed as the
+third argument to the ensure_resource() function.
 
 
 - *Type*: statement

--- a/lib/puppet/parser/functions/ensure_packages.rb
+++ b/lib/puppet/parser/functions/ensure_packages.rb
@@ -5,19 +5,29 @@
 module Puppet::Parser::Functions
   newfunction(:ensure_packages, :type => :statement, :doc => <<-EOS
 Takes a list of packages and only installs them if they don't already exist.
+It optionally takes a hash as a second parameter that will be passed as the
+third argument to the ensure_resource() function.
     EOS
   ) do |arguments|
 
-    if arguments.size != 1
+    if arguments.size > 2 or arguments.size == 0
       raise(Puppet::ParseError, "ensure_packages(): Wrong number of arguments " +
-        "given (#{arguments.size} for 1)")
+        "given (#{arguments.size} for 1 or 2)")
+    elsif arguments.size == 2 and !arguments[1].is_a?(Hash) 
+      raise(Puppet::ParseError, 'ensure_packages(): Requires second argument to be a Hash')
     end
 
     packages = Array(arguments[0])
 
+    if arguments[1]
+      defaults = { 'ensure' => 'present' }.merge(arguments[1])
+    else
+      defaults = { 'ensure' => 'present' }
+    end
+
     Puppet::Parser::Functions.function(:ensure_resource)
     packages.each { |package_name|
-      function_ensure_resource(['package', package_name, {'ensure' => 'present' } ])
+      function_ensure_resource(['package', package_name, defaults ])
     }
   end
 end

--- a/spec/functions/ensure_packages_spec.rb
+++ b/spec/functions/ensure_packages_spec.rb
@@ -32,7 +32,7 @@ describe 'ensure_packages' do
     it 'fails with no arguments' do
       expect {
         scope.function_ensure_packages([])
-      }.to raise_error(Puppet::ParseError, /0 for 1/)
+      }.to raise_error(Puppet::ParseError, /0 for 1 or 2/)
     end
 
     it 'accepts an array of values' do
@@ -65,6 +65,17 @@ describe 'ensure_packages' do
 
     it 'declares package resources with ensure => present' do
       expect(catalog.resource(:package, 'facter')['ensure']).to eq('present')
+    end
+  end
+
+  context 'given a clean catalog and specified defaults' do
+    let :catalog do
+      compile_to_catalog('ensure_packages(["facter"], {"provider" => "gem"})')
+    end
+
+    it 'declares package resources with ensure => present' do
+      expect(catalog.resource(:package, 'facter')['ensure']).to eq('present')
+      expect(catalog.resource(:package, 'facter')['provider']).to eq('gem')
     end
   end
 end


### PR DESCRIPTION
Without this patch one can not specify package resource specific
parameters. All the ensure_packages() function does it makes sure
the named packages are installed. This patch allows one to pass
default as a second argument and allow greater flexibility on
packages installations.

Use case like the following are now possible :
- ensure_packages(['r10k', 'serverspec'], {'provider' => 'gem'})
- ensure_packages(['ntp'], {'require' => 'Exec[foobar]'})
