### PR TITLE
Remove simplecov

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ end
 
 require 'puppet'
 require 'rspec-puppet'
-require 'simplecov'
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'puppet_spec/verbose'
 require 'puppet_spec/files'
@@ -20,10 +19,6 @@ require 'puppet_spec/database'
 require 'monkey_patches/alias_should_to_must'
 require 'mocha/setup'
 
-
-SimpleCov.start do
-  add_filter "/spec/"
-end
 
 
 RSpec.configure do |config|


### PR DESCRIPTION
simplecov 0.9 dropped ruby 1.8 support, and stdlib is one of the oddball
modules that uses it. So we could probably just remove it and be okay.
