### PR TITLE
Remove all the pops stuff

### DIFF
--- a/spec/functions/type_of_spec.rb
+++ b/spec/functions/type_of_spec.rb
@@ -2,32 +2,12 @@
 
 require 'spec_helper'
 
-if ENV["FUTURE_PARSER"] == 'yes' or Puppet.version >= "4"
-  require 'puppet/pops'
-  require 'puppet/loaders'
+describe 'type_of', :if => Puppet.version.to_f >= 4.0 do
+  it 'gives the type of a string' do
+    expect(subject.call_function('type_of', 'hello world')).to be_kind_of(Puppet::Pops::Types::PStringType)
+  end
 
-  describe 'the type_of function' do
-    before(:all) do
-      loaders = Puppet::Pops::Loaders.new(Puppet::Node::Environment.create(:testing, [File.join(fixtures, "modules")]))
-      Puppet.push_context({:loaders => loaders}, "test-examples")
-    end
-
-    after(:all) do
-      Puppet::Pops::Loaders.clear
-      Puppet::pop_context()
-    end
-
-    let(:func) do
-      # Load the function from the environment modulepath's modules (ie, fixtures)
-      Puppet.lookup(:loaders).private_environment_loader.load(:function, 'type_of')
-    end
-
-    it 'gives the type of a string' do
-      expect(func.call({}, 'hello world')).to be_kind_of(Puppet::Pops::Types::PStringType)
-    end
-
-    it 'gives the type of an integer' do
-      expect(func.call({}, 5)).to be_kind_of(Puppet::Pops::Types::PIntegerType)
-    end
+  it 'gives the type of an integer' do
+    expect(subject.call_function('type_of', 5)).to be_kind_of(Puppet::Pops::Types::PIntegerType)
   end
 end


### PR DESCRIPTION
The rspec-puppet matchers don't allow to check the return types, but
this is a pretty rare thing to need to do anyway, so probably not worth
patching rspec-puppet