### PR TITLE
Fix unsupported platforms variable name in tests

### DIFF
--- a/spec/acceptance/fqdn_rand_base64_spec.rb
+++ b/spec/acceptance/fqdn_rand_base64_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby -S rspec
 require 'spec_helper_acceptance'
 
-describe 'fqdn_rand_base64 function', :unless => unsupported_platforms.include?(fact('operatingsystem')) do
+describe 'fqdn_rand_base64 function', :unless => UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem')) do
   describe 'success' do
     let(:facts_d) do
       if fact('is_pe', '--puppet') == "true"

--- a/spec/acceptance/fqdn_rand_string_spec.rb
+++ b/spec/acceptance/fqdn_rand_string_spec.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby -S rspec
 require 'spec_helper_acceptance'
 
-describe 'fqdn_rand_string function', :unless => unsupported_platforms.include?(fact('operatingsystem')) do
+describe 'fqdn_rand_string function', :unless => UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem')) do
   describe 'success' do
     let(:facts_d) do
       if fact('is_pe', '--puppet') == "true"


### PR DESCRIPTION
unsupported_platforms is not a valid identifier, and trying to use it
causes acceptance tests to error out before running any tests. The
correct identifier for the unsupported platforms constance is
UNSUPPORTED_PLATFORMS.