### PR TITLE
Added correct converstions for PB and EB.

### DIFF
--- a/lib/puppet/parser/functions/to_bytes.rb
+++ b/lib/puppet/parser/functions/to_bytes.rb
@@ -2,6 +2,8 @@ module Puppet::Parser::Functions
   newfunction(:to_bytes, :type => :rvalue, :doc => <<-EOS
     Converts the argument into bytes, for example 4 kB becomes 4096.
     Takes a single string value as an argument.
+    These conversions reflect a layperson's understanding of
+    1 MB = 1024 KB, when in fact 1 MB = 1000 KB, and 1 MiB = 1024 KiB.
     EOS
   ) do |arguments|
 
@@ -21,7 +23,8 @@ module Puppet::Parser::Functions
     when 'M' then return (value*(1<<20)).to_i
     when 'G' then return (value*(1<<30)).to_i
     when 'T' then return (value*(1<<40)).to_i
-    when 'E' then return (value*(1<<50)).to_i
+    when 'P' then return (value*(1<<50)).to_i
+    when 'E' then return (value*(1<<60)).to_i
     else raise Puppet::ParseError, "to_bytes(): Unknown prefix #{prefix}"
     end
   end

--- a/spec/functions/to_bytes_spec.rb
+++ b/spec/functions/to_bytes_spec.rb
@@ -18,6 +18,31 @@ describe "the to_bytes function" do
     expect(result).to(eq(4096))
   end
 
+  it "should convert MB to B" do
+    result = scope.function_to_bytes(["4 MB"])
+    expect(result).to(eq(4194304))
+  end
+
+  it "should convert GB to B" do
+    result = scope.function_to_bytes(["4 GB"])
+    expect(result).to(eq(4294967296))
+  end
+
+  it "should convert TB to B" do
+    result = scope.function_to_bytes(["4 TB"])
+    expect(result).to(eq(4398046511104))
+  end
+
+  it "should convert PB to B" do
+    result = scope.function_to_bytes(["4 PB"])
+    expect(result).to(eq(4503599627370496))
+  end
+
+  it "should convert PB to B" do
+    result = scope.function_to_bytes(["4 EB"])
+    expect(result).to(eq(4611686018427387904))
+  end
+
   it "should work without B in unit" do
     result = scope.function_to_bytes(["4 k"])
     expect(result).to(eq(4096))


### PR DESCRIPTION
- We were converting Exabytes to bytes as Petabytes.
- Updated tests to cover ever unit.
- Added note that we're going by the old, inaccurate definitions of
  Kilobytes, Megabytes, etc, in that we treat them as powers of 2.
