### PR TITLE
Add support for using both match and after

### DIFF
--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:file_line).provide(:ruby) do
     end
     if (match_count == 0) and resource[:after]
       handle_create_with_after
-    elsif
+    else
       File.open(resource[:path], 'w') do |fh|
         lines.each do |l|
           fh.puts(regex.match(l) ? resource[:line] : l)

--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -38,13 +38,17 @@ Puppet::Type.type(:file_line).provide(:ruby) do
     if match_count > 1 && resource[:multiple].to_s != 'true'
      raise Puppet::Error, "More than one line in file '#{resource[:path]}' matches pattern '#{resource[:match]}'"
     end
-    File.open(resource[:path], 'w') do |fh|
-      lines.each do |l|
-        fh.puts(regex.match(l) ? resource[:line] : l)
-      end
+    if (match_count == 0) and resource[:after]
+      handle_create_with_after
+    elsif
+      File.open(resource[:path], 'w') do |fh|
+        lines.each do |l|
+          fh.puts(regex.match(l) ? resource[:line] : l)
+        end
 
-      if (match_count == 0)
-        fh.puts(resource[:line])
+        if (match_count == 0)
+          fh.puts(resource[:line])
+        end
       end
     end
   end


### PR DESCRIPTION
This is for "file_line" provider.
Previously we were running "match" handler ignoring "after" param.
This patch enables us to use both "match" and "after" resource
parameters: if "match" is found, then we simply replace the line,
if it's not found and we have "after", then we add line after the
specified pattern. If "match" and "after" not found, then we just
append the line.