### PR TITLE
Fix off-by-one error in validate_augeas_spec.rb that was causing rspec failure

### DIFF
--- a/spec/functions/validate_augeas_spec.rb
+++ b/spec/functions/validate_augeas_spec.rb
@@ -60,7 +60,7 @@ describe Puppet::Parser::Functions.function(:validate_augeas), :if => Puppet.fea
     end
 
     describe "Nicer Error Messages" do
-      # The intent here is to make sure the function returns the 3rd argument
+      # The intent here is to make sure the function returns the 4th argument
       # in the exception thrown
       inputs = [
         [ "root:x:0:0:root\n", 'Passwd.lns', [], 'Failed to validate passwd content' ],
@@ -69,7 +69,7 @@ describe Puppet::Parser::Functions.function(:validate_augeas), :if => Puppet.fea
 
       inputs.each do |input|
         it "validate_augeas(#{input.inspect}) should fail" do
-          expect { subject.call input }.to raise_error /#{input[2]}/
+          expect { subject.call input }.to raise_error /#{input[3]}/
         end
       end
     end


### PR DESCRIPTION
This fixes the test "Nicer Error Messages" in puppetlabs-stdlib/spec/functions/validate_augeas_spec.rb. Without it, 'rake spec' will always fail with RegexpError: empty char-class: /[]/ as Ruby tries and fails to build a pattern off the wrong entry in the inputs array.

I do not understand why I'm the only one to have run into this. But I believe this trivial fix is what the original author intended. 
