### PR TITLE
ensure_resource: be more verbose in debug mode

### DIFF
--- a/lib/puppet/parser/functions/ensure_resource.rb
+++ b/lib/puppet/parser/functions/ensure_resource.rb
@@ -36,8 +36,9 @@ ENDOFDOC
   items.each do |item|
     Puppet::Parser::Functions.function(:defined_with_params)
     if function_defined_with_params(["#{type}[#{item}]", params])
-      Puppet.debug("Resource #{type}[#{item}] not created because it already exists")
+      Puppet.debug("Resource #{type}[#{item}] with params #{params} not created because it already exists")
     else
+      Puppet.debug("Create new resource #{type}[#{item}] with params #{params}")
       Puppet::Parser::Functions.function(:create_resources)
       function_create_resources([type.capitalize, { item => params }])
     end


### PR DESCRIPTION
helps discovering duplication issues, especially when figthing boolean vs. string arguments