### PR TITLE
Add string_rand() function

### DIFF
--- a/lib/puppet/parser/functions/string_rand.rb
+++ b/lib/puppet/parser/functions/string_rand.rb
@@ -1,0 +1,16 @@
+require 'digest/md5'
+
+Puppet::Parser::Functions::newfunction(:string_rand, :arity => -2, :type => :rvalue, :doc =>
+  "Usage: `string_rand(MAX, SEED)`. MAX is required and must be a positive
+  integer; SEED is also required and can be any number or string.
+
+  Generates a random whole number greater than or equal to 0 and less than MAX,
+  using the value of SEED for repeatable randomness.
+
+  This function can be useful to generate a consistent number that will be used
+  across multiple nodes that may be part of a similar role/service. For example
+  a ID used to identify a clustered service.") do |args|
+    max = args.shift.to_i
+    seed = Digest::MD5.hexdigest(args.shift).hex
+    Puppet::Util.deterministic_rand(seed,max)
+end

--- a/spec/functions/string_rand_spec.rb
+++ b/spec/functions/string_rand_spec.rb
@@ -1,0 +1,26 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+
+describe "the string_rand function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    expect(Puppet::Parser::Functions.function("string_rand")).to eq("function_string_rand")
+  end
+  
+  it "provides a random number strictly less than the given max" do
+    scope.function_string_rand([3,'foo']).should satisfy {|n| n.to_i < 3 }
+  end
+
+  it "provides the same 'random' value on subsequent calls for the same string" do
+    scope.function_string_rand([3,'foo']).should eql(scope.function_string_rand([3,'foo']))
+  end
+
+  it "should return different sequences of value for different string" do
+    val1 = scope.function_string_rand([1000000000, 'this_foo'])
+    val2 = scope.function_string_rand([1000000000, 'that_foo'])
+
+    val1.should_not eql(val2)
+  end
+
+end


### PR DESCRIPTION
`string_rand()` behaves mostly like `fqdn_rand(`). The difference being the
`fqdn` is not used as a seed to generate a random number, rather a string
(or integer) argument is used.

Since `fqdn_rand()` provides a random number for a single host, this function can be useful in providing a random number that can be used as an identifier for clustered services (across multiple hosts).