### PR TITLE
Fix pw_hash() on JRuby < 1.7.17

### DIFF
--- a/lib/puppet/parser/functions/pw_hash.rb
+++ b/lib/puppet/parser/functions/pw_hash.rb
@@ -38,6 +38,8 @@ Puppet::Parser::Functions::newfunction(
     password = args[0]
     return nil if password.nil? or password.empty?
 
+    salt = "$#{hash_type}$#{args[2]}"
+
     # handle weak implementations of String#crypt
     if 'test'.crypt('$1$1') != '$1$1$Bp8CU9Oujr9SSEw53WV6G.'
       # JRuby < 1.7.17
@@ -49,6 +51,6 @@ Puppet::Parser::Functions::newfunction(
         raise Puppet::ParseError, 'system does not support enhanced salts'
       end
     else
-      password.crypt("$#{hash_type}$#{args[2]}")
+      password.crypt(salt)
     end
 end


### PR DESCRIPTION
The previous change to this function broke it on JRuby before 1.7.17 by
attempting to use a variable that wasn't defined (`salt`). To fix this,
define `salt` ahead of time and use that instead of building the salt
later.

cf. https://github.com/puppetlabs/puppetlabs-stdlib/pull/443#discussion_r29718588