### PR TITLE
Added dump_args statement function for debugging puppet code

### DIFF
--- a/lib/puppet/parser/functions/dump_args.rb
+++ b/lib/puppet/parser/functions/dump_args.rb
@@ -1,0 +1,17 @@
+require 'json'
+require 'puppet/parser/functions'
+
+module Puppet::Parser::Functions
+  newfunction(:dump_args, :type => :statement,:doc => <<-EOS
+     dump_args - prints the args to STDOUT in Pretty JSON format.
+
+     Useful for debugging purposes only. Ideally you would use this in
+     conjunction with a rspec-puppet unit test.  Otherwise the output will
+     be shown during a puppet run when verbose/debug options are enabled.
+
+  EOS
+  )  do |args|
+    puts JSON.pretty_generate(args)
+  end
+
+end

--- a/spec/unit/puppet/parser/functions/dump_args_spec.rb
+++ b/spec/unit/puppet/parser/functions/dump_args_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+require 'json'
+describe "dump_args" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    Puppet::Parser::Functions.function("dump_args").should == "function_dump_args"
+  end
+
+end


### PR DESCRIPTION
This adds a new function that outputs the variables to STDOUT.  Its pretty dead simple and when used with an rspec test it can decrease debug time greatly. The only other option is to use a bunch of notify resources which to me is not as fast and does not display the variables correctly when you have hashes and arrays in your variables.  If you think this is not useful imagine storing a large hash in hiera and wanting to know why your custom parser is blowing up on your data and the notify statement does a poor job of displaying your 50 line data hash.  Its really nice to see whats in your puppet variables and this helps immensely.

Another use case is trying to find out why create_resources isn't working as expected because your data being passed in is all wrong.

Basically it works like this:

puppet code below:
```puppet
$var1 = 'foo'
$var2 = ['bar']
$var3 = {'foo' => 'bar'}
dump_args($var1, $var2, $var3)

```
yields the following in STDOUT

```json
[
  "foo",
  [
    "bar"
  ],
  {
    "foo": "bar"
  }
]
```