### PR TITLE
URI.escape for the array case was incorrect.

### DIFF
--- a/lib/puppet/parser/functions/uriescape.rb
+++ b/lib/puppet/parser/functions/uriescape.rb
@@ -23,7 +23,7 @@ module Puppet::Parser::Functions
 
     if value.is_a?(Array)
       # Numbers in Puppet are often string-encoded which is troublesome ...
-      result = value.collect { |i| i.is_a?(String) ? URI.escape(i,unsafe) : i }
+      result = value.collect { |i| i.is_a?(String) ? URI.escape(i) : i }
     else
       result = URI.escape(value)
     end

--- a/spec/functions/uriescape_spec.rb
+++ b/spec/functions/uriescape_spec.rb
@@ -17,6 +17,13 @@ describe "the uriescape function" do
     expect(result).to(eq(':/?%23[]@!$&\'()*+,;=%20%22%7B%7D'))
   end
 
+  it "should uriescape an array of strings, while not touching up nonstrings" do
+    teststring = ":/?#[]@!$&'()*+,;= \"{}"
+    expectstring = ':/?%23[]@!$&\'()*+,;=%20%22%7B%7D'
+    result = scope.function_uriescape([[teststring, teststring, 1]])
+    expect(result).to(eq([expectstring, expectstring, 1]))
+  end
+
   it "should do nothing if a string is already safe" do
     result = scope.function_uriescape(["ABCdef"])
     expect(result).to(eq('ABCdef'))


### PR DESCRIPTION
The previous commit to uriescape() changed the implementation to use the ruby default escape list for URI.escape(), but did not change the call triggered when uriescape() was called on an array, triggering ruby errors.