### PR TITLE
Added replace attribute

### DIFF
--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -62,6 +62,11 @@ Puppet::Type.newtype(:file_line) do
     end
   end
 
+  newparam(:replace) do
+    desc 'Add the line but do nothing if match exists'
+    newvalues(true, false)
+  end
+
   # Autorequire the file resource if it's being managed
   autorequire(:file) do
     self[:path]


### PR DESCRIPTION
We have a use case where a Solaris /etc/logadm.conf file has entries like:

```
/var/adm/wtmpx -C 3 -P 'Sun Apr 26 07:10:04 2015' -g adm -m 644 -o adm -p 1m -t '/var/adm/oldlogs/wtmpx-$nodename-%Y%m%d' -z 0
```

Using the shell command to add entries by design puts a timestamp in the line.  A customer would like to manage lines of this file.  Using file_line and the match attribute causes the line to be continually updated with new timestamp.

```
$timestamp = chomp(generate('/bin/date', '+%a %b %d %T %Y'))
$wtmpx_regex = '\/var\/adm\/wtmpx \-C \d+ \-P \'[\w\s:]+\''

file_line { 'wtmpx':
  path    => '/tmp/logadm.conf',
  line    => "/var/adm/wtmpx -C 3 -P '${timestamp}' -g adm -m 644 -o adm -p 1m -t '/var/adm/oldlogs/wtmpx-\$nodename-%Y%m%d' -z 0A",
  match   => $wtmpx_regex,
}
```
The time stamp will be different for each system because it is the time the entry was added.