### PR TITLE
(MODULES-1221) Add file_line autorequire documentation

### DIFF
--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -21,6 +21,9 @@ Puppet::Type.newtype(:file_line) do
     In this example, Puppet will ensure both of the specified lines are
     contained in the file /etc/sudoers.
 
+    **Autorequires:** If Puppet is managing the file that will contain the line
+    being managed, the file_line resource will autorequire that file.
+
   EOT
 
   ensurable do


### PR DESCRIPTION
This commit adds additional documentation to the file_line resource
explaining how it will autorequire file resources when present.
