### PR TITLE
(MODULES-1738) Don't modify the global seed in fqdn_rotate()

### DIFF
--- a/spec/functions/fqdn_rotate_spec.rb
+++ b/spec/functions/fqdn_rotate_spec.rb
@@ -40,4 +40,21 @@ describe "the fqdn_rotate function" do
     result = scope.function_fqdn_rotate([value])
     result.size.should(eq(4))
   end
+
+  it "should use the Puppet::Util.deterministic_rand function if available" do
+    scope.expects(:lookupvar).with("::fqdn").returns("127.0.0.1")
+    if Puppet::Util.respond_to?(:deterministic_rand)
+      Puppet::Util.expects(:deterministic_rand).with(113646079810780526294648115052177588845,4)
+    end
+    scope.function_fqdn_rotate(["asdf"])
+  end
+
+  it "should not leave the global seed in a deterministic state" do
+    scope.expects(:lookupvar).with("::fqdn").returns("127.0.0.1").twice
+    scope.function_fqdn_rotate(["asdf"])
+    rand1 = rand()
+    scope.function_fqdn_rotate(["asdf"])
+    rand2 = rand()
+    expect(rand1).not_to eql(rand2)
+  end
 end


### PR DESCRIPTION
[MODULES-1738](https://tickets.puppetlabs.com/browse/MODULES-1738) is similar to [Redmine-15791](http://projects.puppetlabs.com/issues/15791), which was addressed in puppetlabs/puppet@292233c. The current implementation of fqdn_rotate() leaves the global seed in a deterministic state, which is bad. Puppet::Util.deterministic_rand() exists to avoid running into this issue, but is only present starting in Puppet 3.2.0.

An alternative (and, IMO, superior) way to handle this would be to instead replace lines 34-37 of fqdn_rotate.rb with:
```ruby
Puppet::Parser::Functions.function('fqdn_rand')
function_fqdn_rand([elements, arguments]).to_i.times {
   result.push result.shift
}
```
This would have the benefits of being much cleaner and not having duplicated code from the Puppet codebase that would have to be maintained if for some reason it changed there.  On the other hand, it would not prevent fqdn_rotate() from poisoning the global seed in versions of Puppet prior to 3.2.0.  That being said, since fqdn_rand() already poisons the global seed in versions of Puppet prior to 3.2.0, maybe it doesn't matter if fqdn_rotate() does the same in those versions.