### PR TITLE
AIX has no facter network support

### DIFF
--- a/spec/acceptance/has_interface_with_spec.rb
+++ b/spec/acceptance/has_interface_with_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby -S rspec
 require 'spec_helper_acceptance'
 
-describe 'has_interface_with function', :unless => ((UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem'))) or (fact('osfamily') == 'windows')) do
+describe 'has_interface_with function', :unless => ((UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem'))) or (fact('osfamily') == 'windows') or (fact('osfamily') == 'AIX')) do
   describe 'success' do
     it 'has_interface_with existing ipaddress' do
       pp = <<-EOS

--- a/spec/acceptance/has_ip_address_spec.rb
+++ b/spec/acceptance/has_ip_address_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby -S rspec
 require 'spec_helper_acceptance'
 
-describe 'has_ip_address function', :unless => ((UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem'))) or (fact('osfamily') == 'windows')) do
+describe 'has_ip_address function', :unless => ((UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem'))) or (fact('osfamily') == 'windows') or (fact('osfamily') == 'AIX')) do
   describe 'success' do
     it 'has_ip_address existing ipaddress' do
       pp = <<-EOS

--- a/spec/acceptance/has_ip_network_spec.rb
+++ b/spec/acceptance/has_ip_network_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby -S rspec
 require 'spec_helper_acceptance'
 
-describe 'has_ip_network function', :unless => ((UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem'))) or (fact('osfamily') == 'windows')) do
+describe 'has_ip_network function', :unless => ((UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem'))) or (fact('osfamily') == 'windows') or (fact('osfamily') == 'AIX')) do
   describe 'success' do
     it 'has_ip_network existing ipaddress' do
       pp = <<-EOS


### PR DESCRIPTION
These functions take advantage of IP fact information and AIX does not
appear to support dynamic interface detection in facter.
