### PR TITLE
(MODULES-1670) Do not match dotted-quad IP address as domain name

### DIFF
--- a/lib/puppet/parser/functions/is_domain_name.rb
+++ b/lib/puppet/parser/functions/is_domain_name.rb
@@ -33,6 +33,10 @@ Returns true if the string passed to this function is a syntactically correct do
     return false if domain.empty?
     return false if domain.length > domain_max_length
 
+    # The top level domain must be alphabetic if there are multiple labels.
+    # See rfc1123, 2.1
+    return false if domain.include? '.' and not /\.[A-Za-z]+$/.match(domain)
+
     # Check each label in the domain
     labels = domain.split('.')
     vlabels = labels.each do |label|

--- a/spec/functions/is_domain_name_spec.rb
+++ b/spec/functions/is_domain_name_spec.rb
@@ -68,4 +68,14 @@ describe "the is_domain_name function" do
     result = scope.function_is_domain_name(["my.domain.name".freeze])
     expect(result).to(be_truthy)
   end
+
+  it "should return false if top-level domain is not entirely alphabetic" do
+    result = scope.function_is_domain_name(["kiwi.2bar"])
+    expect(result).to(be_falsey)
+  end
+
+  it "should return false if domain name has the dotted-decimal form, e.g. an IPv4 address" do
+    result = scope.function_is_domain_name(["192.168.1.1"])
+    expect(result).to(be_falsey)
+  end
 end


### PR DESCRIPTION
A valid host name can never have the dotted-decimal form #.#.#.#,
since at least the highest-level component label will be alphabetic.
See RFC 1123, Section 2.1
http://tools.ietf.org/html/rfc1123#section-2
Fixes PUP-3856