### PR TITLE
validate_integer, validate_numeric: explicitely reject hashes in arrays

### DIFF
--- a/lib/puppet/parser/functions/validate_integer.rb
+++ b/lib/puppet/parser/functions/validate_integer.rb
@@ -109,6 +109,7 @@ module Puppet::Parser::Functions
       # check every element of the array
       input.each_with_index do |arg, pos|
         begin
+          raise TypeError if arg.is_a?(Hash)
           arg = Integer(arg.to_s)
           validator.call(arg)
         rescue TypeError, ArgumentError

--- a/lib/puppet/parser/functions/validate_numeric.rb
+++ b/lib/puppet/parser/functions/validate_numeric.rb
@@ -71,6 +71,7 @@ module Puppet::Parser::Functions
       # check every element of the array
       input.each_with_index do |arg, pos|
         begin
+          raise TypeError if arg.is_a?(Hash)
           arg = Float(arg.to_s)
           validator.call(arg)
         rescue TypeError, ArgumentError

--- a/spec/functions/validate_integer_spec.rb
+++ b/spec/functions/validate_integer_spec.rb
@@ -62,6 +62,11 @@ describe Puppet::Parser::Functions.function(:validate_integer) do
       expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /to be an Integer or Array/)
     end
 
+    it "should not compile when a Hash is passed as Array" do
+      Puppet[:code] = "validate_integer([{ 1 => 2 }])"
+      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /to be an Integer/)
+    end
+
     it "should not compile when an explicitly undef variable is passed" do
       Puppet[:code] = <<-'ENDofPUPPETcode'
         $foo = undef

--- a/spec/functions/validate_numeric_spec.rb
+++ b/spec/functions/validate_numeric_spec.rb
@@ -62,6 +62,11 @@ describe Puppet::Parser::Functions.function(:validate_numeric) do
       expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /to be a Numeric or Array/)
     end
 
+    it "should not compile when a Hash is passed in an Array" do
+      Puppet[:code] = "validate_numeric([{ 1 => 2 }])"
+      expect { scope.compiler.compile }.to raise_error(Puppet::ParseError, /to be a Numeric/)
+    end
+
     it "should not compile when an explicitly undef variable is passed" do
       Puppet[:code] = <<-'ENDofPUPPETcode'
         $foo = undef


### PR DESCRIPTION
Without this patch, Ruby 1.8's Hash#to_s behaviour causes [{1=>2}] to be
treated as "12" when validating values.