### PR TITLE
(MODULES-1982)Create a tcp_conn_validator resource

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -97,6 +97,26 @@ If you want to use a standardized set of run stages for Puppet, `include stdlib`
  * `name`: An arbitrary name used as the identity of the resource.
  * `path`: The file in which Puppet will ensure the line specified by the line parameter.
 
+* `tcp_conn_validator`: This resource ensures a service (remote or not) is actually up and running before moving onward with the catalog application. Puppet will block until the tcp connection can be made. If no connection are possible after a certain amount of time this resource will fail.
+
+  ```
+  tcp_conn_validator { 'mysql' :
+    server => '192.168.0.42',
+    port   => '3306',
+  }
+  ```
+
+To validate the same service running on differents nodes one can do :
+
+  ```
+  $array_of_service = ['ip1:3306', '[::1]:3306', 'ip2:3306']
+  tcp_conn_validator { $array_of_service : }
+  ```
+
+  * `server` : An IP or array of IP address of the server to check. Required.
+  * `port` : The port one want to ensure a process is listening on. Required.
+  * `timeout` : Number of second before timing out. Optional.
+
 ### Functions
 
 #### `abs`

--- a/lib/puppet/provider/tcp_conn_validator/tcp_port.rb
+++ b/lib/puppet/provider/tcp_conn_validator/tcp_port.rb
@@ -1,0 +1,47 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
+require 'puppet_x/puppetlabs/tcp_validator'
+
+# This file contains a provider for the resource type `tcp_conn_validator`,
+# which validates the TCP connection.
+
+Puppet::Type.type(:tcp_conn_validator).provide(:tcp_port) do
+  desc "A provider for the resource type `tcp_conn_validator`,
+        which validates the tcp connection."
+
+  def exists?
+    start_time = Time.now
+    timeout = resource[:timeout]
+
+    success = validator.attempt_connection
+
+    while success == false && ((Time.now - start_time) < timeout)
+      Puppet.debug("Failed to connect to the server; sleeping 4 seconds before retry")
+      sleep 4
+      success = validator.attempt_connection
+    end
+
+    if success
+      Puppet.debug("Connected to the server in #{Time.now - start_time} seconds.")
+    else
+      Puppet.notice("Failed to connect to the server within timeout window of #{timeout} seconds; giving up.")
+    end
+
+    success
+  end
+
+  def create
+    # If `#create` is called, that means that `#exists?` returned false, which
+    # means that the connection could not be established... so we need to
+    # cause a failure here.
+    raise Puppet::Error, "Unable to connect to the  server! (#{@validator.tcp_server}:#{@validator.tcp_port})"
+  end
+
+  private
+
+  # @api private
+  def validator
+    @validator ||= PuppetX::Puppetlabs::TcpValidator.new(resource[:name], resource[:server], resource[:port])
+  end
+
+end
+

--- a/lib/puppet/type/tcp_conn_validator.rb
+++ b/lib/puppet/type/tcp_conn_validator.rb
@@ -1,0 +1,44 @@
+Puppet::Type.newtype(:tcp_conn_validator) do
+
+  @doc = "Verify that a TCP connection can be successfully established between a node
+          and the expected  server.  Its primary use is as a precondition to
+          prevent configuration changes from being applied if the server cannot be
+          reached, but it could potentially be used for other purposes such as monitoring."
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'An arbitrary name used as the identity of the resource.'
+  end
+
+  newparam(:server) do
+    desc 'An array containing DNS names or IP addresses of the server where the expected service should be running.'
+    defaultto '127.0.0.1'
+    munge do |value|
+      Array(value).first
+    end
+  end
+
+  newparam(:port) do
+    desc 'The port that the server should be listening on.'
+    defaultto '22'
+  end
+
+  newparam(:timeout) do
+    desc 'The max number of seconds that the validator should wait before giving up and deciding that the service is not running; defaults to 60 seconds.'
+    defaultto 60
+
+    validate do |value|
+      # This will raise an error if the string is not convertible to an integer
+      Integer(value)
+    end
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+end

--- a/lib/puppet_x/puppetlabs/tcp_validator.rb
+++ b/lib/puppet_x/puppetlabs/tcp_validator.rb
@@ -1,0 +1,48 @@
+require 'socket'
+require 'timeout'
+require 'ipaddr'
+require 'uri'
+
+module PuppetX
+  module Puppetlabs
+    class TcpValidator
+      attr_reader :tcp_server
+      attr_reader :tcp_port
+
+      def initialize(tcp_resource_name, tcp_server, tcp_port)
+        begin
+          # NOTE (spredzy) : By relying on the uri module
+          # we rely on its well tested interface to parse
+          # both IPv4 and IPv6 based URL with a port specified.
+          # Unfortunately URI needs a scheme, hence the http
+          # string here to make the string URI compliant.
+          uri = URI("http://#{tcp_resource_name}")
+          @tcp_server = IPAddr.new(uri.host).to_s
+          @tcp_port = uri.port
+        rescue
+          @tcp_server = IPAddr.new(tcp_server).to_s
+          @tcp_port   = tcp_port
+        end
+      end
+
+      # Utility method; attempts to make a tcp connection to the specified server.
+      # This is abstracted out into a method so that it can be called multiple times
+      # for retry attempts.
+      #
+      # @return true if the connection is successful, false otherwise.
+      def attempt_connection
+        Timeout::timeout(Puppet[:configtimeout]) do
+          begin
+            TCPSocket.new(@tcp_server, @tcp_port).close
+            true
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
+            Puppet.debug "Unable to connect to tcp server (#{@tcp_server}:#{@tcp_port}): #{e.message}"
+            false
+          end
+        end
+      rescue Timeout::Error
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some services might take a while to start, even though the service
returned the boot process is finish, the process is not yet actually
listening on the port. This resource would allow to ensure a service is
really up and running before continuing with the application of the
catalog. Other project already rely on a similar feature. [1][2]

[1]
https://github.com/puppetlabs/puppetlabs-mongodb/blob/master/lib/puppet/type/mongodb_conn_validator.rb
[2]
https://github.com/puppetlabs/puppetlabs-puppetdb/blob/master/lib/puppet/type/puppetdb_conn_validator.rb