### PR TITLE
fqdn_rotate: reset srand seed correctly on old ruby versions

### DIFF
--- a/lib/puppet/parser/functions/fqdn_rotate.rb
+++ b/lib/puppet/parser/functions/fqdn_rotate.rb
@@ -39,9 +39,9 @@ Rotates an array a random number of times based on a nodes fqdn.
       if defined?(Random) == 'constant' && Random.class == Class
         offset = Random.new(seed).rand(elements)
       else
-        srand(seed)
+        old_seed = srand(seed)
         offset = rand(elements)
-        srand()
+        srand(old_seed)
       end
     end
     offset.times {


### PR DESCRIPTION
Without this, the global seed is reseeded on every use
of fqdn_rotate, which is a waste. Older rubies might even use a
time-base seed which adversly impacts the quality of the RNG.