### PR TITLE
(MODULES-2031) Add 'url_encode' function to stdlib

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -682,7 +682,21 @@ Converts an object, array or hash of objects that respond to upcase to uppercase
 
 #### `uriescape`
 
-Urlencodes a string or array of strings. Requires either a single string or an array as an input. *Type*: rvalue
+Escapes whole-URL strings (single string or an array of strings) for use as double-quoted arguments to shell commands and HTML attributes by URL-encoding unsafe characters like space, double-quote, octothorpe, and curly braces.
+
+This function is ideal for sanitizing untrusted whole-URL string inputs to prevent command or HTML injection without destroying their validity. In other words, a safe URL passed to this function will be unchanged, in contrast to the `url_encode` function, which will turn a valid URL into a completely inert string containing only alphanums and percents.
+
+Question mark, ampersand, and equals are not URL-encoded by this function. See `url_encode` for encoding arbitrary strings (including other URLs) as URL query string parameter values.
+
+Requires either a single string or an array as an input. *Type*: rvalue
+
+#### `url_encode`
+
+Percent-encode any URI-significant/illegal characters in a string or array of strings.
+
+Passing a whole-URL string to this function will return an encoded string which can then be interpolated, as-is, into another URL string as a parameter value, but which will not be useful by itself in applications until it has been URL-unencoded.
+
+Requires either a single string or an array as an input. *Type*: rvalue
 
 #### `validate_absolute_path`
 

--- a/lib/puppet/parser/functions/url_encode.rb
+++ b/lib/puppet/parser/functions/url_encode.rb
@@ -1,0 +1,37 @@
+#
+#  url_encode.rb
+#
+require 'erb'
+
+module Puppet::Parser::Functions
+  newfunction(:url_encode, :type => :rvalue, :doc => <<-EOS
+    Percent-encode URI significant/illegal characters in a 
+    string or array of strings. Passing a URL to this function will 
+    return an encoded URL string which can then be interpolated, as-is, into
+    another URL string as a parameter value. Requires either a single 
+    string or an array as an input.
+    EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "url_encode(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size < 1
+
+    value = arguments[0]
+
+    unless value.is_a?(Array) || value.is_a?(String)
+      raise(Puppet::ParseError, 'url_encode(): Requires either ' +
+        'array or string to work with')
+    end
+
+    if value.is_a?(Array)
+      # Numbers in Puppet are often string-encoded which is troublesome ...
+      result = value.collect { |i| i.is_a?(String) ? ERB::Util.url_encode(i) : i }
+    else
+      result = ERB::Util.url_encode(value)
+    end
+
+    return result
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/spec/acceptance/url_encode_spec.rb
+++ b/spec/acceptance/url_encode_spec.rb
@@ -1,0 +1,22 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper_acceptance'
+
+describe 'url_encode function', :unless => UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem')) do
+  describe 'success' do
+    it 'url_encode strings' do
+      pp = <<-EOS
+      $a = ":/?#[]@!$&'()*+,;= \\\"{}%"
+      $o = url_encode($a)
+      notice(inline_template('url_encode is <%= @o.inspect %>'))
+      EOS
+
+      apply_manifest(pp, :catch_failures => true) do |r|
+        expect(r.stdout).to match(/url_encode is "%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%20%22%7B%7D%25"/)
+      end
+    end
+  end
+  describe 'failure' do
+    it 'handles no arguments'
+    it 'handles non strings or arrays'
+  end
+end


### PR DESCRIPTION
We recently upgraded our stdlib module to 4.6 and discovered that one of
our modules depended on legacy behavior of the uriescape function that
had changed significantly along the way:

https://github.com/puppetlabs/puppetlabs-stdlib/pull/164
(commit: b2e23dc65bd9851dcb6ad60ffca1acbc70b617e1)

Before PR#164, the effective behavior of uriescape was to replace
characters that are illegal or significant within URIs with
percent-delimited, hex-encoded equivalents, as is necessary when
encoding a free-text UTF-8 string within a URL path segment ( / "text"
    / ) such that any forward-slashes, ampersands, question marks, and
octothorpes embedded within the text do not change the structure of
the URL from the perspective of a URL parser.

After PR#164, the effective behavior of uriescape changed, for the
most part, to minimally escape a complete URL (agnostic of its parts)
in such a way to make it safe to pass as a double-quoted argument to a
shell command like curl, to prevent command injection.

We still need the legacy behavior for building URIs, such as JDBC URLs
in config files that embed a password value from hiera containing
URI-significant characters like '&' or '?'.

Since the uriescape function has been adjusted to match the behavior
of the Ruby URI.escape function, a simple enhancement would be to
expose one of the recommended alternative Ruby functions
(ERB::Util.url_encode), as a distinct puppet function.