### PR TITLE
(MODULES-2026) Support hashes in suffix function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -640,7 +640,7 @@ This function removes leading and trailing whitespace from a string or from ever
 
 #### `suffix`
 
-This function applies a suffix to all elements in an array. For example, `suffix(['a','b','c'], 'p')` returns ['ap','bp','cp']. *Type*: rvalue
+This function applies a suffix to all elements in an array or to the keys in a hash. For example, `suffix(['a','b','c'], 'p')` returns ['ap','bp','cp'], and `suffix({'a'=>'b','b'=>'c','c'=>'d'}, 'p')` returns {'ap'=>'b','bp'=>'c','cp'=>'d'}. *Type*: rvalue
 
 #### `swapcase`
 
@@ -829,7 +829,7 @@ Validates that all passed values are hash data structures. Abort catalog compila
 #### `validate_integer`
 
 Validate that the first argument is an integer (or an array of integers). Abort catalog compilation if any of the checks fail.
-    
+
   The second argument is optional and passes a maximum. (All elements of) the first argument has to be less or equal to this max.
 
   The third argument is optional and passes a minimum.  (All elements of) the first argument has to be greater or equal to this min.
@@ -1036,7 +1036,3 @@ To report or research a bug with any part of this module, please go to
 ##Contributors
 
 The list of contributors can be found at: https://github.com/puppetlabs/puppetlabs-stdlib/graphs/contributors
-
-
-
-

--- a/lib/puppet/parser/functions/suffix.rb
+++ b/lib/puppet/parser/functions/suffix.rb
@@ -4,7 +4,7 @@
 
 module Puppet::Parser::Functions
   newfunction(:suffix, :type => :rvalue, :doc => <<-EOS
-This function applies a suffix to all elements in an array.
+This function applies a suffix to all elements in an array or a hash.
 
 *Examples:*
 
@@ -18,24 +18,31 @@ Will return: ['ap','bp','cp']
     raise(Puppet::ParseError, "suffix(): Wrong number of arguments " +
       "given (#{arguments.size} for 1)") if arguments.size < 1
 
-    array = arguments[0]
+    enumerable = arguments[0]
 
-    unless array.is_a?(Array)
-      raise Puppet::ParseError, "suffix(): expected first argument to be an Array, got #{array.inspect}"
+    unless enumerable.is_a?(Array) or enumerable.is_a?(Hash)
+      raise Puppet::ParseError, "suffix(): expected first argument to be an Array or a Hash, got #{enumerable.inspect}"
     end
 
     suffix = arguments[1] if arguments[1]
 
     if suffix
-      unless suffix.is_a? String
+      unless suffix.is_a?(String)
         raise Puppet::ParseError, "suffix(): expected second argument to be a String, got #{suffix.inspect}"
       end
     end
 
-    # Turn everything into string same as join would do ...
-    result = array.collect do |i|
-      i = i.to_s
-      suffix ? i + suffix : i
+    if enumerable.is_a?(Array)
+      # Turn everything into string same as join would do ...
+      result = enumerable.collect do |i|
+        i = i.to_s
+        suffix ? i + suffix : i
+      end
+    else
+      result = Hash[enumerable.map do |k,v|
+        k = k.to_s
+        [ suffix ? k + suffix : k, v ]
+      end]
     end
 
     return result

--- a/spec/functions/suffix_spec.rb
+++ b/spec/functions/suffix_spec.rb
@@ -24,4 +24,9 @@ describe "the suffix function" do
     result = scope.function_suffix([['a','b','c'], 'p'])
     expect(result).to(eq(['ap','bp','cp']))
   end
+
+  it "returns a prefixed hash" do
+    result = scope.function_prefix([{'a' => 'b','b' => 'c','c' => 'd'}, 'p'])
+    expect(result).to(eq({'pa'=>'b','pb'=>'c','pc'=>'d'}))
+  end
 end


### PR DESCRIPTION
The puppetlabs/stdlib module already supports hashes in the prefix function. This patch adds the same functionality to suffix. It's basically the prefix function with s/prefix/suffix/.

https://tickets.puppetlabs.com/browse/MODULES-2026