### PR TITLE
uses include type class declaration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,5 @@
 # Requires: nothing
 #
 class stdlib {
-
-  class { 'stdlib::stages': }
-
+  include stdlib::stages
 }


### PR DESCRIPTION
previous behavior used class { 'stdlib::stages':} which isn't singleton and could cause duplication resource declaration on the stages class.

Since many community modules work by calling 'include stdlib' we should make stdlib's include of stages singleton as well.