### PR TITLE
(MODULES-1982)Create a http_conn_validator resource

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -97,6 +97,23 @@ If you want to use a standardized set of run stages for Puppet, `include stdlib`
  * `name`: An arbitrary name used as the identity of the resource.
  * `path`: The file in which Puppet will ensure the line specified by the line parameter.
 
+* `http_conn_validator`: This resource ensures a service (remote or not) is actually up and running before moving onward with the catalog application. Puppet will block until an http connection can be made. If no connection are possible after a certain amount of time this resource will fail.
+
+  ```
+  http_conn_validator { 'mysql' :
+    server   => '192.168.0.42',
+    port     => '80',
+    test_url => '/',
+  }
+  ```
+
+  * `server` : An IP or array of IP address of the server to check. Required.
+  * `port` : The port one want to ensure a process is listening on. Required.
+  * `use_ssl` : Whether the connection will be attempted using https. Optional. Default to false.
+  * `test_url' : The URL path to test. Optional. Default to '/'.
+  * `timeout` : Number of second before timint out. Optional.
+
+
 ### Functions
 
 #### `abs`

--- a/lib/puppet/provider/http_conn_validator/http_conn_validator.rb
+++ b/lib/puppet/provider/http_conn_validator/http_conn_validator.rb
@@ -1,0 +1,62 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
+require 'puppet/util/http_validator'
+
+# This file contains a provider for the resource type `http_conn_validator`,
+# which validates an HTTP connection by attempting an http(s) connection.
+
+Puppet::Type.type(:http_conn_validator).provide(:http_conn_validator) do
+  desc "A provider for the resource type `http_conn_validator`,
+        which validates an HTTP connection by attempting an http(s)
+        connection to the server."
+
+  # Test to see if the resource exists, returns true if it does, false if it
+  # does not.
+  #
+  # Here we simply monopolize the resource API, to execute a test to see if the
+  # database is connectable. When we return a state of `false` it triggers the
+  # create method where we can return an error message.
+  #
+  # @return [bool] did the test succeed?
+  def exists?
+    start_time = Time.now
+    timeout = resource[:timeout]
+
+    success = validator.attempt_connection
+
+    while success == false && ((Time.now - start_time) < timeout)
+      # It can take several seconds for an HTTP  service to start up;
+      # especially on the first install.  Therefore, our first connection attempt
+      # may fail.  Here we have somewhat arbitrarily chosen to retry every 2
+      # seconds until the configurable timeout has expired.
+      Puppet.notice("Failed to make an HTTP connection; sleeping 2 seconds before retry")
+      sleep 2
+      success = validator.attempt_connection
+    end
+
+    unless success
+      Puppet.notice("Failed to make an HTTP connection within timeout window of #{timeout} seconds; giving up.")
+    end
+
+    success
+  end
+
+  # This method is called when the exists? method returns false.
+  #
+  # @return [void]
+  def create
+    # If `#create` is called, that means that `#exists?` returned false, which
+    # means that the connection could not be established... so we need to
+    # cause a failure here.
+    raise Puppet::Error, "Unable to connect to the HTTP server! (#{@validator.http_server}:#{@validator.http_port})"
+  end
+
+  # Returns the existing validator, if one exists otherwise creates a new object
+  # from the class.
+  #
+  # @api private
+  def validator
+    @validator ||= PuppetX::Puppetlabs::HttpValidator.new(resource[:server], resource[:port], resource[:use_ssl], resource[:test_url])
+  end
+
+end
+

--- a/lib/puppet/type/http_conn_validator.rb
+++ b/lib/puppet/type/http_conn_validator.rb
@@ -1,0 +1,50 @@
+Puppet::Type.newtype(:http_conn_validator) do
+
+  @doc = "Verify that a connection can be successfully established between a node
+          and an HTTP server.  Its primary use is as a precondition to
+          prevent configuration changes from being applied if the HTTP
+          server cannot be reached, but it could potentially be used for other
+          purposes such as monitoring."
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'An arbitrary name used as the identity of the resource.'
+  end
+
+  newparam(:server) do
+    desc 'The DNS name or IP address of the HTTP server.'
+  end
+
+  newparam(:port) do
+    desc 'The port to check on the HTTP server.'
+  end
+
+  newparam(:use_ssl) do
+    desc 'Whether the connection will be attemped using https'
+    defaultto false
+  end
+
+  newparam(:test_url) do
+    desc 'URL to use for testing if the HTTP server is up'
+    defaultto '/'
+  end
+
+  newparam(:timeout) do
+    desc 'The max number of seconds that the validator should wait before giving up and deciding that the HTTP server is not running; defaults to 15 seconds.'
+    defaultto 15
+
+    validate do |value|
+      # This will raise an error if the string is not convertible to an integer
+      Integer(value)
+    end
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+end

--- a/lib/puppet/util/http_validator.rb
+++ b/lib/puppet/util/http_validator.rb
@@ -1,0 +1,41 @@
+require 'puppet/network/http_pool'
+
+module PuppetX
+  module Puppetlabs
+    class HttpValidator
+      attr_reader :http_server
+      attr_reader :http_port
+      attr_reader :use_ssl
+      attr_reader :test_path
+      attr_reader :test_headers
+
+      def initialize(http_server, http_port, use_ssl, test_path)
+        @http_server  = http_server
+        @http_port    = http_port
+        @use_ssl      = use_ssl
+        @test_path    = test_path
+        @test_headers = { "Accept" => "application/json" }
+      end
+
+      # Utility method; attempts to make an http/https connection to a server.
+      # This is abstracted out into a method so that it can be called multiple times
+      # for retry attempts.
+      #
+      # @return true if the connection is successful, false otherwise.
+      def attempt_connection
+        conn = Puppet::Network::HttpPool.http_instance(http_server, http_port, use_ssl)
+
+        response = conn.get(test_path, test_headers)
+        unless response.kind_of?(Net::HTTPSuccess)
+          Puppet.notice "Unable to connect to the server (http#{use_ssl ? "s" : ""}://#{http_server}:#{http_port}): [#{response.code}] #{response.msg}"
+          return false
+        end
+        return true
+      rescue Exception => e
+        Puppet.notice "Unable to connect to the server (http#{use_ssl ? "s" : ""}://#{http_server}:#{http_port}): #{e.message}"
+        return false
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Some services might take a while to start, even though the service
returned the boot process is finish, the process is not yet actually
listening on the port. This resource would allow to ensure a service is
really up and running before continuing with the application of the
catalog. Other project already rely on a similar feature. [1][2]

[1]
https://github.com/puppetlabs/puppetlabs-mongodb/blob/master/lib/puppet/type/mongodb_conn_validator.rb
[2]
https://github.com/puppetlabs/puppetlabs-puppetdb/blob/master/lib/puppet/type/puppetdb_conn_validator.rb