### PR TITLE
Adding a respond_to function

### DIFF
--- a/lib/puppet/parser/functions/respond_to.rb
+++ b/lib/puppet/parser/functions/respond_to.rb
@@ -17,15 +17,15 @@ EOS
   if args[0] =~ /^(?i:class)$/
     type, title, params = args
     raise ArgumentError, 'Must specify a class name' unless title
-    raise ArgumentError, 'Must specify a parameter' unless params
     resource = find_hostclass(title)
   else
     title, params = args
     type = 'resource'
-    raise ArgumentError, 'Must specify a parameter' unless params
+    raise ArgumentError, 'Must specify a resource type' unless title
     resource = find_resource_type(title) || find_definition(title)
   end
 
+  raise ArgumentError, 'Must specify parameter(s)' unless params
   raise ArgumentError, "The #{title} #{type} could not be found" if resource.nil?
 
   params = [params] unless params.is_a?(Array)

--- a/lib/puppet/parser/functions/respond_to.rb
+++ b/lib/puppet/parser/functions/respond_to.rb
@@ -8,23 +8,34 @@ returns true if that resource responds to the given parameter.
     respond_to('class', 'apt', 'always_update_apt')
     respond_to('file', 'path')
     respond_to('apt::key', 'key')
+    respond_to('archive', ['checksum_type', 'checksum_file'])
 EOS
 ) do |args|
   args = [args] unless args.is_a?(Array)
+  valid_params = []
 
   if args[0] =~ /^(?i:class)$/
-    type, title, param = args
+    type, title, params = args
     raise ArgumentError, 'Must specify a class name' unless title
-    raise ArgumentError, 'Must specify a parameter' unless param
+    raise ArgumentError, 'Must specify a parameter' unless params
     resource = find_hostclass(title)
   else
-    title, param = args
+    title, params = args
     type = 'resource'
-    raise ArgumentError, 'Must specify a parameter' unless param
+    raise ArgumentError, 'Must specify a parameter' unless params
     resource = find_resource_type(title) || find_definition(title)
   end
 
   raise ArgumentError, "The #{title} #{type} could not be found" if resource.nil?
 
-  resource.valid_parameter?(param)
+  params = [params] unless params.is_a?(Array)
+  params.each do |param|
+    valid_params << resource.valid_parameter?(param)
+  end
+
+  if valid_params.include?(false)
+    return false
+  else
+    return true
+  end
 end

--- a/lib/puppet/parser/functions/respond_to.rb
+++ b/lib/puppet/parser/functions/respond_to.rb
@@ -1,0 +1,30 @@
+# Test whether a given class or resource type responds to the given parameter.
+Puppet::Parser::Functions.newfunction(:respond_to,
+                                      :type => :rvalue,
+                                      :doc => <<-EOS
+Takes a resource type, title (only if type == class), and parameter name and
+returns true if that resource responds to the given parameter.
+
+    respond_to('class', 'apt', 'always_update_apt')
+    respond_to('file', 'path')
+    respond_to('apt::key', 'key')
+EOS
+) do |args|
+  args = [args] unless args.is_a?(Array)
+
+  if args[0] =~ /^(?i:class)$/
+    type, title, param = args
+    raise ArgumentError, 'Must specify a class name' unless title
+    raise ArgumentError, 'Must specify a parameter' unless param
+    resource = find_hostclass(title)
+  else
+    title, param = args
+    type = 'resource'
+    raise ArgumentError, 'Must specify a parameter' unless param
+    resource = find_resource_type(title) || find_definition(title)
+  end
+
+  raise ArgumentError, "The #{title} #{type} could not be found" if resource.nil?
+
+  resource.valid_parameter?(param)
+end

--- a/spec/functions/respond_to_spec.rb
+++ b/spec/functions/respond_to_spec.rb
@@ -1,0 +1,45 @@
+#! /usr/bin/env ruby -S rspec
+
+require 'spec_helper'
+
+describe 'respond_to' do
+  describe 'with no arguments' do
+    it { is_expected.to run.with_params().and_raise_error(ArgumentError, /Must specify a resource type/) }
+  end
+
+  describe 'when looking up a class' do
+    let(:pre_condition) do
+      'class mock ($mocked_var1, $mocked_var2) { }'
+    end
+
+    it { is_expected.to run.with_params('class', 'mock', 'mocked_var1').and_return(true) }
+    it { is_expected.to run.with_params('class', 'mock', ['mocked_var1']).and_return(true) }
+    it { is_expected.to run.with_params('class', 'mock', 'nonexistent').and_return(false) }
+    it { is_expected.to run.with_params('class', 'mock', ['mocked_var1', 'mocked_var2']).and_return(true) }
+    it { is_expected.to run.with_params('class', 'mock', ['mocked_var1', 'mocked_var2', 'nonexistent']).and_return(false) }
+
+    it { is_expected.to run.with_params('class').and_raise_error(ArgumentError, /Must specify a class name/) }
+  end
+
+  describe 'when looking up a defined type' do
+    let(:pre_condition) do
+      'define mock ($mocked_var1, $mocked_var2) { }'
+    end
+
+    it { is_expected.to run.with_params('mock', 'mocked_var1').and_return(true) }
+    it { is_expected.to run.with_params('mock', ['mocked_var1']).and_return(true) }
+    it { is_expected.to run.with_params('mock', 'nonexistent').and_return(false) }
+    it { is_expected.to run.with_params('mock', ['mocked_var1', 'mocked_var2']).and_return(true) }
+    it { is_expected.to run.with_params('mock', ['mocked_var1', 'mocked_var2', 'nonexistent']).and_return(false) }
+
+    it { is_expected.to run.with_params('mock').and_raise_error(ArgumentError, /Must specify parameter\(s\)/) }
+  end
+
+  describe 'when looking up a nonexistent type' do
+    it { is_expected.to run.with_params('nonexistent', 'parameter').and_raise_error(ArgumentError, /The nonexistent resource could not be found/) }
+  end
+
+  describe 'when looking up a nonexistent class' do
+    it { is_expected.to run.with_params('class', 'nonexistent', 'parameter').and_raise_error(ArgumentError, /The nonexistent class could not be found/) }
+  end
+end


### PR DESCRIPTION
This PR adds a `respond_to` function to check if a resource type has a particular parameter, similar (in concept) to the `respond_to?` method in Ruby. This could be useful in a number of circumstances, not sure if I'm the only one that finds this function interesting.