### PR TITLE
Adding forgotten documentation for deep_merge()

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -162,6 +162,23 @@ If called with only an array it counts the number of elements that are not nil/u
 
 - *Type*: rvalue
 
+deep_merge
+----------
+Recursively merges two or more hashes together and returns the resulting hash.
+
+For example:
+
+    $hash1 = {'one' => 1, 'two' => 2, 'three' => { 'four' => 4 } }
+    $hash2 = {'two' => 'dos', 'three' => { 'five' => 5 } }
+    $merged_hash = deep_merge($hash1, $hash2)
+    # The resulting hash is equivalent to:
+    # $merged_hash = { 'one' => 1, 'two' => 'dos', 'three' => { 'four' => 4, 'five' => 5 } }
+
+When there is a duplicate key that is a hash, they are recursively merged.
+When there is a duplicate key that is not a hash, the key in the rightmost hash will "win."
+
+- *Type*: rvalue
+
 defined_with_params
 -------------------
 Takes a resource reference and an optional hash of attributes.


### PR DESCRIPTION
This function was self-documented but it was not put in the README, hence this PR. 
