### PR TITLE
Add private() function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -725,6 +725,27 @@ Will return: ['pa','pb','pc']
 
 - *Type*: rvalue
 
+
+private
+-------
+This function sets the current class or definition as private.
+Calling the class or definition from outside the current module will fail.
+
+*Examples:*
+
+    private()
+
+called in class `foo::bar` will output the following message if class is called
+from outside module `foo`:
+
+    Class foo::bar is private
+
+You can specify the error message you want to use as a parameter:
+
+    private("You're not supposed to do that!")
+
+- *Type*: statement
+
 range
 -----
 When given range in the form of (start, stop) it will extrapolate a range as

--- a/lib/puppet/parser/functions/private.rb
+++ b/lib/puppet/parser/functions/private.rb
@@ -1,0 +1,29 @@
+#
+# private.rb
+#
+
+module Puppet::Parser::Functions
+  newfunction(:private, :doc => <<-'EOS'
+    Sets the current class or definition as private.
+    Calling the class or definition from outside the current module will fail.
+    EOS
+  ) do |args|
+
+    raise(Puppet::ParseError, "private(): Wrong number of arguments "+
+      "given (#{args.size}}) for 0 or 1)") if args.size > 1
+
+    scope = self
+    if scope.lookupvar('module_name') != scope.lookupvar('caller_module_name')
+      message = nil
+      if args[0] and args[0].is_a? String
+        message = args[0]
+      else
+        manifest_name = scope.source.name
+        manifest_type = scope.source.type
+        message = (manifest_type.to_s == 'hostclass') ? 'Class' : 'Definition'
+        message += " #{manifest_name} is private"
+      end
+      raise(Puppet::ParseError, message)
+    end
+  end
+end

--- a/spec/functions/private_spec.rb
+++ b/spec/functions/private_spec.rb
@@ -1,0 +1,55 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe Puppet::Parser::Functions.function(:private) do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  subject do
+    function_name = Puppet::Parser::Functions.function(:private)
+    scope.method(function_name)
+  end
+
+  context "when called from inside module" do
+    it "should not fail" do
+      scope.expects(:lookupvar).with('module_name').returns('foo')
+      scope.expects(:lookupvar).with('caller_module_name').returns('foo')
+      expect {
+        subject.call []
+      }.not_to raise_error
+    end
+  end
+
+  context "with an explicit failure message" do
+    it "prints the failure message on error" do
+      scope.expects(:lookupvar).with('module_name').returns('foo')
+      scope.expects(:lookupvar).with('caller_module_name').returns('bar')
+      expect {
+        subject.call ['failure message!']
+      }.to raise_error Puppet::ParseError, /failure message!/
+    end
+  end
+
+  context "when called from private class" do
+    it "should fail with a class error message" do
+      scope.expects(:lookupvar).with('module_name').returns('foo')
+      scope.expects(:lookupvar).with('caller_module_name').returns('bar')
+      scope.source.expects(:name).returns('foo::baz')
+      scope.source.expects(:type).returns('hostclass')
+      expect {
+        subject.call []
+      }.to raise_error Puppet::ParseError, /Class foo::baz is private/
+    end
+  end
+
+  context "when called from private definition" do
+    it "should fail with a class error message" do
+      scope.expects(:lookupvar).with('module_name').returns('foo')
+      scope.expects(:lookupvar).with('caller_module_name').returns('bar')
+      scope.source.expects(:name).returns('foo::baz')
+      scope.source.expects(:type).returns('definition')
+      expect {
+        subject.call []
+      }.to raise_error Puppet::ParseError, /Definition foo::baz is private/
+    end
+  end
+end


### PR DESCRIPTION
## private

This function sets the current class or definition as private.
Calling the class or definition from outside the current module will fail.

_Examples:_

```
private()
```

called in class `foo::bar` will output the following message if class is called
from outside module `foo`:

```
Class foo::bar is private
```

You can specify the error message you want to use as a parameter:

```
private("You're not supposed to do that!")
```
- _Type_: statement
