### PR TITLE
Remove matching lines in absent file_line

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -314,8 +314,8 @@ the type and parameters specified if it doesn't already exist.
 
 file_line
 ---------
-This resource ensures that a given line is contained within a file. You can also use 
-"match" to replace existing lines.
+This resource ensures that a given line is present or absent within a file. You
+can also use "match" to replace or remove existing lines.
 
 *Examples:*
 

--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -1,8 +1,9 @@
 Puppet::Type.newtype(:file_line) do
 
   desc <<-EOT
-    Ensures that a given line is contained within a file.  The implementation
-    matches the full line, including whitespace at the beginning and end.  If
+    Ensures that a given line is present or absent within a file.  The implementation
+    matches the full line, including whitespace at the beginning and end. If a 'match'
+    parameter was given, Puppet will change (or remove) the given line. If
     the line is not contained in the given file, Puppet will add the line to
     ensure the desired state.  Multiple resources may be declared to manage
     multiple lines in the same file.

--- a/spec/unit/puppet/provider/file_line/ruby_spec.rb
+++ b/spec/unit/puppet/provider/file_line/ruby_spec.rb
@@ -222,4 +222,42 @@ describe provider_class do
       File.read(@tmpfile).should eql("foo1\nfoo2\n")
     end
   end
+
+  context "when removing matching" do
+    before :each do
+      # TODO: these should be ported over to use the PuppetLabs spec_helper
+      #  file fixtures once the following pull request has been merged:
+      # https://github.com/puppetlabs/puppetlabs-stdlib/pull/73/files
+      tmp = Tempfile.new('tmp')
+      @tmpfile = tmp.path
+      tmp.close!
+      @resource = Puppet::Type::File_line.new(
+        {:name => 'foo', :path => @tmpfile, :line => 'foobar', :match => '^foo(bar)?$', :ensure => 'absent' }
+      )
+      @provider = provider_class.new(@resource)
+    end
+    it 'should remove the match if it exists' do
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write("foo1\nfoo\nfoo2")
+      end
+      @provider.destroy
+      File.read(@tmpfile).should eql("foo1\nfoo2")
+    end
+
+    it 'should remove the match without touching the last new line' do
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write("foo1\nfoo\nfoo2\n")
+      end
+      @provider.destroy
+      File.read(@tmpfile).should eql("foo1\nfoo2\n")
+    end
+
+    it 'should remove any occurence of the match' do
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write("foo1\nfoo\nfoo2\nfoo\nfoo")
+      end
+      @provider.destroy
+      File.read(@tmpfile).should eql("foo1\nfoo2\n")
+    end
+  end
 end


### PR DESCRIPTION
Use the pattern specified in 'match' when using ensure => absent to
decide which lines should be removed.

Useful for something like:

```puppet
if empty($partitions) {
  $ensure = 'absent'
} else {
  $partitions_arg = join(prefix($partitions, '-p'), ' ')
  $ensure = 'present'
}

file_line{'check_disk':
  ensure => $ensure,
  patch  => '/etc/nagios/nrpe.cfg',
  line   => "command[check_disk]=../nagios/plugins/check_disk -w10 -c5 $partitions_arg",
  match  => '^command\[check_disk\]='
}
```