### PR TITLE
(QENG-1404) Segregate system testing gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,15 +10,18 @@ def location_for(place, fake_version = nil)
   end
 end
 
-group :development, :test do
+group :development, :unit_tests do
   gem 'rake', '~> 10.1.0',       :require => false
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
-  gem 'serverspec',              :require => false
   gem 'puppet-lint',             :require => false
   gem 'pry',                     :require => false
   gem 'simplecov',               :require => false
+end
+
+group :system_tests do
   gem 'beaker-rspec',            :require => false
+  gem 'serverspec',              :require => false
 end
 
 ENV['GEM_PUPPET_VERSION'] ||= ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
Prior to this there was generic :test group.

Unfortunately Beaker will be EOL-ing support for Ruby 1.8 (a number of
Beaker's dependencies already have and pinning to older versions is
becoming costly). Once Beaker does this it will cause failures whenever
running `bundle install`.

To avoid this failure we can segregate the system testing gems, allowing
unit, lint and development to continue with
`bundle install --without system_tests`.
