### PR TITLE
Make :after more usefull

### DIFF
--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -38,13 +38,17 @@ Puppet::Type.type(:file_line).provide(:ruby) do
     if match_count > 1 && resource[:multiple].to_s != 'true'
      raise Puppet::Error, "More than one line in file '#{resource[:path]}' matches pattern '#{resource[:match]}'"
     end
-    File.open(resource[:path], 'w') do |fh|
-      lines.each do |l|
-        fh.puts(regex.match(l) ? resource[:line] : l)
-      end
-
-      if (match_count == 0)
-        fh.puts(resource[:line])
+    if (match_count == 0 and resource[:after])
+      handle_create_with_after
+    else
+      File.open(resource[:path], 'w') do |fh|
+        lines.each do |l|
+          fh.puts(regex.match(l) ? resource[:line] : l)
+        end
+  
+        if (match_count == 0)
+          fh.puts(resource[:line])
+        end
       end
     end
   end


### PR DESCRIPTION
If :match and :after is defined, only the :match value is honored which leads to appends at the end of the file even if an appropriate location was defined via :after. This change adds an if to switch over to the :after method for insertion if no match was found but an :after is defined.