### PR TITLE
Fix Travis builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,14 @@ group :system_tests do
   gem 'serverspec',              :require => false
 end
 
-ENV['GEM_PUPPET_VERSION'] ||= ENV['PUPPET_GEM_VERSION']
-puppetversion = ENV['GEM_PUPPET_VERSION']
+facterversion = ENV['GEM_FACTER_VERSION'] || ENV['FACTER_GEM_VERSION']
+if facterversion
+  gem 'facter', *location_for(facterversion)
+else
+  gem 'facter', :require => false
+end
+
+puppetversion = ENV['GEM_PUPPET_VERSION'] || ENV['PUPPET_GEM_VERSION']
 if puppetversion
   gem 'puppet', *location_for(puppetversion)
 else

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ end
 
 group :development, :unit_tests do
   gem 'rake', '~> 10.1.0',       :require => false
+  gem 'rspec', '~> 3.1.0',       :require => false
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'puppet-lint',             :require => false


### PR DESCRIPTION
The release of rspec 3.2.0 broke a lot of tests. rspec-puppet 2.0 has a dependency on rspec ~> 2.0, so pinning to that resolves the problems.  Additionally, the Gemfile didn't actually specify which version to use for Facter, even when there was an environment variable to that effect.