### PR TITLE
Set arity on all functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ matrix:
   fast_finish: true
   include:
   - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
+    env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0

--- a/lib/puppet/parser/functions/abs.rb
+++ b/lib/puppet/parser/functions/abs.rb
@@ -3,14 +3,11 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:abs, :type => :rvalue, :doc => <<-EOS
+  newfunction(:abs, :type => :rvalue, :arity => 1, :doc => <<-EOS
     Returns the absolute value of a number, for example -34.56 becomes
     34.56. Takes a single integer and float value as an argument.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "abs(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
 

--- a/lib/puppet/parser/functions/any2array.rb
+++ b/lib/puppet/parser/functions/any2array.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:any2array, :type => :rvalue, :doc => <<-EOS
+  newfunction(:any2array, :type => :rvalue, :arity => -1, :doc => <<-EOS
 This converts any object to an array containing that object. Empty argument
 lists are converted to an empty array. Arrays are left untouched. Hashes are
 converted to arrays of alternating keys and values.

--- a/lib/puppet/parser/functions/base64.rb
+++ b/lib/puppet/parser/functions/base64.rb
@@ -1,6 +1,6 @@
 module Puppet::Parser::Functions
-
-  newfunction(:base64, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
+ 
+  newfunction(:base64, :type => :rvalue, :arity => 2, :doc => <<-'ENDHEREDOC') do |args|
 
     Base64 encode or decode a string based on the command and the string submitted
 
@@ -12,9 +12,7 @@ module Puppet::Parser::Functions
     ENDHEREDOC
 
     require 'base64'
-
-    raise Puppet::ParseError, ("base64(): Wrong number of arguments (#{args.length}; must be = 2)") unless args.length == 2
-
+ 
     actions = ['encode','decode']
 
     unless actions.include?(args[0])

--- a/lib/puppet/parser/functions/bool2num.rb
+++ b/lib/puppet/parser/functions/bool2num.rb
@@ -3,16 +3,13 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:bool2num, :type => :rvalue, :doc => <<-EOS
+  newfunction(:bool2num, :type => :rvalue, :arity => 1, :doc => <<-EOS
     Converts a boolean to a number. Converts the values:
       false, f, 0, n, and no to 0
       true, t, 1, y, and yes to 1
     Requires a single boolean or string as an input.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "bool2num(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/bool2str.rb
+++ b/lib/puppet/parser/functions/bool2str.rb
@@ -3,14 +3,11 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:bool2str, :type => :rvalue, :doc => <<-EOS
+  newfunction(:bool2str, :type => :rvalue, :arity => 1, :doc => <<-EOS
     Converts a boolean to a string.
     Requires a single boolean as an input.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "bool2str(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/camelcase.rb
+++ b/lib/puppet/parser/functions/camelcase.rb
@@ -3,13 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:camelcase, :type => :rvalue, :doc => <<-EOS
+  newfunction(:camelcase, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Converts the case of a string or all strings in an array to camel case.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "camelcase(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/capitalize.rb
+++ b/lib/puppet/parser/functions/capitalize.rb
@@ -3,14 +3,11 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:capitalize, :type => :rvalue, :doc => <<-EOS
+  newfunction(:capitalize, :type => :rvalue, :arity => 1, :doc => <<-EOS
     Capitalizes the first letter of a string or array of strings.
     Requires either a single string or an array as an input.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "capitalize(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/chomp.rb
+++ b/lib/puppet/parser/functions/chomp.rb
@@ -3,15 +3,12 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:chomp, :type => :rvalue, :doc => <<-'EOS'
+  newfunction(:chomp, :type => :rvalue, :arity => 1, :doc => <<-'EOS'
     Removes the record separator from the end of a string or an array of
     strings, for example `hello\n` becomes `hello`.
     Requires a single string or array as an input.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "chomp(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/chop.rb
+++ b/lib/puppet/parser/functions/chop.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:chop, :type => :rvalue, :doc => <<-'EOS'
+  newfunction(:chop, :type => :rvalue, :arity => 1, :doc => <<-'EOS'
     Returns a new string with the last character removed. If the string ends
     with `\r\n`, both characters are removed. Applying chop to an empty
     string returns an empty string. If you wish to merely remove record
@@ -11,9 +11,6 @@ module Puppet::Parser::Functions
     Requires a string or array of strings as input.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "chop(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/concat.rb
+++ b/lib/puppet/parser/functions/concat.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:concat, :type => :rvalue, :doc => <<-EOS
+  newfunction(:concat, :type => :rvalue, :arity => 2, :doc => <<-EOS
 Appends the contents of array 2 onto array 1.
 
 *Example:*
@@ -15,10 +15,6 @@ Would result in:
   ['1','2','3','4','5','6']
     EOS
   ) do |arguments|
-
-    # Check that 2 arguments have been given ...
-    raise(Puppet::ParseError, "concat(): Wrong number of arguments " +
-      "given (#{arguments.size} for 2)") if arguments.size != 2
 
     a = arguments[0]
     b = arguments[1]

--- a/lib/puppet/parser/functions/deep_merge.rb
+++ b/lib/puppet/parser/functions/deep_merge.rb
@@ -1,5 +1,5 @@
 module Puppet::Parser::Functions
-  newfunction(:deep_merge, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:deep_merge, :type => :rvalue, :arity => -3, :doc => <<-'ENDHEREDOC') do |args|
     Recursively merges two or more hashes together and returns the resulting hash.
 
     For example:
@@ -14,10 +14,6 @@ module Puppet::Parser::Functions
     When there is a duplicate key that is not a hash, the key in the rightmost hash will "win."
 
     ENDHEREDOC
-
-    if args.length < 2
-      raise Puppet::ParseError, ("deep_merge(): wrong number of arguments (#{args.length}; must be at least 2)")
-    end
 
     deep_merge = Proc.new do |hash1,hash2|
       hash1.merge(hash2) do |key,old_value,new_value|

--- a/lib/puppet/parser/functions/defined_with_params.rb
+++ b/lib/puppet/parser/functions/defined_with_params.rb
@@ -3,6 +3,7 @@ require 'puppet/parser/functions'
 
 Puppet::Parser::Functions.newfunction(:defined_with_params,
                                       :type => :rvalue,
+                                      :arity => -1,
                                       :doc => <<-'ENDOFDOC'
 Takes a resource reference and an optional hash of attributes.
 

--- a/lib/puppet/parser/functions/delete.rb
+++ b/lib/puppet/parser/functions/delete.rb
@@ -5,7 +5,7 @@
 # TODO(Krzysztof Wilczynski): We need to add support for regular expression ...
 
 module Puppet::Parser::Functions
-  newfunction(:delete, :type => :rvalue, :doc => <<-EOS
+  newfunction(:delete, :type => :rvalue, :arity => 2, :doc => <<-EOS
 Deletes all instances of a given element from an array, substring from a
 string, or key from a hash.
 
@@ -21,11 +21,6 @@ string, or key from a hash.
     Would return: 'acada'
     EOS
   ) do |arguments|
-
-    if (arguments.size != 2) then
-      raise(Puppet::ParseError, "delete(): Wrong number of arguments "+
-        "given #{arguments.size} for 2.")
-    end
 
     collection = arguments[0].dup
     item = arguments[1]

--- a/lib/puppet/parser/functions/delete_at.rb
+++ b/lib/puppet/parser/functions/delete_at.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:delete_at, :type => :rvalue, :doc => <<-EOS
+  newfunction(:delete_at, :type => :rvalue, :arity => 2, :doc => <<-EOS
 Deletes a determined indexed value from an array.
 
 *Examples:*
@@ -13,9 +13,6 @@ Deletes a determined indexed value from an array.
 Would return: ['a','c']
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "delete_at(): Wrong number of arguments " +
-      "given (#{arguments.size} for 2)") if arguments.size < 2
 
     array = arguments[0]
 

--- a/lib/puppet/parser/functions/delete_undef_values.rb
+++ b/lib/puppet/parser/functions/delete_undef_values.rb
@@ -1,5 +1,5 @@
 module Puppet::Parser::Functions
-  newfunction(:delete_undef_values, :type => :rvalue, :doc => <<-EOS
+  newfunction(:delete_undef_values, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns a copy of input hash or array with all undefs deleted.
 
 *Examples:*
@@ -14,10 +14,6 @@ Would return: ['A','',false]
 
       EOS
     ) do |args|
-
-    raise(Puppet::ParseError,
-          "delete_undef_values(): Wrong number of arguments given " +
-          "(#{args.size})") if args.size < 1
 
     unless args[0].is_a? Array or args[0].is_a? Hash
       raise(Puppet::ParseError,

--- a/lib/puppet/parser/functions/delete_values.rb
+++ b/lib/puppet/parser/functions/delete_values.rb
@@ -1,5 +1,5 @@
 module Puppet::Parser::Functions
-  newfunction(:delete_values, :type => :rvalue, :doc => <<-EOS
+  newfunction(:delete_values, :type => :rvalue, :arity => 2, :doc => <<-EOS
 Deletes all instances of a given value from a hash.
 
 *Examples:*
@@ -10,10 +10,6 @@ Would return: {'a'=>'A','c'=>'C','B'=>'D'}
 
       EOS
     ) do |arguments|
-
-    raise(Puppet::ParseError,
-          "delete_values(): Wrong number of arguments given " +
-          "(#{arguments.size} of 2)") if arguments.size != 2
 
     hash, item = arguments
 

--- a/lib/puppet/parser/functions/difference.rb
+++ b/lib/puppet/parser/functions/difference.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:difference, :type => :rvalue, :doc => <<-EOS
+  newfunction(:difference, :type => :rvalue, :arity => 2, :doc => <<-EOS
 This function returns the difference between two arrays.
 The returned array is a copy of the original array, removing any items that
 also appear in the second array.
@@ -15,10 +15,6 @@ also appear in the second array.
 Would return: ["a"]
     EOS
   ) do |arguments|
-
-    # Two arguments are required
-    raise(Puppet::ParseError, "difference(): Wrong number of arguments " +
-      "given (#{arguments.size} for 2)") if arguments.size != 2
 
     first = arguments[0]
     second = arguments[1]

--- a/lib/puppet/parser/functions/dirname.rb
+++ b/lib/puppet/parser/functions/dirname.rb
@@ -1,11 +1,8 @@
 module Puppet::Parser::Functions
-  newfunction(:dirname, :type => :rvalue, :doc => <<-EOS
+  newfunction(:dirname, :type => :rvalue, :arity => 1, :doc => <<-EOS
     Returns the dirname of a path.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "dirname(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     path = arguments[0]
     return File.dirname(path)

--- a/lib/puppet/parser/functions/downcase.rb
+++ b/lib/puppet/parser/functions/downcase.rb
@@ -3,13 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:downcase, :type => :rvalue, :doc => <<-EOS
+  newfunction(:downcase, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Converts the case of a string or all strings in an array to lower case.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "downcase(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/empty.rb
+++ b/lib/puppet/parser/functions/empty.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:empty, :type => :rvalue, :doc => <<-EOS
+  newfunction(:empty, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns true if the variable is empty.
     EOS
   ) do |arguments|

--- a/lib/puppet/parser/functions/ensure_packages.rb
+++ b/lib/puppet/parser/functions/ensure_packages.rb
@@ -3,18 +3,18 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:ensure_packages, :type => :statement, :doc => <<-EOS
+  newfunction(:ensure_packages, :type => :statement, :arity => -2, :doc => <<-EOS
 Takes a list of packages and only installs them if they don't already exist.
 It optionally takes a hash as a second parameter that will be passed as the
 third argument to the ensure_resource() function.
     EOS
   ) do |arguments|
 
-    if arguments.size > 2 or arguments.size == 0
-      raise(Puppet::ParseError, "ensure_packages(): Wrong number of arguments " +
+    if arguments.size > 2
+      raise(ArgumentError, "ensure_packages(): Wrong number of arguments " +
         "given (#{arguments.size} for 1 or 2)")
-    elsif arguments.size == 2 and !arguments[1].is_a?(Hash) 
-      raise(Puppet::ParseError, 'ensure_packages(): Requires second argument to be a Hash')
+    elsif arguments.size == 2 and !arguments[1].is_a?(Hash)
+      raise(ArgumentError, 'ensure_packages(): Requires second argument to be a Hash')
     end
 
     packages = Array(arguments[0])

--- a/lib/puppet/parser/functions/ensure_resource.rb
+++ b/lib/puppet/parser/functions/ensure_resource.rb
@@ -3,6 +3,7 @@ require 'puppet/parser/functions'
 
 Puppet::Parser::Functions.newfunction(:ensure_resource,
                                       :type => :statement,
+                                      :arity => -3,
                                       :doc => <<-'ENDOFDOC'
 Takes a resource type, title, and a list of attributes that describe a
 resource.
@@ -27,8 +28,6 @@ the type and parameters specified if it doesn't already exist.
 ENDOFDOC
 ) do |vals|
   type, title, params = vals
-  raise(ArgumentError, 'Must specify a type') unless type
-  raise(ArgumentError, 'Must specify a title') unless title
   params ||= {}
 
   items = [title].flatten

--- a/lib/puppet/parser/functions/flatten.rb
+++ b/lib/puppet/parser/functions/flatten.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:flatten, :type => :rvalue, :doc => <<-EOS
+  newfunction(:flatten, :type => :rvalue, :arity => 1, :doc => <<-EOS
 This function flattens any deeply nested arrays and returns a single flat array
 as a result.
 
@@ -14,9 +14,6 @@ as a result.
 Would return: ['a','b','c']
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "flatten(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size != 1
 
     array = arguments[0]
 

--- a/lib/puppet/parser/functions/floor.rb
+++ b/lib/puppet/parser/functions/floor.rb
@@ -1,12 +1,9 @@
 module Puppet::Parser::Functions
-  newfunction(:floor, :type => :rvalue, :doc => <<-EOS
+  newfunction(:floor, :type => :rvalue, :arity => 1, :doc => <<-EOS
     Returns the largest integer less or equal to the argument.
     Takes a single numeric value as an argument.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "floor(): Wrong number of arguments " +
-          "given (#{arguments.size} for 1)") if arguments.size != 1
 
     begin
       arg = Float(arguments[0])

--- a/lib/puppet/parser/functions/fqdn_rotate.rb
+++ b/lib/puppet/parser/functions/fqdn_rotate.rb
@@ -3,13 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:fqdn_rotate, :type => :rvalue, :doc => <<-EOS
+  newfunction(:fqdn_rotate, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Rotates an array a random number of times based on a nodes fqdn.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "fqdn_rotate(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/get_module_path.rb
+++ b/lib/puppet/parser/functions/get_module_path.rb
@@ -1,5 +1,5 @@
 module Puppet::Parser::Functions
-  newfunction(:get_module_path, :type =>:rvalue, :doc => <<-EOT
+  newfunction(:get_module_path, :type =>:rvalue, :arity => 1, :doc => <<-EOT
     Returns the absolute path of the specified module for the current
     environment.
 
@@ -7,7 +7,6 @@ module Puppet::Parser::Functions
       $module_path = get_module_path('stdlib')
   EOT
   ) do |args|
-    raise(Puppet::ParseError, "get_module_path(): Wrong number of arguments, expects one") unless args.size == 1
     if module_path = Puppet::Module.find(args[0], compiler.environment.to_s)
       module_path.path
     else

--- a/lib/puppet/parser/functions/getparam.rb
+++ b/lib/puppet/parser/functions/getparam.rb
@@ -3,6 +3,7 @@ require 'puppet/parser/functions'
 
 Puppet::Parser::Functions.newfunction(:getparam,
                                       :type => :rvalue,
+                                      :arity => 2,
                                       :doc => <<-'ENDOFDOC'
 Takes a resource reference and name of the parameter and
 returns value of resource's parameter.
@@ -22,7 +23,6 @@ Would return: param_value
 ENDOFDOC
 ) do |vals|
   reference, param = vals
-  raise(ArgumentError, 'Must specify a reference') unless reference
   raise(ArgumentError, 'Must specify name of a parameter') unless param and param.instance_of? String
 
   return '' if param.empty?

--- a/lib/puppet/parser/functions/getvar.rb
+++ b/lib/puppet/parser/functions/getvar.rb
@@ -1,6 +1,6 @@
 module Puppet::Parser::Functions
 
-  newfunction(:getvar, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:getvar, :type => :rvalue, :arity => 1, :doc => <<-'ENDHEREDOC') do |args|
     Lookup a variable in a remote namespace.
 
     For example:
@@ -14,10 +14,6 @@ module Puppet::Parser::Functions
         $bar = getvar("${datalocation}::bar")
         # Equivalent to $bar = $site::data::bar
     ENDHEREDOC
-
-    unless args.length == 1
-      raise Puppet::ParseError, ("getvar(): wrong number of arguments (#{args.length}; must be 1)")
-    end
 
     begin
       self.lookupvar("#{args[0]}")

--- a/lib/puppet/parser/functions/grep.rb
+++ b/lib/puppet/parser/functions/grep.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:grep, :type => :rvalue, :doc => <<-EOS
+  newfunction(:grep, :type => :rvalue, :arity => 2, :doc => <<-EOS
 This function searches through an array and returns any elements that match
 the provided regular expression.
 
@@ -16,11 +16,6 @@ Would return:
     ['aaa','aaaddd']
     EOS
   ) do |arguments|
-
-    if (arguments.size != 2) then
-      raise(Puppet::ParseError, "grep(): Wrong number of arguments "+
-        "given #{arguments.size} for 2")
-    end
 
     a = arguments[0]
     pattern = Regexp.new(arguments[1])

--- a/lib/puppet/parser/functions/has_interface_with.rb
+++ b/lib/puppet/parser/functions/has_interface_with.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:has_interface_with, :type => :rvalue, :doc => <<-EOS
+  newfunction(:has_interface_with, :type => :rvalue, :arity => -2, :doc => <<-EOS
 Returns boolean based on kind and value:
   * macaddress
   * netmask
@@ -19,8 +19,8 @@ has_interface_with("lo")                        => true
     EOS
   ) do |args|
 
-    raise(Puppet::ParseError, "has_interface_with(): Wrong number of arguments " +
-          "given (#{args.size} for 1 or 2)") if args.size < 1 or args.size > 2
+    raise(ArgumentError, "has_interface_with(): Wrong number of arguments " +
+          "given (#{args.size} for 1 or 2)") if args.size > 2
 
     interfaces = lookupvar('interfaces')
 

--- a/lib/puppet/parser/functions/has_ip_address.rb
+++ b/lib/puppet/parser/functions/has_ip_address.rb
@@ -3,16 +3,13 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:has_ip_address, :type => :rvalue, :doc => <<-EOS
+  newfunction(:has_ip_address, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns true if the client has the requested IP address on some interface.
 
 This function iterates through the 'interfaces' fact and checks the
 'ipaddress_IFACE' facts, performing a simple string comparison.
     EOS
   ) do |args|
-
-    raise(Puppet::ParseError, "has_ip_address(): Wrong number of arguments " +
-          "given (#{args.size} for 1)") if args.size != 1
 
     Puppet::Parser::Functions.autoloader.load(:has_interface_with) \
       unless Puppet::Parser::Functions.autoloader.loaded?(:has_interface_with)

--- a/lib/puppet/parser/functions/has_ip_network.rb
+++ b/lib/puppet/parser/functions/has_ip_network.rb
@@ -3,16 +3,13 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:has_ip_network, :type => :rvalue, :doc => <<-EOS
+  newfunction(:has_ip_network, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns true if the client has an IP address within the requested network.
 
 This function iterates through the 'interfaces' fact and checks the
 'network_IFACE' facts, performing a simple string comparision.
     EOS
   ) do |args|
-
-    raise(Puppet::ParseError, "has_ip_network(): Wrong number of arguments " +
-          "given (#{args.size} for 1)") if args.size != 1
 
     Puppet::Parser::Functions.autoloader.load(:has_interface_with) \
       unless Puppet::Parser::Functions.autoloader.loaded?(:has_interface_with)

--- a/lib/puppet/parser/functions/has_key.rb
+++ b/lib/puppet/parser/functions/has_key.rb
@@ -1,6 +1,6 @@
 module Puppet::Parser::Functions
 
-  newfunction(:has_key, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:has_key, :type => :rvalue, :arity => 2, :doc => <<-'ENDHEREDOC') do |args|
     Determine if a hash has a certain key value.
 
     Example:
@@ -15,9 +15,6 @@ module Puppet::Parser::Functions
 
     ENDHEREDOC
 
-    unless args.length == 2
-      raise Puppet::ParseError, ("has_key(): wrong number of arguments (#{args.length}; must be 2)")
-    end
     unless args[0].is_a?(Hash)
       raise Puppet::ParseError, "has_key(): expects the first argument to be a hash, got #{args[0].inspect} which is of type #{args[0].class}"
     end

--- a/lib/puppet/parser/functions/hash.rb
+++ b/lib/puppet/parser/functions/hash.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:hash, :type => :rvalue, :doc => <<-EOS
+  newfunction(:hash, :type => :rvalue, :arity => 1, :doc => <<-EOS
 This function converts an array into a hash.
 
 *Examples:*
@@ -13,9 +13,6 @@ This function converts an array into a hash.
 Would return: {'a'=>1,'b'=>2,'c'=>3}
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "hash(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     array = arguments[0]
 

--- a/lib/puppet/parser/functions/intersection.rb
+++ b/lib/puppet/parser/functions/intersection.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:intersection, :type => :rvalue, :doc => <<-EOS
+  newfunction(:intersection, :type => :rvalue, :arity => 2, :doc => <<-EOS
 This function returns an array an intersection of two.
 
 *Examples:*
@@ -13,10 +13,6 @@ This function returns an array an intersection of two.
 Would return: ["b","c"]
     EOS
   ) do |arguments|
-
-    # Two arguments are required
-    raise(Puppet::ParseError, "intersection(): Wrong number of arguments " +
-      "given (#{arguments.size} for 2)") if arguments.size != 2
 
     first = arguments[0]
     second = arguments[1]

--- a/lib/puppet/parser/functions/is_array.rb
+++ b/lib/puppet/parser/functions/is_array.rb
@@ -3,13 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:is_array, :type => :rvalue, :doc => <<-EOS
+  newfunction(:is_array, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns true if the variable passed to this function is an array.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "is_array(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     type = arguments[0]
 

--- a/lib/puppet/parser/functions/is_bool.rb
+++ b/lib/puppet/parser/functions/is_bool.rb
@@ -3,13 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:is_bool, :type => :rvalue, :doc => <<-EOS
+  newfunction(:is_bool, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns true if the variable passed to this function is a boolean.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "is_bool(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size != 1
 
     type = arguments[0]
 

--- a/lib/puppet/parser/functions/is_domain_name.rb
+++ b/lib/puppet/parser/functions/is_domain_name.rb
@@ -3,15 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:is_domain_name, :type => :rvalue, :doc => <<-EOS
+  newfunction(:is_domain_name, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns true if the string passed to this function is a syntactically correct domain name.
     EOS
   ) do |arguments|
-
-    if (arguments.size != 1) then
-      raise(Puppet::ParseError, "is_domain_name(): Wrong number of arguments "+
-        "given #{arguments.size} for 1")
-    end
 
     domain = arguments[0]
 

--- a/lib/puppet/parser/functions/is_float.rb
+++ b/lib/puppet/parser/functions/is_float.rb
@@ -3,15 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:is_float, :type => :rvalue, :doc => <<-EOS
+  newfunction(:is_float, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns true if the variable passed to this function is a float.
     EOS
   ) do |arguments|
-
-    if (arguments.size != 1) then
-      raise(Puppet::ParseError, "is_float(): Wrong number of arguments "+
-        "given #{arguments.size} for 1")
-    end
 
     value = arguments[0]
 

--- a/lib/puppet/parser/functions/is_function_available.rb
+++ b/lib/puppet/parser/functions/is_function_available.rb
@@ -3,17 +3,12 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:is_function_available, :type => :rvalue, :doc => <<-EOS
+  newfunction(:is_function_available, :type => :rvalue, :arity => 1, :doc => <<-EOS
 This function accepts a string as an argument, determines whether the
 Puppet runtime has access to a function by that name.  It returns a
 true if the function exists, false if not.
     EOS
   ) do |arguments|
-
-    if (arguments.size != 1) then
-      raise(Puppet::ParseError, "is_function_available?(): Wrong number of arguments "+
-        "given #{arguments.size} for 1")
-    end
 
     # Only allow String types
     return false unless arguments[0].is_a?(String)

--- a/lib/puppet/parser/functions/is_hash.rb
+++ b/lib/puppet/parser/functions/is_hash.rb
@@ -3,13 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:is_hash, :type => :rvalue, :doc => <<-EOS
+  newfunction(:is_hash, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns true if the variable passed to this function is a hash.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "is_hash(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size != 1
 
     type = arguments[0]
 

--- a/lib/puppet/parser/functions/is_integer.rb
+++ b/lib/puppet/parser/functions/is_integer.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:is_integer, :type => :rvalue, :doc => <<-EOS
+  newfunction(:is_integer, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns true if the variable passed to this function is an Integer or
 a decimal (base 10) integer in String form. The string may
 start with a '-' (minus). A value of '0' is allowed, but a leading '0' digit may not
@@ -12,11 +12,6 @@ be followed by other digits as this indicates that the value is octal (base 8).
 If given any other argument `false` is returned.
     EOS
   ) do |arguments|
-
-    if (arguments.size != 1) then
-      raise(Puppet::ParseError, "is_integer(): Wrong number of arguments "+
-        "given #{arguments.size} for 1")
-    end
 
     value = arguments[0]
 

--- a/lib/puppet/parser/functions/is_ip_address.rb
+++ b/lib/puppet/parser/functions/is_ip_address.rb
@@ -3,17 +3,12 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:is_ip_address, :type => :rvalue, :doc => <<-EOS
+  newfunction(:is_ip_address, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns true if the string passed to this function is a valid IP address.
     EOS
   ) do |arguments|
 
     require 'ipaddr'
-
-    if (arguments.size != 1) then
-      raise(Puppet::ParseError, "is_ip_address(): Wrong number of arguments "+
-        "given #{arguments.size} for 1")
-    end
 
     begin
       ip = IPAddr.new(arguments[0])

--- a/lib/puppet/parser/functions/is_mac_address.rb
+++ b/lib/puppet/parser/functions/is_mac_address.rb
@@ -3,15 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:is_mac_address, :type => :rvalue, :doc => <<-EOS
+  newfunction(:is_mac_address, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns true if the string passed to this function is a valid mac address.
     EOS
   ) do |arguments|
-
-    if (arguments.size != 1) then
-      raise(Puppet::ParseError, "is_mac_address(): Wrong number of arguments "+
-        "given #{arguments.size} for 1")
-    end
 
     mac = arguments[0]
 

--- a/lib/puppet/parser/functions/is_numeric.rb
+++ b/lib/puppet/parser/functions/is_numeric.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:is_numeric, :type => :rvalue, :doc => <<-EOS
+  newfunction(:is_numeric, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns true if the given argument is a Numeric (Integer or Float),
 or a String containing either a valid integer in decimal base 10 form, or
 a valid floating point string representation.
@@ -23,11 +23,6 @@ Valid examples:
   -23.561e3
     EOS
   ) do |arguments|
-
-    if (arguments.size != 1) then
-      raise(Puppet::ParseError, "is_numeric(): Wrong number of arguments "+
-        "given #{arguments.size} for 1")
-    end
 
     value = arguments[0]
 

--- a/lib/puppet/parser/functions/is_string.rb
+++ b/lib/puppet/parser/functions/is_string.rb
@@ -3,13 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:is_string, :type => :rvalue, :doc => <<-EOS
+  newfunction(:is_string, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns true if the variable passed to this function is a string.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "is_string(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     type = arguments[0]
 

--- a/lib/puppet/parser/functions/join.rb
+++ b/lib/puppet/parser/functions/join.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:join, :type => :rvalue, :doc => <<-EOS
+  newfunction(:join, :type => :rvalue, :arity => -2, :doc => <<-EOS
 This function joins an array into a string using a separator.
 
 *Examples:*
@@ -13,10 +13,6 @@ This function joins an array into a string using a separator.
 Would result in: "a,b,c"
     EOS
   ) do |arguments|
-
-    # Technically we support two arguments but only first is mandatory ...
-    raise(Puppet::ParseError, "join(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     array = arguments[0]
 

--- a/lib/puppet/parser/functions/join_keys_to_values.rb
+++ b/lib/puppet/parser/functions/join_keys_to_values.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:join_keys_to_values, :type => :rvalue, :doc => <<-EOS
+  newfunction(:join_keys_to_values, :type => :rvalue, :arity => 2, :doc => <<-EOS
 This function joins each key of a hash to that key's corresponding value with a
 separator. Keys and values are cast to strings. The return value is an array in
 which each element is one joined key/value pair.
@@ -15,12 +15,6 @@ which each element is one joined key/value pair.
 Would result in: ["a is 1","b is 2"]
     EOS
   ) do |arguments|
-
-    # Validate the number of arguments.
-    if arguments.size != 2
-      raise(Puppet::ParseError, "join_keys_to_values(): Takes exactly two " +
-            "arguments, but #{arguments.size} given.")
-    end
 
     # Validate the first argument.
     hash = arguments[0]

--- a/lib/puppet/parser/functions/keys.rb
+++ b/lib/puppet/parser/functions/keys.rb
@@ -3,13 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:keys, :type => :rvalue, :doc => <<-EOS
+  newfunction(:keys, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns the keys of a hash as an array.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "keys(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     hash = arguments[0]
 

--- a/lib/puppet/parser/functions/loadyaml.rb
+++ b/lib/puppet/parser/functions/loadyaml.rb
@@ -1,6 +1,6 @@
 module Puppet::Parser::Functions
 
-  newfunction(:loadyaml, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:loadyaml, :type => :rvalue, :arity => 1, :doc => <<-'ENDHEREDOC') do |args|
     Load a YAML file containing an array, string, or hash, and return the data
     in the corresponding native data type.
 
@@ -8,10 +8,6 @@ module Puppet::Parser::Functions
 
         $myhash = loadyaml('/etc/puppet/data/myhash.yaml')
     ENDHEREDOC
-
-    unless args.length == 1
-      raise Puppet::ParseError, ("loadyaml(): wrong number of arguments (#{args.length}; must be 1)")
-    end
 
     YAML.load_file(args[0])
 

--- a/lib/puppet/parser/functions/lstrip.rb
+++ b/lib/puppet/parser/functions/lstrip.rb
@@ -3,13 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:lstrip, :type => :rvalue, :doc => <<-EOS
+  newfunction(:lstrip, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Strips leading spaces to the left of a string.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "lstrip(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/max.rb
+++ b/lib/puppet/parser/functions/max.rb
@@ -1,12 +1,9 @@
 module Puppet::Parser::Functions
-  newfunction(:max, :type => :rvalue, :doc => <<-EOS
+  newfunction(:max, :type => :rvalue, :arity => -2, :doc => <<-EOS
     Returns the highest value of all arguments.
     Requires at least one argument.
     EOS
   ) do |args|
-
-    raise(Puppet::ParseError, "max(): Wrong number of arguments " +
-          "need at least one") if args.size == 0
 
     # Sometimes we get numbers as numerics and sometimes as strings.
     # We try to compare them as numbers when possible

--- a/lib/puppet/parser/functions/member.rb
+++ b/lib/puppet/parser/functions/member.rb
@@ -6,7 +6,7 @@
 # TODO(Krzysztof Wilczynski): Support for strings and hashes too ...
 
 module Puppet::Parser::Functions
-  newfunction(:member, :type => :rvalue, :doc => <<-EOS
+  newfunction(:member, :type => :rvalue, :arity => 2, :doc => <<-EOS
 This function determines if a variable is a member of an array.
 
 *Examples:*
@@ -20,9 +20,6 @@ Would return: true
 Would return: false
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "member(): Wrong number of arguments " +
-      "given (#{arguments.size} for 2)") if arguments.size < 2
 
     array = arguments[0]
 

--- a/lib/puppet/parser/functions/merge.rb
+++ b/lib/puppet/parser/functions/merge.rb
@@ -1,5 +1,5 @@
 module Puppet::Parser::Functions
-  newfunction(:merge, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:merge, :type => :rvalue, :arity => -3, :doc => <<-'ENDHEREDOC') do |args|
     Merges two or more hashes together and returns the resulting hash.
 
     For example:
@@ -13,10 +13,6 @@ module Puppet::Parser::Functions
     When there is a duplicate key, the key in the rightmost hash will "win."
 
     ENDHEREDOC
-
-    if args.length < 2
-      raise Puppet::ParseError, ("merge(): wrong number of arguments (#{args.length}; must be at least 2)")
-    end
 
     # The hash we accumulate into
     accumulator = Hash.new

--- a/lib/puppet/parser/functions/min.rb
+++ b/lib/puppet/parser/functions/min.rb
@@ -1,12 +1,9 @@
 module Puppet::Parser::Functions
-  newfunction(:min, :type => :rvalue, :doc => <<-EOS
+  newfunction(:min, :type => :rvalue, :arity => -2, :doc => <<-EOS
     Returns the lowest value of all arguments.
     Requires at least one argument.
     EOS
   ) do |args|
-
-    raise(Puppet::ParseError, "min(): Wrong number of arguments " +
-          "need at least one") if args.size == 0
 
     # Sometimes we get numbers as numerics and sometimes as strings.
     # We try to compare them as numbers when possible

--- a/lib/puppet/parser/functions/num2bool.rb
+++ b/lib/puppet/parser/functions/num2bool.rb
@@ -3,15 +3,12 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:num2bool, :type => :rvalue, :doc => <<-EOS
+  newfunction(:num2bool, :type => :rvalue, :arity => 1, :doc => <<-EOS
 This function converts a number or a string representation of a number into a
 true boolean. Zero or anything non-numeric becomes false. Numbers higher then 0
 become true.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "num2bool(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size != 1
 
     number = arguments[0]
 

--- a/lib/puppet/parser/functions/parsejson.rb
+++ b/lib/puppet/parser/functions/parsejson.rb
@@ -3,16 +3,11 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:parsejson, :type => :rvalue, :doc => <<-EOS
+  newfunction(:parsejson, :type => :rvalue, :arity => 1, :doc => <<-EOS
 This function accepts JSON as a string and converts into the correct Puppet
 structure.
     EOS
   ) do |arguments|
-
-    if (arguments.size != 1) then
-      raise(Puppet::ParseError, "parsejson(): Wrong number of arguments "+
-        "given #{arguments.size} for 1")
-    end
 
     json = arguments[0]
 

--- a/lib/puppet/parser/functions/parseyaml.rb
+++ b/lib/puppet/parser/functions/parseyaml.rb
@@ -3,16 +3,11 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:parseyaml, :type => :rvalue, :doc => <<-EOS
+  newfunction(:parseyaml, :type => :rvalue, :arity => 1, :doc => <<-EOS
 This function accepts YAML as a string and converts it into the correct
 Puppet structure.
     EOS
   ) do |arguments|
-
-    if (arguments.size != 1) then
-      raise(Puppet::ParseError, "parseyaml(): Wrong number of arguments "+
-        "given #{arguments.size} for 1")
-    end
 
     require 'yaml'
 

--- a/lib/puppet/parser/functions/pick.rb
+++ b/lib/puppet/parser/functions/pick.rb
@@ -1,5 +1,5 @@
 module Puppet::Parser::Functions
- newfunction(:pick, :type => :rvalue, :doc => <<-EOS
+ newfunction(:pick, :type => :rvalue, :arity => -2, :doc => <<-EOS
 
 This function is similar to a coalesce function in SQL in that it will return
 the first value in a list of values that is not undefined or an empty string

--- a/lib/puppet/parser/functions/pick_default.rb
+++ b/lib/puppet/parser/functions/pick_default.rb
@@ -1,5 +1,5 @@
 module Puppet::Parser::Functions
- newfunction(:pick_default, :type => :rvalue, :doc => <<-EOS
+ newfunction(:pick_default, :type => :rvalue, :arity => -2, :doc => <<-EOS
 
 This function is similar to a coalesce function in SQL in that it will return
 the first value in a list of values that is not undefined or an empty string
@@ -23,7 +23,6 @@ default.
 
 EOS
 ) do |args|
-   fail "Must receive at least one argument." if args.empty?
    default = args.last
    args = args[0..-2].compact
    args.delete(:undef)

--- a/lib/puppet/parser/functions/prefix.rb
+++ b/lib/puppet/parser/functions/prefix.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:prefix, :type => :rvalue, :doc => <<-EOS
+  newfunction(:prefix, :type => :rvalue, :arity => -2, :doc => <<-EOS
 This function applies a prefix to all elements in an array.
 
 *Examples:*
@@ -13,10 +13,6 @@ This function applies a prefix to all elements in an array.
 Will return: ['pa','pb','pc']
     EOS
   ) do |arguments|
-
-    # Technically we support two arguments but only first is mandatory ...
-    raise(Puppet::ParseError, "prefix(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     array = arguments[0]
 

--- a/lib/puppet/parser/functions/private.rb
+++ b/lib/puppet/parser/functions/private.rb
@@ -3,13 +3,13 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:private, :doc => <<-'EOS'
+  newfunction(:private, :arity => -1, :doc => <<-'EOS'
     Sets the current class or definition as private.
     Calling the class or definition from outside the current module will fail.
     EOS
   ) do |args|
 
-    raise(Puppet::ParseError, "private(): Wrong number of arguments "+
+    raise(ArgumentError, "private(): Wrong number of arguments "+
       "given (#{args.size}}) for 0 or 1)") if args.size > 1
 
     scope = self

--- a/lib/puppet/parser/functions/range.rb
+++ b/lib/puppet/parser/functions/range.rb
@@ -5,7 +5,7 @@
 # TODO(Krzysztof Wilczynski): We probably need to approach numeric values differently ...
 
 module Puppet::Parser::Functions
-  newfunction(:range, :type => :rvalue, :doc => <<-EOS
+  newfunction(:range, :type => :rvalue, :arity => -2, :doc => <<-EOS
 When given range in the form of (start, stop) it will extrapolate a range as
 an array.
 
@@ -37,10 +37,6 @@ Will return: [0,2,4,6,8]
     EOS
   ) do |arguments|
 
-    # We support more than one argument but at least one is mandatory ...
-    raise(Puppet::ParseError, "range(): Wrong number of " +
-      "arguments given (#{arguments.size} for 1)") if arguments.size < 1
-
     if arguments.size > 1
       start = arguments[0]
       stop  = arguments[1]
@@ -48,7 +44,7 @@ Will return: [0,2,4,6,8]
 
       type = '..' # We select simplest type for Range available in Ruby ...
 
-    elsif arguments.size > 0
+    else
       value = arguments[0]
 
       if m = value.match(/^(\w+)(\.\.\.?|\-)(\w+)$/)

--- a/lib/puppet/parser/functions/reject.rb
+++ b/lib/puppet/parser/functions/reject.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:reject, :type => :rvalue, :doc => <<-EOS) do |args|
+  newfunction(:reject, :type => :rvalue, :arity => 2, :doc => <<-EOS) do |args|
 This function searches through an array and rejects all elements that match
 the provided regular expression.
 
@@ -15,11 +15,6 @@ Would return:
 
     ['bbb','ccc']
 EOS
-
-    if (args.size != 2)
-      raise Puppet::ParseError,
-        "reject(): Wrong number of arguments given #{args.size} for 2"
-    end
 
     ary = args[0]
     pattern = Regexp.new(args[1])

--- a/lib/puppet/parser/functions/reverse.rb
+++ b/lib/puppet/parser/functions/reverse.rb
@@ -3,13 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:reverse, :type => :rvalue, :doc => <<-EOS
+  newfunction(:reverse, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Reverses the order of a string or array.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "reverse(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/rstrip.rb
+++ b/lib/puppet/parser/functions/rstrip.rb
@@ -3,13 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:rstrip, :type => :rvalue, :doc => <<-EOS
+  newfunction(:rstrip, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Strips leading spaces to the right of the string.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "rstrip(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/shuffle.rb
+++ b/lib/puppet/parser/functions/shuffle.rb
@@ -3,13 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:shuffle, :type => :rvalue, :doc => <<-EOS
+  newfunction(:shuffle, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Randomizes the order of a string or array elements.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "shuffle(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/size.rb
+++ b/lib/puppet/parser/functions/size.rb
@@ -5,13 +5,10 @@
 # TODO(Krzysztof Wilczynski): Support for hashes would be nice too ...
 
 module Puppet::Parser::Functions
-  newfunction(:size, :type => :rvalue, :doc => <<-EOS
+  newfunction(:size, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns the number of elements in a string or array.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "size(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     item = arguments[0]
 

--- a/lib/puppet/parser/functions/sort.rb
+++ b/lib/puppet/parser/functions/sort.rb
@@ -3,15 +3,10 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:sort, :type => :rvalue, :doc => <<-EOS
+  newfunction(:sort, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Sorts strings and arrays lexically.
     EOS
   ) do |arguments|
-
-    if (arguments.size != 1) then
-      raise(Puppet::ParseError, "sort(): Wrong number of arguments "+
-        "given #{arguments.size} for 1")
-    end
 
     value = arguments[0]
 

--- a/lib/puppet/parser/functions/squeeze.rb
+++ b/lib/puppet/parser/functions/squeeze.rb
@@ -3,13 +3,13 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:squeeze, :type => :rvalue, :doc => <<-EOS
+  newfunction(:squeeze, :type => :rvalue, :arity => -2, :doc => <<-EOS
 Returns a new string where runs of the same character that occur in this set are replaced by a single character.
     EOS
   ) do |arguments|
 
-    if ((arguments.size != 2) and (arguments.size != 1)) then
-      raise(Puppet::ParseError, "squeeze(): Wrong number of arguments "+
+    if (arguments.size > 2) then
+      raise(ArgumentError, "squeeze(): Wrong number of arguments "+
         "given #{arguments.size} for 2 or 1")
     end
 

--- a/lib/puppet/parser/functions/str2bool.rb
+++ b/lib/puppet/parser/functions/str2bool.rb
@@ -3,15 +3,12 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:str2bool, :type => :rvalue, :doc => <<-EOS
+  newfunction(:str2bool, :type => :rvalue, :arity => 1, :doc => <<-EOS
 This converts a string to a boolean. This attempt to convert strings that
 contain things like: y, 1, t, true to 'true' and strings that contain things
 like: 0, f, n, false, no to 'false'.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "str2bool(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     string = arguments[0]
 

--- a/lib/puppet/parser/functions/str2saltedsha512.rb
+++ b/lib/puppet/parser/functions/str2saltedsha512.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:str2saltedsha512, :type => :rvalue, :doc => <<-EOS
+  newfunction(:str2saltedsha512, :type => :rvalue, :arity => 1, :doc => <<-EOS
 This converts a string to a salted-SHA512 password hash (which is used for
 OS X versions >= 10.7). Given any simple string, you will get a hex version
 of a salted-SHA512 password hash that can be inserted into your Puppet
@@ -11,9 +11,6 @@ manifests as a valid password attribute.
     EOS
   ) do |arguments|
     require 'digest/sha2'
-
-    raise(Puppet::ParseError, "str2saltedsha512(): Wrong number of arguments " +
-      "passed (#{arguments.size} but we require 1)") if arguments.size != 1
 
     password = arguments[0]
 

--- a/lib/puppet/parser/functions/strftime.rb
+++ b/lib/puppet/parser/functions/strftime.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:strftime, :type => :rvalue, :doc => <<-EOS
+  newfunction(:strftime, :type => :rvalue, :arity => -2, :doc => <<-EOS
 This function returns formatted time.
 
 *Examples:*
@@ -69,10 +69,6 @@ To return the date:
     %% - Literal ``%'' character
     EOS
   ) do |arguments|
-
-    # Technically we support two arguments but only first is mandatory ...
-    raise(Puppet::ParseError, "strftime(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     format = arguments[0]
 

--- a/lib/puppet/parser/functions/strip.rb
+++ b/lib/puppet/parser/functions/strip.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:strip, :type => :rvalue, :doc => <<-EOS
+  newfunction(:strip, :type => :rvalue, :arity => 1, :doc => <<-EOS
 This function removes leading and trailing whitespace from a string or from
 every string inside an array.
 
@@ -14,9 +14,6 @@ every string inside an array.
 Would result in: "aaa"
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "strip(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/suffix.rb
+++ b/lib/puppet/parser/functions/suffix.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:suffix, :type => :rvalue, :doc => <<-EOS
+  newfunction(:suffix, :type => :rvalue, :arity => -2, :doc => <<-EOS
 This function applies a suffix to all elements in an array.
 
 *Examples:*
@@ -13,10 +13,6 @@ This function applies a suffix to all elements in an array.
 Will return: ['ap','bp','cp']
     EOS
   ) do |arguments|
-
-    # Technically we support two arguments but only first is mandatory ...
-    raise(Puppet::ParseError, "suffix(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     array = arguments[0]
 

--- a/lib/puppet/parser/functions/swapcase.rb
+++ b/lib/puppet/parser/functions/swapcase.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:swapcase, :type => :rvalue, :doc => <<-EOS
+  newfunction(:swapcase, :type => :rvalue, :arity => 1, :doc => <<-EOS
 This function will swap the existing case of a string.
 
 *Examples:*
@@ -13,9 +13,6 @@ This function will swap the existing case of a string.
 Would result in: "AbCd"
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "swapcase(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/time.rb
+++ b/lib/puppet/parser/functions/time.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:time, :type => :rvalue, :doc => <<-EOS
+  newfunction(:time, :type => :rvalue, :arity => -1,:doc => <<-EOS
 This function will return the current time since epoch as an integer.
 
 *Examples:*
@@ -17,8 +17,8 @@ Will return something like: 1311972653
     # The Time Zone argument is optional ...
     time_zone = arguments[0] if arguments[0]
 
-    if (arguments.size != 0) and (arguments.size != 1) then
-      raise(Puppet::ParseError, "time(): Wrong number of arguments "+
+    if (arguments.size > 1) then
+      raise(ArgumentError, "time(): Wrong number of arguments "+
         "given #{arguments.size} for 0 or 1")
     end
 

--- a/lib/puppet/parser/functions/to_bytes.rb
+++ b/lib/puppet/parser/functions/to_bytes.rb
@@ -1,12 +1,9 @@
 module Puppet::Parser::Functions
-  newfunction(:to_bytes, :type => :rvalue, :doc => <<-EOS
+  newfunction(:to_bytes, :type => :rvalue, :arity => 1, :doc => <<-EOS
     Converts the argument into bytes, for example 4 kB becomes 4096.
     Takes a single string value as an argument.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "to_bytes(): Wrong number of arguments " +
-          "given (#{arguments.size} for 1)") if arguments.size != 1
 
     arg = arguments[0]
 

--- a/lib/puppet/parser/functions/type.rb
+++ b/lib/puppet/parser/functions/type.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:type, :type => :rvalue, :doc => <<-EOS
+  newfunction(:type, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Returns the type when passed a variable. Type can be one of:
 
 * string
@@ -14,9 +14,6 @@ Returns the type when passed a variable. Type can be one of:
 * boolean
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "type(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
 

--- a/lib/puppet/parser/functions/union.rb
+++ b/lib/puppet/parser/functions/union.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:union, :type => :rvalue, :doc => <<-EOS
+  newfunction(:union, :type => :rvalue, :arity => 2, :doc => <<-EOS
 This function returns a union of two arrays.
 
 *Examples:*
@@ -13,10 +13,6 @@ This function returns a union of two arrays.
 Would return: ["a","b","c","d"]
     EOS
   ) do |arguments|
-
-    # Two arguments are required
-    raise(Puppet::ParseError, "union(): Wrong number of arguments " +
-      "given (#{arguments.size} for 2)") if arguments.size != 2
 
     first = arguments[0]
     second = arguments[1]

--- a/lib/puppet/parser/functions/unique.rb
+++ b/lib/puppet/parser/functions/unique.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:unique, :type => :rvalue, :doc => <<-EOS
+  newfunction(:unique, :type => :rvalue, :arity => 1, :doc => <<-EOS
 This function will remove duplicates from strings and arrays.
 
 *Examples:*
@@ -23,9 +23,6 @@ This returns:
     ["a","b","c"]
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "unique(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/upcase.rb
+++ b/lib/puppet/parser/functions/upcase.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:upcase, :type => :rvalue, :doc => <<-EOS
+  newfunction(:upcase, :type => :rvalue, :arity => 1, :doc => <<-EOS
 Converts a string or an array of strings to uppercase.
 
 *Examples:*
@@ -15,9 +15,6 @@ Will return:
     ASDF
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "upcase(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/uriescape.rb
+++ b/lib/puppet/parser/functions/uriescape.rb
@@ -4,14 +4,11 @@
 require 'uri'
 
 module Puppet::Parser::Functions
-  newfunction(:uriescape, :type => :rvalue, :doc => <<-EOS
+  newfunction(:uriescape, :type => :rvalue, :arity => 1, :doc => <<-EOS
     Urlencodes a string or array of strings.
     Requires either a single string or an array as an input.
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "uriescape(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     value = arguments[0]
     klass = value.class

--- a/lib/puppet/parser/functions/validate_absolute_path.rb
+++ b/lib/puppet/parser/functions/validate_absolute_path.rb
@@ -1,5 +1,5 @@
 module Puppet::Parser::Functions
-  newfunction(:validate_absolute_path, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:validate_absolute_path, :arity => -2, :doc => <<-'ENDHEREDOC') do |args|
     Validate the string represents an absolute path in the filesystem.  This function works
     for windows and unix style paths.
 
@@ -22,10 +22,6 @@ module Puppet::Parser::Functions
     ENDHEREDOC
 
     require 'puppet/util'
-
-    unless args.length > 0 then
-      raise Puppet::ParseError, ("validate_absolute_path(): wrong number of arguments (#{args.length}; must be > 0)")
-    end
 
     args.each do |arg|
       # This logic was borrowed from

--- a/lib/puppet/parser/functions/validate_array.rb
+++ b/lib/puppet/parser/functions/validate_array.rb
@@ -1,6 +1,6 @@
 module Puppet::Parser::Functions
 
-  newfunction(:validate_array, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:validate_array, :arity => -2, :doc => <<-'ENDHEREDOC') do |args|
     Validate that all passed values are array data structures. Abort catalog
     compilation if any value fails this check.
 
@@ -17,10 +17,6 @@ module Puppet::Parser::Functions
         validate_array($undefined)
 
     ENDHEREDOC
-
-    unless args.length > 0 then
-      raise Puppet::ParseError, ("validate_array(): wrong number of arguments (#{args.length}; must be > 0)")
-    end
 
     args.each do |arg|
       unless arg.is_a?(Array)

--- a/lib/puppet/parser/functions/validate_augeas.rb
+++ b/lib/puppet/parser/functions/validate_augeas.rb
@@ -1,5 +1,5 @@
 module Puppet::Parser::Functions
-  newfunction(:validate_augeas, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:validate_augeas, :arity => -3, :doc => <<-'ENDHEREDOC') do |args|
     Perform validation of a string using an Augeas lens
     The first argument of this function should be a string to
     test, and the second argument should be the name of the Augeas lens to use.
@@ -32,8 +32,8 @@ module Puppet::Parser::Functions
       raise Puppet::ParseError, ("validate_augeas(): this function requires the augeas feature. See http://projects.puppetlabs.com/projects/puppet/wiki/Puppet_Augeas#Pre-requisites for how to activate it.")
     end
 
-    if (args.length < 2) or (args.length > 4) then
-      raise Puppet::ParseError, ("validate_augeas(): wrong number of arguments (#{args.length}; must be 2, 3, or 4)")
+    if args.length > 4 then
+      raise ArgumentError, ("validate_augeas(): wrong number of arguments (#{args.length}; must be 2, 3, or 4)")
     end
 
     msg = args[3] || "validate_augeas(): Failed to validate content against #{args[1].inspect}"

--- a/lib/puppet/parser/functions/validate_bool.rb
+++ b/lib/puppet/parser/functions/validate_bool.rb
@@ -1,6 +1,6 @@
 module Puppet::Parser::Functions
 
-  newfunction(:validate_bool, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:validate_bool, :arity => -2, :doc => <<-'ENDHEREDOC') do |args|
     Validate that all passed values are either true or false. Abort catalog
     compilation if any value fails this check.
 
@@ -18,10 +18,6 @@ module Puppet::Parser::Functions
         validate_bool($some_array)
 
     ENDHEREDOC
-
-    unless args.length > 0 then
-      raise Puppet::ParseError, ("validate_bool(): wrong number of arguments (#{args.length}; must be > 0)")
-    end
 
     args.each do |arg|
       unless function_is_bool([arg])

--- a/lib/puppet/parser/functions/validate_cmd.rb
+++ b/lib/puppet/parser/functions/validate_cmd.rb
@@ -1,7 +1,7 @@
 require 'puppet/util/execution'
 
 module Puppet::Parser::Functions
-  newfunction(:validate_cmd, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:validate_cmd, :arity => -3, :doc => <<-'ENDHEREDOC') do |args|
     Perform validation of a string with an external command.
     The first argument of this function should be a string to
     test, and the second argument should be a path to a test command
@@ -19,8 +19,8 @@ module Puppet::Parser::Functions
         validate_cmd($sudoerscontent, '/usr/sbin/visudo -c -f', 'Visudo failed to validate sudoers content')
 
     ENDHEREDOC
-    if (args.length < 2) or (args.length > 3) then
-      raise Puppet::ParseError, ("validate_cmd(): wrong number of arguments (#{args.length}; must be 2 or 3)")
+    if args.length > 3 then
+      raise ArgumentError, ("validate_cmd(): wrong number of arguments (#{args.length}; must be 2 or 3)")
     end
 
     msg = args[2] || "validate_cmd(): failed to validate content with command #{args[1].inspect}"

--- a/lib/puppet/parser/functions/validate_hash.rb
+++ b/lib/puppet/parser/functions/validate_hash.rb
@@ -1,6 +1,6 @@
 module Puppet::Parser::Functions
 
-  newfunction(:validate_hash, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:validate_hash, :arity => -2, :doc => <<-'ENDHEREDOC') do |args|
     Validate that all passed values are hash data structures. Abort catalog
     compilation if any value fails this check.
 
@@ -17,10 +17,6 @@ module Puppet::Parser::Functions
         validate_hash($undefined)
 
     ENDHEREDOC
-
-    unless args.length > 0 then
-      raise Puppet::ParseError, ("validate_hash(): wrong number of arguments (#{args.length}; must be > 0)")
-    end
 
     args.each do |arg|
       unless arg.is_a?(Hash)

--- a/lib/puppet/parser/functions/validate_ipv4_address.rb
+++ b/lib/puppet/parser/functions/validate_ipv4_address.rb
@@ -1,6 +1,6 @@
 module Puppet::Parser::Functions
 
-  newfunction(:validate_ipv4_address, :doc => <<-ENDHEREDOC
+  newfunction(:validate_ipv4_address, :arity => -2, :doc => <<-ENDHEREDOC
     Validate that all values passed are valid IPv4 addresses.
     Fail compilation if any value fails this check.
 
@@ -23,10 +23,6 @@ module Puppet::Parser::Functions
 
     if defined?(IPAddr::InvalidAddressError)
       rescuable_exceptions << IPAddr::InvalidAddressError
-    end
-
-    unless args.length > 0 then
-      raise Puppet::ParseError, ("validate_ipv4_address(): wrong number of arguments (#{args.length}; must be > 0)")
     end
 
     args.each do |arg|

--- a/lib/puppet/parser/functions/validate_ipv6_address.rb
+++ b/lib/puppet/parser/functions/validate_ipv6_address.rb
@@ -1,6 +1,6 @@
 module Puppet::Parser::Functions
 
-  newfunction(:validate_ipv6_address, :doc => <<-ENDHEREDOC
+  newfunction(:validate_ipv6_address, :arity => -2, :doc => <<-ENDHEREDOC
     Validate that all values passed are valid IPv6 addresses.
     Fail compilation if any value fails this check.
 
@@ -24,10 +24,6 @@ module Puppet::Parser::Functions
 
     if defined?(IPAddr::InvalidAddressError)
       rescuable_exceptions << IPAddr::InvalidAddressError
-    end
-
-    unless args.length > 0 then
-      raise Puppet::ParseError, ("validate_ipv6_address(): wrong number of arguments (#{args.length}; must be > 0)")
     end
 
     args.each do |arg|

--- a/lib/puppet/parser/functions/validate_re.rb
+++ b/lib/puppet/parser/functions/validate_re.rb
@@ -1,5 +1,5 @@
 module Puppet::Parser::Functions
-  newfunction(:validate_re, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:validate_re, :arity => -3, :doc => <<-'ENDHEREDOC') do |args|
     Perform simple validation of a string against one or more regular
     expressions. The first argument of this function should be a string to
     test, and the second argument should be a stringified regular expression
@@ -24,8 +24,8 @@ module Puppet::Parser::Functions
         validate_re($::puppetversion, '^2.7', 'The $puppetversion fact value does not match 2.7')
 
     ENDHEREDOC
-    if (args.length < 2) or (args.length > 3) then
-      raise Puppet::ParseError, ("validate_re(): wrong number of arguments (#{args.length}; must be 2 or 3)")
+    if args.length > 3 then
+      raise ArgumentError, ("validate_re(): wrong number of arguments (#{args.length}; must be 2 or 3)")
     end
 
     msg = args[2] || "validate_re(): #{args[0].inspect} does not match #{args[1].inspect}"

--- a/lib/puppet/parser/functions/validate_slength.rb
+++ b/lib/puppet/parser/functions/validate_slength.rb
@@ -1,6 +1,6 @@
 module Puppet::Parser::Functions
 
-  newfunction(:validate_slength, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:validate_slength, :arity => -3, :doc => <<-'ENDHEREDOC') do |args|
     Validate that the first argument is a string (or an array of strings), and
     less/equal to than the length of the second argument. An optional third
     parameter can be given a the minimum length. It fails if the first
@@ -21,7 +21,7 @@ module Puppet::Parser::Functions
 
     ENDHEREDOC
 
-    raise Puppet::ParseError, "validate_slength(): Wrong number of arguments (#{args.length}; must be 2 or 3)" unless args.length == 2 or args.length == 3
+    raise ArgumentError, "validate_slength(): Wrong number of arguments (#{args.length}; must be 2 or 3)" unless args.length == 2 or args.length == 3
 
     input, max_length, min_length = *args
 

--- a/lib/puppet/parser/functions/validate_string.rb
+++ b/lib/puppet/parser/functions/validate_string.rb
@@ -1,6 +1,6 @@
 module Puppet::Parser::Functions
 
-  newfunction(:validate_string, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:validate_string, :arity => -2, :doc => <<-'ENDHEREDOC') do |args|
     Validate that all passed values are string data structures. Abort catalog
     compilation if any value fails this check.
 
@@ -22,10 +22,6 @@ module Puppet::Parser::Functions
         }
     
     ENDHEREDOC
-
-    unless args.length > 0 then
-      raise Puppet::ParseError, ("validate_string(): wrong number of arguments (#{args.length}; must be > 0)")
-    end
 
     args.each do |arg|
       unless arg.is_a?(String)

--- a/lib/puppet/parser/functions/values.rb
+++ b/lib/puppet/parser/functions/values.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:values, :type => :rvalue, :doc => <<-EOS
+  newfunction(:values, :type => :rvalue, :arity => 1, :doc => <<-EOS
 When given a hash this function will return the values of that hash.
 
 *Examples:*
@@ -20,9 +20,6 @@ This example would return:
     [1,2,3]
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "values(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
 
     hash = arguments[0]
 

--- a/lib/puppet/parser/functions/values_at.rb
+++ b/lib/puppet/parser/functions/values_at.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:values_at, :type => :rvalue, :doc => <<-EOS
+  newfunction(:values_at, :type => :rvalue, :arity => 2, :doc => <<-EOS
 Finds value inside an array based on location.
 
 The first argument is the array you want to analyze, and the second element can
@@ -28,9 +28,6 @@ Would return ['a','b'].
 Would return ['a','c','d'].
     EOS
   ) do |arguments|
-
-    raise(Puppet::ParseError, "values_at(): Wrong number of " +
-      "arguments given (#{arguments.size} for 2)") if arguments.size < 2
 
     array = arguments.shift
 

--- a/lib/puppet/parser/functions/zip.rb
+++ b/lib/puppet/parser/functions/zip.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:zip, :type => :rvalue, :doc => <<-EOS
+  newfunction(:zip, :type => :rvalue, :arity => -2, :doc => <<-EOS
 Takes one element from first array and merges corresponding elements from second array. This generates a sequence of n-element arrays, where n is one more than the count of arguments.
 
 *Example:*
@@ -15,10 +15,6 @@ Would result in:
     ["1", "4"], ["2", "5"], ["3", "6"]
     EOS
   ) do |arguments|
-
-    # Technically we support three arguments but only first is mandatory ...
-    raise(Puppet::ParseError, "zip(): Wrong number of arguments " +
-      "given (#{arguments.size} for 2)") if arguments.size < 2
 
     a = arguments[0]
     b = arguments[1]

--- a/spec/functions/abs_spec.rb
+++ b/spec/functions/abs_spec.rb
@@ -10,7 +10,7 @@ describe "the abs function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_abs([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_abs([]) }.to( raise_error(ArgumentError))
   end
 
   it "should convert a negative number into a positive" do

--- a/spec/functions/base64_spec.rb
+++ b/spec/functions/base64_spec.rb
@@ -10,9 +10,9 @@ describe "the base64 function" do
   end
 
   it "should raise a ParseError if there are other than 2 arguments" do
-    expect { scope.function_base64([]) }.to(raise_error(Puppet::ParseError))
-    expect { scope.function_base64(["asdf"]) }.to(raise_error(Puppet::ParseError))
-    expect { scope.function_base64(["asdf","moo","cow"]) }.to(raise_error(Puppet::ParseError))
+    expect { scope.function_base64([]) }.to(raise_error(ArgumentError))
+    expect { scope.function_base64(["asdf"]) }.to(raise_error(ArgumentError))
+    expect { scope.function_base64(["asdf","moo","cow"]) }.to(raise_error(ArgumentError))
   end
 
   it "should raise a ParseError if argument 1 isn't 'encode' or 'decode'" do

--- a/spec/functions/bool2num_spec.rb
+++ b/spec/functions/bool2num_spec.rb
@@ -9,7 +9,7 @@ describe "the bool2num function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_bool2num([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_bool2num([]) }.to( raise_error(ArgumentError))
   end
 
   it "should convert true to 1" do

--- a/spec/functions/capitalize_spec.rb
+++ b/spec/functions/capitalize_spec.rb
@@ -9,7 +9,7 @@ describe "the capitalize function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_capitalize([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_capitalize([]) }.to( raise_error(ArgumentError))
   end
 
   it "should capitalize the beginning of a string" do

--- a/spec/functions/chomp_spec.rb
+++ b/spec/functions/chomp_spec.rb
@@ -9,7 +9,7 @@ describe "the chomp function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_chomp([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_chomp([]) }.to( raise_error(ArgumentError))
   end
 
   it "should chomp the end of a string" do

--- a/spec/functions/chop_spec.rb
+++ b/spec/functions/chop_spec.rb
@@ -9,7 +9,7 @@ describe "the chop function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_chop([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_chop([]) }.to( raise_error(ArgumentError))
   end
 
   it "should chop the end of a string" do

--- a/spec/functions/concat_spec.rb
+++ b/spec/functions/concat_spec.rb
@@ -5,7 +5,7 @@ describe "the concat function" do
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should raise a ParseError if the client does not provide two arguments" do
-    expect { scope.function_concat([]) }.to(raise_error(Puppet::ParseError))
+    expect { scope.function_concat([]) }.to(raise_error(ArgumentError))
   end
 
   it "should raise a ParseError if the first parameter is not an array" do

--- a/spec/functions/deep_merge_spec.rb
+++ b/spec/functions/deep_merge_spec.rb
@@ -11,7 +11,7 @@ describe Puppet::Parser::Functions.function(:deep_merge) do
       Puppet[:code] = '$x = deep_merge()'
       expect {
         scope.compiler.compile
-      }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
+      }.to raise_error(Puppet::ParseError)
     end
 
     it "should not compile when 1 argument is passed" do
@@ -19,7 +19,7 @@ describe Puppet::Parser::Functions.function(:deep_merge) do
       Puppet[:code] = "$my_hash={'one' => 1}\n$x = deep_merge($my_hash)"
       expect {
         scope.compiler.compile
-      }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
+      }.to raise_error(Puppet::ParseError)
     end
   end
 

--- a/spec/functions/delete_at_spec.rb
+++ b/spec/functions/delete_at_spec.rb
@@ -9,7 +9,7 @@ describe "the delete_at function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_delete_at([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_delete_at([]) }.to( raise_error(ArgumentError))
   end
 
   it "should delete an item at specified location from an array" do

--- a/spec/functions/delete_spec.rb
+++ b/spec/functions/delete_spec.rb
@@ -9,11 +9,11 @@ describe "the delete function" do
   end
 
   it "should raise a ParseError if there are fewer than 2 arguments" do
-    expect { scope.function_delete([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_delete([]) }.to( raise_error(ArgumentError))
   end
 
   it "should raise a ParseError if there are greater than 2 arguments" do
-    expect { scope.function_delete([[], 'foo', 'bar']) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_delete([[], 'foo', 'bar']) }.to( raise_error(ArgumentError))
   end
 
   it "should raise a TypeError if a number is passed as the first argument" do

--- a/spec/functions/delete_undef_values_spec.rb
+++ b/spec/functions/delete_undef_values_spec.rb
@@ -9,7 +9,7 @@ describe "the delete_undef_values function" do
   end
 
   it "should raise a ParseError if there is less than 1 argument" do
-    expect { scope.function_delete_undef_values([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_delete_undef_values([]) }.to( raise_error(ArgumentError))
   end
 
   it "should raise a ParseError if the argument is not Array nor Hash" do

--- a/spec/functions/delete_values_spec.rb
+++ b/spec/functions/delete_values_spec.rb
@@ -9,11 +9,11 @@ describe "the delete_values function" do
   end
 
   it "should raise a ParseError if there are fewer than 2 arguments" do
-    expect { scope.function_delete_values([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_delete_values([]) }.to( raise_error(ArgumentError))
   end
 
   it "should raise a ParseError if there are greater than 2 arguments" do
-    expect { scope.function_delete_values([[], 'foo', 'bar']) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_delete_values([[], 'foo', 'bar']) }.to( raise_error(ArgumentError))
   end
 
   it "should raise a TypeError if the argument is not a hash" do

--- a/spec/functions/difference_spec.rb
+++ b/spec/functions/difference_spec.rb
@@ -9,7 +9,7 @@ describe "the difference function" do
   end
 
   it "should raise a ParseError if there are fewer than 2 arguments" do
-    expect { scope.function_difference([]) }.to( raise_error(Puppet::ParseError) )
+    expect { scope.function_difference([]) }.to( raise_error(ArgumentError) )
   end
 
   it "should return the difference between two arrays" do

--- a/spec/functions/dirname_spec.rb
+++ b/spec/functions/dirname_spec.rb
@@ -9,7 +9,7 @@ describe "the dirname function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_dirname([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_dirname([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return dirname for an absolute path" do

--- a/spec/functions/downcase_spec.rb
+++ b/spec/functions/downcase_spec.rb
@@ -9,7 +9,7 @@ describe "the downcase function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_downcase([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_downcase([]) }.to( raise_error(ArgumentError))
   end
 
   it "should downcase a string" do

--- a/spec/functions/empty_spec.rb
+++ b/spec/functions/empty_spec.rb
@@ -8,7 +8,7 @@ describe "the empty function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_empty([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_empty([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return a true for an empty string" do

--- a/spec/functions/ensure_packages_spec.rb
+++ b/spec/functions/ensure_packages_spec.rb
@@ -32,7 +32,7 @@ describe 'ensure_packages' do
     it 'fails with no arguments' do
       expect {
         scope.function_ensure_packages([])
-      }.to raise_error(Puppet::ParseError, /0 for 1 or 2/)
+      }.to raise_error(ArgumentError)
     end
 
     it 'accepts an array of values' do

--- a/spec/functions/flatten_spec.rb
+++ b/spec/functions/flatten_spec.rb
@@ -8,11 +8,11 @@ describe "the flatten function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_flatten([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_flatten([]) }.to( raise_error(ArgumentError))
   end
 
   it "should raise a ParseError if there is more than 1 argument" do
-    expect { scope.function_flatten([[], []]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_flatten([[], []]) }.to( raise_error(ArgumentError))
   end
 
   it "should flatten a complex data structure" do

--- a/spec/functions/floor_spec.rb
+++ b/spec/functions/floor_spec.rb
@@ -10,7 +10,7 @@ describe "the floor function" do
   end
 
   it "should raise a ParseError if there is less than 1 argument" do
-    expect { scope.function_floor([]) }.to( raise_error(Puppet::ParseError, /Wrong number of arguments/))
+    expect { scope.function_floor([]) }.to( raise_error(ArgumentError, /Wrong number of arguments/))
   end
 
   it "should should raise a ParseError if input isn't numeric (eg. String)" do
@@ -36,4 +36,3 @@ describe "the floor function" do
     expect(result).to(eq(3))
   end
 end
-

--- a/spec/functions/fqdn_rotate_spec.rb
+++ b/spec/functions/fqdn_rotate_spec.rb
@@ -9,7 +9,7 @@ describe "the fqdn_rotate function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_fqdn_rotate([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_fqdn_rotate([]) }.to( raise_error(ArgumentError))
   end
 
   it "should rotate a string and the result should be the same size" do

--- a/spec/functions/get_module_path_spec.rb
+++ b/spec/functions/get_module_path_spec.rb
@@ -15,8 +15,8 @@ describe Puppet::Parser::Functions.function(:get_module_path) do
   end
 
   it 'should only allow one argument' do
-    expect { scope.function_get_module_path([]) }.to raise_error(Puppet::ParseError, /Wrong number of arguments, expects one/)
-    expect { scope.function_get_module_path(['1','2','3']) }.to raise_error(Puppet::ParseError, /Wrong number of arguments, expects one/)
+    expect { scope.function_get_module_path([]) }.to raise_error(ArgumentError)
+    expect { scope.function_get_module_path(['1','2','3']) }.to raise_error(ArgumentError)
   end
   it 'should raise an exception when the module cannot be found' do
     expect { scope.function_get_module_path(['foo']) }.to raise_error(Puppet::ParseError, /Could not find module/)

--- a/spec/functions/getvar_spec.rb
+++ b/spec/functions/getvar_spec.rb
@@ -10,7 +10,7 @@ describe Puppet::Parser::Functions.function(:getvar) do
       Puppet[:code] = '$foo = getvar()'
       expect {
         scope.compiler.compile
-      }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
+      }.to raise_error(Puppet::ParseError)
     end
 
     it "should not compile when too many arguments are passed" do
@@ -18,7 +18,7 @@ describe Puppet::Parser::Functions.function(:getvar) do
       Puppet[:code] = '$foo = getvar("foo::bar", "baz")'
       expect {
         scope.compiler.compile
-      }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
+      }.to raise_error(Puppet::ParseError)
     end
 
     it "should lookup variables in other namespaces" do

--- a/spec/functions/grep_spec.rb
+++ b/spec/functions/grep_spec.rb
@@ -9,7 +9,7 @@ describe "the grep function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_grep([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_grep([]) }.to( raise_error(ArgumentError))
   end
 
   it "should grep contents from an array" do

--- a/spec/functions/has_key_spec.rb
+++ b/spec/functions/has_key_spec.rb
@@ -10,7 +10,7 @@ describe Puppet::Parser::Functions.function(:has_key) do
       Puppet[:code] = '$x = has_key()'
       expect {
         scope.compiler.compile
-      }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
+      }.to raise_error(Puppet::ParseError)
     end
 
     it "should not compile when 1 argument is passed" do
@@ -18,7 +18,7 @@ describe Puppet::Parser::Functions.function(:has_key) do
       Puppet[:code] = "$x = has_key('foo')"
       expect {
         scope.compiler.compile
-      }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
+      }.to raise_error(Puppet::ParseError)
     end
 
     it "should require the first value to be a Hash" do

--- a/spec/functions/hash_spec.rb
+++ b/spec/functions/hash_spec.rb
@@ -9,7 +9,7 @@ describe "the hash function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_hash([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_hash([]) }.to( raise_error(ArgumentError))
   end
 
   it "should convert an array to a hash" do

--- a/spec/functions/intersection_spec.rb
+++ b/spec/functions/intersection_spec.rb
@@ -9,7 +9,7 @@ describe "the intersection function" do
   end
 
   it "should raise a ParseError if there are fewer than 2 arguments" do
-    expect { scope.function_intersection([]) }.to( raise_error(Puppet::ParseError) )
+    expect { scope.function_intersection([]) }.to( raise_error(ArgumentError) )
   end
 
   it "should return the intersection of two arrays" do

--- a/spec/functions/is_array_spec.rb
+++ b/spec/functions/is_array_spec.rb
@@ -9,7 +9,7 @@ describe "the is_array function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_is_array([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_is_array([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return true if passed an array" do

--- a/spec/functions/is_bool_spec.rb
+++ b/spec/functions/is_bool_spec.rb
@@ -9,7 +9,7 @@ describe "the is_bool function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_is_bool([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_is_bool([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return true if passed a TrueClass" do

--- a/spec/functions/is_domain_name_spec.rb
+++ b/spec/functions/is_domain_name_spec.rb
@@ -9,7 +9,7 @@ describe "the is_domain_name function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_is_domain_name([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_is_domain_name([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return true if a valid short domain name" do

--- a/spec/functions/is_float_spec.rb
+++ b/spec/functions/is_float_spec.rb
@@ -9,7 +9,7 @@ describe "the is_float function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_is_float([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_is_float([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return true if a float" do

--- a/spec/functions/is_hash_spec.rb
+++ b/spec/functions/is_hash_spec.rb
@@ -9,7 +9,7 @@ describe "the is_hash function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_is_hash([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_is_hash([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return true if passed a hash" do

--- a/spec/functions/is_integer_spec.rb
+++ b/spec/functions/is_integer_spec.rb
@@ -9,7 +9,7 @@ describe "the is_integer function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_is_integer([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_is_integer([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return true if an integer" do

--- a/spec/functions/is_ip_address_spec.rb
+++ b/spec/functions/is_ip_address_spec.rb
@@ -9,7 +9,7 @@ describe "the is_ip_address function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_is_ip_address([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_is_ip_address([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return true if an IPv4 address" do

--- a/spec/functions/is_mac_address_spec.rb
+++ b/spec/functions/is_mac_address_spec.rb
@@ -9,7 +9,7 @@ describe "the is_mac_address function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_is_mac_address([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_is_mac_address([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return true if a valid mac address" do

--- a/spec/functions/is_numeric_spec.rb
+++ b/spec/functions/is_numeric_spec.rb
@@ -9,7 +9,7 @@ describe "the is_numeric function" do
   end
 
   it "should raise a ParseError if there is less than 1 argument" do
-    expect { scope.function_is_numeric([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_is_numeric([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return true if an integer" do

--- a/spec/functions/is_string_spec.rb
+++ b/spec/functions/is_string_spec.rb
@@ -9,7 +9,7 @@ describe "the is_string function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_is_string([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_is_string([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return true if a string" do

--- a/spec/functions/join_keys_to_values_spec.rb
+++ b/spec/functions/join_keys_to_values_spec.rb
@@ -9,11 +9,11 @@ describe "the join_keys_to_values function" do
   end
 
   it "should raise a ParseError if there are fewer than two arguments" do
-    expect { scope.function_join_keys_to_values([{}]) }.to raise_error Puppet::ParseError
+    expect { scope.function_join_keys_to_values([{}]) }.to raise_error ArgumentError
   end
 
   it "should raise a ParseError if there are greater than two arguments" do
-    expect { scope.function_join_keys_to_values([{}, 'foo', 'bar']) }.to raise_error Puppet::ParseError
+    expect { scope.function_join_keys_to_values([{}, 'foo', 'bar']) }.to raise_error ArgumentError
   end
 
   it "should raise a TypeError if the first argument is an array" do

--- a/spec/functions/join_spec.rb
+++ b/spec/functions/join_spec.rb
@@ -9,7 +9,7 @@ describe "the join function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_join([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_join([]) }.to( raise_error(ArgumentError))
   end
 
   it "should join an array into a string" do

--- a/spec/functions/keys_spec.rb
+++ b/spec/functions/keys_spec.rb
@@ -9,7 +9,7 @@ describe "the keys function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_keys([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_keys([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return an array of keys when given a hash" do

--- a/spec/functions/loadyaml_spec.rb
+++ b/spec/functions/loadyaml_spec.rb
@@ -11,7 +11,7 @@ describe "the loadyaml function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_loadyaml([]) }.to raise_error(Puppet::ParseError)
+    expect { scope.function_loadyaml([]) }.to raise_error(ArgumentError)
   end
 
   it "should convert YAML file to a data structure" do

--- a/spec/functions/lstrip_spec.rb
+++ b/spec/functions/lstrip_spec.rb
@@ -9,7 +9,7 @@ describe "the lstrip function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_lstrip([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_lstrip([]) }.to( raise_error(ArgumentError))
   end
 
   it "should lstrip a string" do

--- a/spec/functions/max_spec.rb
+++ b/spec/functions/max_spec.rb
@@ -10,7 +10,7 @@ describe "the max function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_max([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_max([]) }.to( raise_error(ArgumentError))
   end
 
   it "should be able to compare strings" do

--- a/spec/functions/member_spec.rb
+++ b/spec/functions/member_spec.rb
@@ -9,7 +9,7 @@ describe "the member function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_member([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_member([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return true if a member is in an array" do

--- a/spec/functions/merge_spec.rb
+++ b/spec/functions/merge_spec.rb
@@ -11,7 +11,7 @@ describe Puppet::Parser::Functions.function(:merge) do
       Puppet[:code] = '$x = merge()'
       expect {
         scope.compiler.compile
-      }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
+      }.to raise_error(Puppet::ParseError)
     end
 
     it "should not compile when 1 argument is passed" do
@@ -19,7 +19,7 @@ describe Puppet::Parser::Functions.function(:merge) do
       Puppet[:code] = "$my_hash={'one' => 1}\n$x = merge($my_hash)"
       expect {
         scope.compiler.compile
-      }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
+      }.to raise_error(Puppet::ParseError)
     end
   end
 

--- a/spec/functions/min_spec.rb
+++ b/spec/functions/min_spec.rb
@@ -10,7 +10,7 @@ describe "the min function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_min([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_min([]) }.to( raise_error(ArgumentError))
   end
 
   it "should be able to compare strings" do

--- a/spec/functions/num2bool_spec.rb
+++ b/spec/functions/num2bool_spec.rb
@@ -9,11 +9,11 @@ describe "the num2bool function" do
   end
 
   it "should raise a ParseError if there are no arguments" do
-    expect { scope.function_num2bool([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_num2bool([]) }.to( raise_error(ArgumentError))
   end
 
   it "should raise a ParseError if there are more than 1 arguments" do
-    expect { scope.function_num2bool(["foo","bar"]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_num2bool(["foo","bar"]) }.to( raise_error(ArgumentError))
   end
 
   it "should raise a ParseError if passed something non-numeric" do

--- a/spec/functions/parsejson_spec.rb
+++ b/spec/functions/parsejson_spec.rb
@@ -9,7 +9,7 @@ describe "the parsejson function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_parsejson([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_parsejson([]) }.to( raise_error(ArgumentError))
   end
 
   it "should convert JSON to a data structure" do

--- a/spec/functions/parseyaml_spec.rb
+++ b/spec/functions/parseyaml_spec.rb
@@ -9,7 +9,7 @@ describe "the parseyaml function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_parseyaml([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_parseyaml([]) }.to( raise_error(ArgumentError))
   end
 
   it "should convert YAML to a data structure" do

--- a/spec/functions/pick_default_spec.rb
+++ b/spec/functions/pick_default_spec.rb
@@ -53,6 +53,6 @@ describe "the pick_default function" do
   end
 
   it 'should error if no values are passed' do
-    expect { scope.function_pick_default([]) }.to raise_error(Puppet::Error, /Must receive at least one argument./)
+    expect { scope.function_pick_default([]) }.to raise_error(ArgumentError)
   end
 end

--- a/spec/functions/pick_spec.rb
+++ b/spec/functions/pick_spec.rb
@@ -29,6 +29,6 @@ describe "the pick function" do
   end
 
   it 'should error if no values are passed' do
-    expect { scope.function_pick([]) }.to( raise_error(Puppet::ParseError, "pick(): must receive at least one non empty value"))
+    expect { scope.function_pick([]) }.to( raise_error(ArgumentError))
   end
 end

--- a/spec/functions/prefix_spec.rb
+++ b/spec/functions/prefix_spec.rb
@@ -5,7 +5,7 @@ describe "the prefix function" do
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "raises a ParseError if there is less than 1 arguments" do
-    expect { scope.function_prefix([]) }.to raise_error(Puppet::ParseError, /number of arguments/)
+    expect { scope.function_prefix([]) }.to raise_error(ArgumentError)
   end
 
   it "raises an error if the first argument is not an array" do
@@ -13,7 +13,6 @@ describe "the prefix function" do
       scope.function_prefix([Object.new])
     }.to raise_error(Puppet::ParseError, /expected first argument to be an Array/)
   end
-
 
   it "raises an error if the second argument is not a string" do
     expect {

--- a/spec/functions/range_spec.rb
+++ b/spec/functions/range_spec.rb
@@ -9,7 +9,7 @@ describe "the range function" do
   end
 
   it "raises a ParseError if there is less than 1 arguments" do
-    expect { scope.function_range([]) }.to raise_error Puppet::ParseError, /Wrong number of arguments.*0 for 1/
+    expect { scope.function_range([]) }.to raise_error ArgumentError
   end
 
   describe 'with a letter range' do

--- a/spec/functions/reject_spec.rb
+++ b/spec/functions/reject_spec.rb
@@ -10,7 +10,7 @@ describe "the reject function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_reject([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_reject([]) }.to( raise_error(ArgumentError))
   end
 
   it "should reject contents from an array" do

--- a/spec/functions/reverse_spec.rb
+++ b/spec/functions/reverse_spec.rb
@@ -9,7 +9,7 @@ describe "the reverse function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_reverse([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_reverse([]) }.to( raise_error(ArgumentError))
   end
 
   it "should reverse a string" do

--- a/spec/functions/rstrip_spec.rb
+++ b/spec/functions/rstrip_spec.rb
@@ -9,7 +9,7 @@ describe "the rstrip function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_rstrip([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_rstrip([]) }.to( raise_error(ArgumentError))
   end
 
   it "should rstrip a string" do

--- a/spec/functions/shuffle_spec.rb
+++ b/spec/functions/shuffle_spec.rb
@@ -9,7 +9,7 @@ describe "the shuffle function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_shuffle([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_shuffle([]) }.to( raise_error(ArgumentError))
   end
 
   it "should shuffle a string and the result should be the same size" do

--- a/spec/functions/size_spec.rb
+++ b/spec/functions/size_spec.rb
@@ -9,7 +9,7 @@ describe "the size function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_size([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_size([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return the size of a string" do

--- a/spec/functions/sort_spec.rb
+++ b/spec/functions/sort_spec.rb
@@ -9,7 +9,7 @@ describe "the sort function" do
   end
 
   it "should raise a ParseError if there is not 1 arguments" do
-    expect { scope.function_sort(['','']) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_sort(['','']) }.to( raise_error(ArgumentError))
   end
 
   it "should sort an array" do

--- a/spec/functions/squeeze_spec.rb
+++ b/spec/functions/squeeze_spec.rb
@@ -9,7 +9,7 @@ describe "the squeeze function" do
   end
 
   it "should raise a ParseError if there is less than 2 arguments" do
-    expect { scope.function_squeeze([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_squeeze([]) }.to( raise_error(ArgumentError))
   end
 
   it "should squeeze a string" do

--- a/spec/functions/str2bool_spec.rb
+++ b/spec/functions/str2bool_spec.rb
@@ -9,7 +9,7 @@ describe "the str2bool function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_str2bool([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_str2bool([]) }.to( raise_error(ArgumentError))
   end
 
   it "should convert string 'true' to true" do

--- a/spec/functions/str2saltedsha512_spec.rb
+++ b/spec/functions/str2saltedsha512_spec.rb
@@ -9,11 +9,11 @@ describe "the str2saltedsha512 function" do
   end
 
   it "should raise a ParseError if there is less than 1 argument" do
-    expect { scope.function_str2saltedsha512([]) }.to( raise_error(Puppet::ParseError) )
+    expect { scope.function_str2saltedsha512([]) }.to( raise_error(ArgumentError) )
   end
 
   it "should raise a ParseError if there is more than 1 argument" do
-    expect { scope.function_str2saltedsha512(['foo', 'bar', 'baz']) }.to( raise_error(Puppet::ParseError) )
+    expect { scope.function_str2saltedsha512(['foo', 'bar', 'baz']) }.to( raise_error(ArgumentError) )
   end
 
   it "should return a salted-sha512 password hash 136 characters in length" do

--- a/spec/functions/strftime_spec.rb
+++ b/spec/functions/strftime_spec.rb
@@ -9,7 +9,7 @@ describe "the strftime function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_strftime([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_strftime([]) }.to( raise_error(ArgumentError))
   end
 
   it "using %s should be higher then when I wrote this test" do

--- a/spec/functions/strip_spec.rb
+++ b/spec/functions/strip_spec.rb
@@ -8,7 +8,7 @@ describe "the strip function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_strip([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_strip([]) }.to( raise_error(ArgumentError))
   end
 
   it "should strip a string" do

--- a/spec/functions/suffix_spec.rb
+++ b/spec/functions/suffix_spec.rb
@@ -5,7 +5,7 @@ describe "the suffix function" do
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "raises a ParseError if there is less than 1 arguments" do
-    expect { scope.function_suffix([]) }.to raise_error(Puppet::ParseError, /number of arguments/)
+    expect { scope.function_suffix([]) }.to raise_error(ArgumentError)
   end
 
   it "raises an error if the first argument is not an array" do

--- a/spec/functions/swapcase_spec.rb
+++ b/spec/functions/swapcase_spec.rb
@@ -9,7 +9,7 @@ describe "the swapcase function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_swapcase([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_swapcase([]) }.to( raise_error(ArgumentError))
   end
 
   it "should swapcase a string" do

--- a/spec/functions/time_spec.rb
+++ b/spec/functions/time_spec.rb
@@ -9,7 +9,7 @@ describe "the time function" do
   end
 
   it "should raise a ParseError if there is more than 2 arguments" do
-    expect { scope.function_time(['','']) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_time(['','']) }.to( raise_error(ArgumentError))
   end
 
   it "should return a number" do

--- a/spec/functions/to_bytes_spec.rb
+++ b/spec/functions/to_bytes_spec.rb
@@ -10,7 +10,7 @@ describe "the to_bytes function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_to_bytes([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_to_bytes([]) }.to( raise_error(ArgumentError))
   end
 
   it "should convert kB to B" do

--- a/spec/functions/type_spec.rb
+++ b/spec/functions/type_spec.rb
@@ -8,7 +8,7 @@ describe "the type function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_type([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_type([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return string when given a string" do

--- a/spec/functions/union_spec.rb
+++ b/spec/functions/union_spec.rb
@@ -9,7 +9,7 @@ describe "the union function" do
   end
 
   it "should raise a ParseError if there are fewer than 2 arguments" do
-    expect { scope.function_union([]) }.to( raise_error(Puppet::ParseError) )
+    expect { scope.function_union([]) }.to( raise_error(ArgumentError) )
   end
 
   it "should join two arrays together" do

--- a/spec/functions/unique_spec.rb
+++ b/spec/functions/unique_spec.rb
@@ -9,7 +9,7 @@ describe "the unique function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_unique([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_unique([]) }.to( raise_error(ArgumentError))
   end
 
   it "should remove duplicate elements in a string" do

--- a/spec/functions/upcase_spec.rb
+++ b/spec/functions/upcase_spec.rb
@@ -9,7 +9,7 @@ describe "the upcase function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_upcase([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_upcase([]) }.to( raise_error(ArgumentError))
   end
 
   it "should upcase a string" do

--- a/spec/functions/uriescape_spec.rb
+++ b/spec/functions/uriescape_spec.rb
@@ -9,7 +9,7 @@ describe "the uriescape function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_uriescape([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_uriescape([]) }.to( raise_error(ArgumentError))
   end
 
   it "should uriescape a string" do

--- a/spec/functions/validate_bool_spec.rb
+++ b/spec/functions/validate_bool_spec.rb
@@ -27,7 +27,7 @@ describe Puppet::Parser::Functions.function(:validate_bool) do
 
     it "should not compile when no arguments are passed" do
       Puppet[:code] = 'validate_bool()'
-      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
+      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError)
     end
 
     it "should compile when multiple boolean arguments are passed" do

--- a/spec/functions/validate_ipv4_address_spec.rb
+++ b/spec/functions/validate_ipv4_address_spec.rb
@@ -58,7 +58,7 @@ describe Puppet::Parser::Functions.function(:validate_ipv4_address) do
       Puppet[:code] = "validate_ipv4_address()"
       expect {
         scope.compiler.compile
-      }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
+      }.to raise_error(Puppet::ParseError)
     end
   end
 end

--- a/spec/functions/validate_ipv6_address_spec.rb
+++ b/spec/functions/validate_ipv6_address_spec.rb
@@ -61,7 +61,7 @@ describe Puppet::Parser::Functions.function(:validate_ipv6_address) do
       Puppet[:code] = "validate_ipv6_address()"
       expect {
         scope.compiler.compile
-      }.to raise_error(Puppet::ParseError, /wrong number of arguments/)
+      }.to raise_error(Puppet::ParseError)
     end
   end
 end

--- a/spec/functions/validate_re_spec.rb
+++ b/spec/functions/validate_re_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::Parser::Functions.function(:validate_re) do
 
       inputs.each do |input|
         it "validate_re(#{input.inspect}) should fail" do
-          expect { subject.call [input] }.to raise_error Puppet::ParseError
+          expect { subject.call [input] }.to raise_error ArgumentError
         end
       end
     end

--- a/spec/functions/validate_slength_spec.rb
+++ b/spec/functions/validate_slength_spec.rb
@@ -11,11 +11,11 @@ describe "the validate_slength function" do
 
   describe "validating the input argument types" do
     it "raises an error if there are less than two arguments" do
-      expect { scope.function_validate_slength([]) }.to raise_error Puppet::ParseError, /Wrong number of arguments/
+      expect { scope.function_validate_slength([]) }.to raise_error ArgumentError
     end
 
     it "raises an error if there are more than three arguments" do
-      expect { scope.function_validate_slength(['input', 1, 2, 3]) }.to raise_error Puppet::ParseError, /Wrong number of arguments/
+      expect { scope.function_validate_slength(['input', 1, 2, 3]) }.to raise_error ArgumentError
     end
 
     it "raises an error if the first argument is not a string" do

--- a/spec/functions/values_at_spec.rb
+++ b/spec/functions/values_at_spec.rb
@@ -9,7 +9,7 @@ describe "the values_at function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_values_at([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_values_at([]) }.to( raise_error(ArgumentError))
   end
 
   it "should raise a ParseError if you try to use a range where stop is greater then start" do

--- a/spec/functions/values_spec.rb
+++ b/spec/functions/values_spec.rb
@@ -9,7 +9,7 @@ describe "the values function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_values([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_values([]) }.to( raise_error(ArgumentError))
   end
 
   it "should return values from a hash" do

--- a/spec/functions/zip_spec.rb
+++ b/spec/functions/zip_spec.rb
@@ -5,7 +5,7 @@ describe "the zip function" do
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_zip([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_zip([]) }.to( raise_error(ArgumentError))
   end
 
   it "should be able to zip an array" do

--- a/spec/unit/puppet/parser/functions/bool2str_spec.rb
+++ b/spec/unit/puppet/parser/functions/bool2str_spec.rb
@@ -9,7 +9,7 @@ describe "the bool2str function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_bool2str([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_bool2str([]) }.to( raise_error(ArgumentError))
   end
 
   it "should convert true to 'true'" do

--- a/spec/unit/puppet/parser/functions/camelcase_spec.rb
+++ b/spec/unit/puppet/parser/functions/camelcase_spec.rb
@@ -9,7 +9,7 @@ describe "the camelcase function" do
   end
 
   it "should raise a ParseError if there is less than 1 arguments" do
-    expect { scope.function_camelcase([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_camelcase([]) }.to( raise_error(ArgumentError))
   end
 
   it "should capitalize the beginning of a normal string" do


### PR DESCRIPTION
Use the function arity feature to remove a lot of boilerplate code from
the functions.

take 2, now that puppet 2.x support is deprecated (again kinda)