### PR TITLE
Remove line match validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This release improves functionality of the member function and adds improved fut
 ####Bugfixes
 - Fix range() to work with numeric ranges with the future parser
 - Accurately express SLES support in metadata.json (was missing 10SP4 and 12)
+- Don't require `line` to match the `match` parameter
 
 ##2014-11-10 - Supported Release 4.4.0
 ###Summary

--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -71,12 +71,5 @@ Puppet::Type.newtype(:file_line) do
     unless self[:line] and self[:path]
       raise(Puppet::Error, "Both line and path are required attributes")
     end
-
-    if (self[:match])
-      unless Regexp.new(self[:match]).match(self[:line])
-        raise(Puppet::Error, "When providing a 'match' parameter, the value must be a regex that matches against the value of your 'line' parameter")
-      end
-    end
-
   end
 end

--- a/spec/unit/puppet/type/file_line_spec.rb
+++ b/spec/unit/puppet/type/file_line_spec.rb
@@ -15,14 +15,14 @@ describe Puppet::Type.type(:file_line) do
     file_line[:match] = '^foo.*$'
     expect(file_line[:match]).to eq('^foo.*$')
   end
-  it 'should not accept a match regex that does not match the specified line' do
+  it 'should accept a match regex that does not match the specified line' do
     expect {
       Puppet::Type.type(:file_line).new(
           :name   => 'foo',
           :path   => '/my/path',
           :line   => 'foo=bar',
           :match  => '^bar=blah$'
-    )}.to raise_error(Puppet::Error, /the value must be a regex that matches/)
+    )}.not_to raise_error
   end
   it 'should accept a match regex that does match the specified line' do
     expect {


### PR DESCRIPTION
The `match` attribute was validated to match `line`, except that in many cases (even the example given in the docs) a user would want to match a line entirely different from the new line.

See comments on the original commit https://github.com/puppetlabs/puppetlabs-stdlib/commit/a06c0d8115892a74666676b50d4282df9850a119 and ask https://ask.puppetlabs.com/question/14366/file_line-resource-match-problems/ for further examples of confusion.
