### PR TITLE
Increase resilience if lookup var comes back with nil object

### DIFF
--- a/lib/puppet/parser/functions/has_interface_with.rb
+++ b/lib/puppet/parser/functions/has_interface_with.rb
@@ -25,7 +25,7 @@ has_interface_with("lo")                        => true
     interfaces = lookupvar('interfaces')
 
     # If we do not have any interfaces, then there are no requested attributes
-    return false if (interfaces == :undefined)
+    return false if (interfaces == :undefined || interfaces.nil?)
 
     interfaces = interfaces.split(',')
 


### PR DESCRIPTION
This blows up on Windows 2003 as no interfaces show up in Facter.

has_interface.pp

```
$a = '192.168.0.15'
$o = has_interface_with('ipaddress', $a)
notice(inline_template('has_interface_with is <%= @o.inspect %>'))
```

puppet apply yields

```
Error: undefined method `split' for nil:NilClass at C:/has_interface.pp:2 on node xran6l3uabwistu.mydomain.com
Wrapped exception:
undefined method `split' for nil:NilClass
Error: undefined method `split' for nil:NilClass at C:/has_interface.pp:2 on node xran6l3uabwistu.mydomain.com
```
