### PR TITLE
Release 4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+##2014-07-14 - Supported Release 4.3.1
+### Summary
+This supported release updates the metadata.json to work around upgrade behavior of the PMT.
+
+#### Bugfixes
+- Synchronize metadata.json with PMT-generated metadata to pass checksums
+
 ##2014-06-27 - Supported Release 4.3.0
 ### Summary
 This release is the first supported release of the stdlib 4 series. It remains

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-stdlib",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "author": "puppetlabs",
   "summary": "Puppet Module Standard Library",
   "license": "Apache 2.0",


### PR DESCRIPTION
Summary
This supported release updates the metadata.json to work around upgrade
behavior of the PMT.

Bugfixes
- Synchronize metadata.json with PMT-generated metadata to pass
  checksums
