### PR TITLE
Rename private() to assert_private()

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -360,8 +360,8 @@ returns the value of the resource's parameter. For example, the following code r
 * `prefix`: This function applies a prefix to all elements in an array. For example, `prefix(['a','b','c'], 'p')` returns ['pa','pb','pc']. *Type*: rvalue
 
 
-* `private`: This function sets the current class or definition as private.
-Calling the class or definition from outside the current module will fail. For example, `private()` called in class `foo::bar` outputs the following message if class is called from outside module `foo`:
+* `assert_private`: This function sets the current class or definition as private.
+Calling the class or definition from outside the current module will fail. For example, `assert_private()` called in class `foo::bar` outputs the following message if class is called from outside module `foo`:
 
   ```
   Class foo::bar is private
@@ -370,7 +370,7 @@ Calling the class or definition from outside the current module will fail. For e
   You can specify the error message you want to use:
   
   ```
-  private("You're not supposed to do that!")
+  assert_private("You're not supposed to do that!")
   ```
 
   *Type*: statement

--- a/lib/puppet/parser/functions/assert_private.rb
+++ b/lib/puppet/parser/functions/assert_private.rb
@@ -1,15 +1,15 @@
 #
-# private.rb
+# assert_private.rb
 #
 
 module Puppet::Parser::Functions
-  newfunction(:private, :doc => <<-'EOS'
+  newfunction(:assert_private, :doc => <<-'EOS'
     Sets the current class or definition as private.
     Calling the class or definition from outside the current module will fail.
     EOS
   ) do |args|
 
-    raise(Puppet::ParseError, "private(): Wrong number of arguments "+
+    raise(Puppet::ParseError, "assert_private(): Wrong number of arguments "+
       "given (#{args.size}}) for 0 or 1)") if args.size > 1
 
     scope = self

--- a/spec/functions/assert_private_spec.rb
+++ b/spec/functions/assert_private_spec.rb
@@ -1,11 +1,11 @@
 #! /usr/bin/env ruby -S rspec
 require 'spec_helper'
 
-describe Puppet::Parser::Functions.function(:private) do
+describe Puppet::Parser::Functions.function(:assert_private) do
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   subject do
-    function_name = Puppet::Parser::Functions.function(:private)
+    function_name = Puppet::Parser::Functions.function(:assert_private)
     scope.method(function_name)
   end
 


### PR DESCRIPTION
As mentioned in #270, private is a reserved keyword in the future parser which is to be released with Puppet 4. As it stands, this function is not useable with the future parser so it needs to be renamed.

This is a breaking change.

This should've been fixed right after merging #270. But it wasn't.