### PR TITLE
Restore removed functionality to range()

### DIFF
--- a/lib/puppet/parser/functions/range.rb
+++ b/lib/puppet/parser/functions/range.rb
@@ -37,18 +37,17 @@ Will return: [0,2,4,6,8]
     EOS
   ) do |arguments|
 
-    # We support more than one argument but at least one is mandatory ...
-    raise(Puppet::ParseError, "range(): Wrong number of " +
-      "arguments given (#{arguments.size} for 1)") if arguments.size < 1
+    raise(Puppet::ParseError, 'range(): Wrong number of ' +
+      'arguments given (0 for 1)') if arguments.size == 0
 
     if arguments.size > 1
       start = arguments[0]
       stop  = arguments[1]
       step  = arguments[2].nil? ? 1 : arguments[2].to_i.abs
 
-      type = '..' # We select simplest type for Range available in Ruby ...
+      type = '..' # Use the simplest type of Range available in Ruby
 
-    elsif arguments.size > 0
+    else # arguments.size == 0
       value = arguments[0]
 
       if m = value.match(/^(\w+)(\.\.\.?|\-)(\w+)$/)
@@ -58,14 +57,14 @@ Will return: [0,2,4,6,8]
         type = m[2]
 
       elsif value.match(/^.+$/)
-        raise(Puppet::ParseError, 'range(): Unable to compute range ' +
-          'from the value given')
+        raise(Puppet::ParseError, "range(): Unable to compute range " +
+          "from the value: #{value}")
       else
-        raise(Puppet::ParseError, 'range(): Unknown format of range given')
+        raise(Puppet::ParseError, "range(): Unknown range format: #{value}")
       end
     end
 
-    # Check whether we have integer value if so then make it so ...
+    # If we were given an integer, ensure we work with one
     if start.to_s.match(/^\d+$/)
       start = start.to_i
       stop  = stop.to_i
@@ -76,10 +75,10 @@ Will return: [0,2,4,6,8]
 
     range = case type
       when /^(\.\.|\-)$/ then (start .. stop)
-      when /^(\.\.\.)$/  then (start ... stop) # Exclusive of last element ...
+      when '...'         then (start ... stop) # Exclusive of last element
     end
 
-    result = range.step(step).collect { |i| i } # Get them all ... Pokemon ...
+    result = range.step(step).collect { |i| i }
 
     return result
   end


### PR DESCRIPTION
This restores functionality removed from `range()` by a recent commit, specifically the ability to make calls such as `range('2..3')`, `range('2...3')`, and `range('2-3')`.  Such removal should be done only on a new major version due to it being a breaking change and should be documented correctly.  I suspect this was done due to misreading of [one of the removed checks](https://github.com/puppetlabs/puppetlabs-stdlib/pull/443#discussion_r29721193), so I have also cleaned up the function a bit to clarify it. 

cf. https://github.com/puppetlabs/puppetlabs-stdlib/pull/443#commitcomment-11055565