### PR TITLE
jstringtohash function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -604,6 +604,24 @@ Would result in: ["a is 1","b is 2"]
 
 - *Type*: rvalue
 
+jstringtohash
+---------
+This function accepts a Ruby hash as a string and converts into the correct Puppet
+structure.
+
+*Examples:*
+
+    $str = '{
+      "foo"   => "bar",
+      "hello" => "world"
+    }'
+    $hash = jstringtohash($str)
+    $hash['hello']
+
+Would result in: 'world'
+
+- *Type*: rvalue
+
 keys
 ----
 Returns the keys of a hash as an array.

--- a/lib/puppet/parser/functions/jstringtohash.rb
+++ b/lib/puppet/parser/functions/jstringtohash.rb
@@ -1,0 +1,27 @@
+#
+# jstringtohash.rb
+#
+
+module Puppet::Parser::Functions
+  newfunction(:jstringtohash, :type => :rvalue, :doc => <<-EOS
+Take a json string object and convert to a hash.
+    EOS
+  ) do |arguments|
+
+    if (arguments.size != 1) then
+      raise(Puppet::ParseError, "jstringtohash(): Wrong number of arguments "+
+        "given #{arguments.size} for 1")
+    end
+
+    value = arguments[0]
+
+    #Puppet::Parser::Functions.function('regsubst')
+
+    if ! value.is_a?(String) then
+      raise(Puppet::ParseError, "jstringtohash(): Supply a string only")
+    else
+      function_parsejson([function_regsubst([value, '=>', ':', 'G'])])
+    end
+
+  end
+end

--- a/lib/puppet/parser/functions/jstringtohash.rb
+++ b/lib/puppet/parser/functions/jstringtohash.rb
@@ -4,7 +4,7 @@
 
 module Puppet::Parser::Functions
   newfunction(:jstringtohash, :type => :rvalue, :doc => <<-EOS
-Take a json string object and convert to a hash.
+Take a json string object and converts to a hash.
     EOS
   ) do |arguments|
 

--- a/lib/puppet/parser/functions/jstringtohash.rb
+++ b/lib/puppet/parser/functions/jstringtohash.rb
@@ -15,8 +15,6 @@ Take a json string object and converts to a hash.
 
     value = arguments[0]
 
-    #Puppet::Parser::Functions.function('regsubst')
-
     if ! value.is_a?(String) then
       raise(Puppet::ParseError, "jstringtohash(): Supply a string only")
     else


### PR DESCRIPTION
Before structured facts are adopted, some facts in EC2 are returning "JSON" objects which are actually Strings.  This function allows you to safely convert them into actual data objects.