### PR TITLE
(PUP-2571) add 'before' functionality to file_line

### DIFF
--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -9,7 +9,9 @@ Puppet::Type.type(:file_line).provide(:ruby) do
     if resource[:match]
       handle_create_with_match
     elsif resource[:after]
-      handle_create_with_after
+      handle_create_with_position :after
+    elsif resource[:before]
+      handle_create_with_position :before
     else
       append_line
     end
@@ -49,29 +51,29 @@ Puppet::Type.type(:file_line).provide(:ruby) do
     end
   end
 
-  def handle_create_with_after
-    regex = Regexp.new(resource[:after])
+  def handle_create_with_position(position)
+    regex = resource[position] ? Regexp.new(resource[position]) : nil
 
     count = lines.count {|l| l.match(regex)}
 
     case count
-    when 1 # find the line to put our line after
+    when 1 # find the line to put our line before/after
       File.open(resource[:path], 'w') do |fh|
         lines.each do |l|
-          fh.puts(l)
+          fh.puts(l) if position == :after
           if regex.match(l) then
             fh.puts(resource[:line])
           end
+          fh.puts(l) if position == :before
         end
       end
     when 0 # append the line to the end of the file
       append_line
     else
-      raise Puppet::Error, "#{count} lines match pattern '#{resource[:after]}' in file '#{resource[:path]}'.  One or no line must match the pattern."
+      raise Puppet::Error, "#{count} lines match pattern '#{resource[position]}' in file '#{resource[:path]}'.  One or no line must match the pattern."
     end
   end
 
-  ##
   # append the line to the file.
   #
   # @api private

--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -46,6 +46,10 @@ Puppet::Type.newtype(:file_line) do
     desc 'An optional value used to specify the line after which we will add any new lines. (Existing lines are added in place)'
   end
 
+  newparam(:before) do
+    desc 'An optional value used to specify the line before which we will add any new lines. (Existing lines are added in place)'
+  end
+
   newparam(:line) do
     desc 'The line to be appended to the file located by the path parameter.'
   end

--- a/spec/unit/puppet/type/file_line_spec.rb
+++ b/spec/unit/puppet/type/file_line_spec.rb
@@ -15,6 +15,14 @@ describe Puppet::Type.type(:file_line) do
     file_line[:match] = '^foo.*$'
     file_line[:match].should == '^foo.*$'
   end
+  it 'should accept an after regex' do
+    file_line[:after] = '^foo.*$'
+    file_line[:after].should == '^foo.*$'
+  end
+  it 'should accept a before regex' do
+    file_line[:before] = '^foo.*$'
+    file_line[:before].should == '^foo.*$'
+  end
   it 'should not accept a match regex that does not match the specified line' do
     expect {
       Puppet::Type.type(:file_line).new(


### PR DESCRIPTION
file_line supports adding lines after a match, but there are use cases when
having "before" would be useful. For example, in Debian-based OS's, the last
line of /etc/rc.local is "exit 0" it's an incredible pain to deal with
that scenario today.

This commit adds a 'before' parameter to the file_line type, and implements
it for the ruby provider.
