### PR TITLE
Add parser function "array_contains"

### DIFF
--- a/lib/puppet/parser/functions/array_contains.rb
+++ b/lib/puppet/parser/functions/array_contains.rb
@@ -1,0 +1,22 @@
+module Puppet::Parser::Functions
+  newfunction(:array_contains, :type => :rvalue, :doc => <<-EOS
+Returns true if the array contains this value.
+  EOS
+  ) do |arguments|
+    needle = arguments[0]
+    haystack = arguments[1]
+
+    unless arguments.length == 2
+      raise(Puppet::ParseError,
+            "array_contains(): Wrong number of arguments provided. Usage: array_contains(needle, haystack)")
+    end
+
+    unless haystack.is_a?(Array)
+      raise(Puppet::ParseError,
+            "array_contains(): Second argument must be an array. Usage: array_contains(needle, haystack)"
+      )
+    end
+
+    return haystack.include?(needle)
+  end
+end

--- a/spec/functions/array_contains_spec.rb
+++ b/spec/functions/array_contains_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe "the array_contains function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    expect(Puppet::Parser::Functions.function("array_contains")).to eq("function_array_contains")
+  end
+
+  it "should raise a ParseError if a wrong number of arguments is provided" do
+    expect { scope.function_array_contains([]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_array_contains(["a"]) }.to( raise_error(Puppet::ParseError))
+    expect { scope.function_array_contains(["a", "b", ["c", "d"]]) }.to( raise_error(Puppet::ParseError))
+  end
+
+  it "should return false if the second argument isn't an array" do
+    expect { scope.function_array_contains(["a","b"]) }.to( raise_error(Puppet::ParseError))
+  end
+
+  it "should return true if the element was found in the array" do
+    expect(scope.function_array_contains(["a", ["a","b"]]) ).to eq(true)
+  end
+
+  it "should return false if the element was not found in the array" do
+    expect(scope.function_array_contains(["x", ["a","b"]]) ).to eq(false)
+  end
+end


### PR DESCRIPTION
This function returns true if an element is
found in the array, false otherwise. It delegates
work to Ruby's underlying array.include? function.

One of the use cases for this function is where
a list of master nodes is defined, and a manifest
looks at its $fqdn to determine whether it's part
of that master list, in which case it should a
process with slightly different startup parameters.