### PR TITLE
Add an append_file_content function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -80,6 +80,8 @@ If you want to use a standardized set of run stages for Puppet, `include stdlib`
 
 * `any2array`: This converts any object to an array containing that object. Empty argument lists are converted to an empty array. Arrays are left untouched. Hashes are converted to arrays of alternating keys and values. *Type*: rvalue
 
+* `append_file_content`: Add content to a file resource. This allows to generate concatenated files on the master side, without managing multiple file resources.
+
 * `base64`: Converts a string to and from base64 encoding.
 Requires an action ('encode', 'decode') and either a plain or base64-encoded
 string. *Type*: rvalue

--- a/lib/puppet/parser/functions/append_file_content.rb
+++ b/lib/puppet/parser/functions/append_file_content.rb
@@ -1,3 +1,7 @@
+class Puppet::Parser::Resource
+  attr_accessor :concat_fragments
+end
+
 module Puppet::Parser::Functions
   newfunction(:append_file_content, :doc => <<-'ENDHEREDOC') do |args|
     Add content to a file resource.
@@ -44,17 +48,17 @@ module Puppet::Parser::Functions
 
     # Find resource
     if resource = findresource("File[#{file}]")
-      @append_content_data[file] ||= [{
+      resource.concat_fragments ||= [{
         :content => resource[:content],
         :order   => '00',
       }]
 
-      @append_content_data[file] << {
+      resource.concat_fragments << {
         :content => content,
         :order   => order,
       }
 
-      resource[:content] = @append_content_data[file].sort_by { |c|
+      resource[:content] = resource.concat_fragments.sort_by { |c|
         [c[:order], c[:content]]
       }.map { |c| c[:content] }.join
     else

--- a/lib/puppet/parser/functions/append_file_content.rb
+++ b/lib/puppet/parser/functions/append_file_content.rb
@@ -1,0 +1,64 @@
+module Puppet::Parser::Functions
+  newfunction(:append_file_content, :doc => <<-'ENDHEREDOC') do |args|
+    Add content to a file resource.
+
+    This allows to generate concatenated files on the master side,
+    without managing multiple file resources.
+
+    The first argument is the file path. You are responsible for
+    creating the file resource yourself prior to calling the
+    function. This way, you can finely control the file's
+    parameters.
+
+    The second argument is the content to be added to the file.
+
+    The third (optional) argument is the order, specifying the
+    position in which the content should be added. The default
+    order is '10'. If you specified a content in the original
+    file resource, this content is kept with order '00'
+
+    Examples:
+
+        file { '/tmp/target':
+          content => "Orig content\n",
+        }
+
+        append_file_content('/tmp/target', "hello, ")
+        append_file_content('/tmp/target', "world\n")
+        append_file_content('/tmp/target', "This is a multi
+        line statement
+        ", '01')
+        append_file_content('/tmp/target', template('foobar/example.erb'), '05')
+
+    ENDHEREDOC
+
+    file, content, order = args
+    order ||= '10'
+
+    function_validate_absolute_path([file])
+    function_validate_string([content])
+    function_validate_string([order])
+    function_validate_re([order, '^\d{2}$', "order must be a two-digit number, not #{order}"])
+
+    @append_content_data ||= {}
+
+    # Find resource
+    if resource = findresource("File[#{file}]")
+      @append_content_data[file] ||= [{
+        :content => resource[:content],
+        :order   => '00',
+      }]
+
+      @append_content_data[file] << {
+        :content => content,
+        :order   => order,
+      }
+
+      resource[:content] = @append_content_data[file].sort_by { |c|
+        [c[:order], c[:content]]
+      }.map { |c| c[:content] }.join
+    else
+      raise Puppet::Error, "You must create a file resource for #{file} before calling this function"
+    end
+  end
+end

--- a/spec/functions/append_file_content_spec.rb
+++ b/spec/functions/append_file_content_spec.rb
@@ -1,0 +1,121 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+require 'rspec-puppet'
+require 'puppet_spec/compiler'
+
+describe 'append_file_content' do
+  include PuppetSpec::Compiler
+
+  context 'when testing signature' do
+    let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+    context 'when file resource does not exist yet' do
+      it 'should fail' do
+        expect {
+          scope.function_append_file_content(['/tmp/foo', 'content'])
+        }.to raise_error(Puppet::Error, /You must create a file resource for/)
+      end
+    end
+
+    context 'when file is not an absolute path' do
+      it 'should fail' do
+        expect {
+          scope.function_append_file_content(['foobar', 'content'])
+        }.to raise_error(Puppet::Error, /"foobar" is not an absolute path/)
+      end
+    end
+
+    context 'when content is not a string' do
+      it 'should fail' do
+        expect {
+          scope.function_append_file_content(['/tmp/foo', ['content']])
+        }.to raise_error(Puppet::Error, /\["content"\] is not a string/)
+      end
+    end
+
+    context 'when order is not a number' do
+      it 'should fail' do
+        expect {
+          scope.function_append_file_content(['/tmp/foo', 'content', '10e'])
+        }.to raise_error(Puppet::Error, /order must be a two-digit number/)
+      end
+    end
+  end
+
+  context 'when testing functionality' do
+    before :all do
+      Puppet::Parser::Functions.autoloader.loadall
+      Puppet::Parser::Functions.function(:append_file_content)
+    end
+
+    let :node     do Puppet::Node.new('localhost') end
+    let :compiler do Puppet::Parser::Compiler.new(node) end
+    let :scope    do Puppet::Parser::Scope.new(compiler) end
+
+
+    context 'when adding content without initial content' do
+      let :catalog do
+        compile_to_catalog(<<-EOS
+        file { "/tmp/foo": }
+        append_file_content('/tmp/foo', 'hello')
+                           EOS
+                          )
+      end
+
+      it 'should contain the new content' do
+        expect(catalog.resource(:file, '/tmp/foo')[:content]).to eq('hello')
+      end
+    end
+
+    context 'when adding content with initial content' do
+      let :catalog do
+        compile_to_catalog(<<-EOS
+        file { "/tmp/foo":
+          content => "Hello, ",
+        }
+        append_file_content('/tmp/foo', 'World!')
+                           EOS
+                          )
+      end
+
+      it 'should add the new content' do
+        expect(catalog.resource(:file, '/tmp/foo')[:content]).to eq('Hello, World!')
+      end
+    end
+
+    context 'when adding content with order' do
+      let :catalog do
+        compile_to_catalog(<<-EOS
+        file { "/tmp/foo":
+          content => "Hello, ",
+        }
+        append_file_content('/tmp/foo', "The end is near")
+        append_file_content('/tmp/foo', 'World! ', '05')
+                           EOS
+                          )
+      end
+
+      it 'should position content properly' do
+        expect(catalog.resource(:file, '/tmp/foo')[:content]).to eq('Hello, World! The end is near')
+      end
+    end
+
+    context 'when adding content with same order' do
+      let :catalog do
+        compile_to_catalog(<<-EOS
+        file { "/tmp/foo":
+          content => "Hello, ",
+        }
+        append_file_content('/tmp/foo', 'The end is near', '50')
+        append_file_content('/tmp/foo', 'World! ', '05')
+        append_file_content('/tmp/foo', 'Here or there? ', '50')
+                           EOS
+                          )
+      end
+
+      it 'should position content alphabetically' do
+        expect(catalog.resource(:file, '/tmp/foo')[:content]).to eq('Hello, World! Here or there? The end is near')
+      end
+    end
+  end
+end

--- a/spec/functions/append_file_content_spec.rb
+++ b/spec/functions/append_file_content_spec.rb
@@ -117,5 +117,27 @@ describe 'append_file_content' do
         expect(catalog.resource(:file, '/tmp/foo')[:content]).to eq('Hello, World! Here or there? The end is near')
       end
     end
+
+    context 'when calling the function from different scopes' do
+      let :catalog do
+        compile_to_catalog(<<-EOS
+        class world {
+          append_file_content('/tmp/foo', 'World! ', '05')
+        }
+
+        file { "/tmp/foo":
+          content => "Hello, ",
+        }
+        append_file_content('/tmp/foo', 'The end is near', '50')
+        append_file_content('/tmp/foo', 'Here or there? ', '50')
+        include ::world
+                           EOS
+                          )
+      end
+
+      it 'should position content alphabetically' do
+        expect(catalog.resource(:file, '/tmp/foo')[:content]).to eq('Hello, World! Here or there? The end is near')
+      end
+    end
   end
 end


### PR DESCRIPTION
Add content to a file resource.

This allows to generate concatenated files on the master side, without managing multiple file resources.

The first argument is the file path. You are responsible for creating the file resource yourself prior to calling the function. This way, you can finely control the file's parameters.

The second argument is the content to be added to the file.

The third (optional) argument is the order, specifying the position in which the content should be added. The default order is '10'. If you specified a content in the original file resource, this content is kept with order '00'

Examples:


    file { '/tmp/target':
      content => "Orig content\n",
    }

    append_file_content('/tmp/target', "hello, ")
    append_file_content('/tmp/target', "world\n")
    append_file_content('/tmp/target', "This is a multi
    line statement
    ", '01')
    append_file_content('/tmp/target', template('foobar/example.erb'), '05')

- *Type* : statement
