### PR TITLE
 (MODULES-2071) Patch file_line provider to use multiple with after

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -96,8 +96,8 @@ All parameters are optional, unless otherwise noted.
 * `ensure`: Ensures whether the resource is present. Valid options: 'present', 'absent'. Default: 'present'.
 * `line`: **Required.** Sets the line to be added to the file located by the `path` parameter. Valid options: String. Default: Undefined.
 * `match`: Specifies a regular expression to run against existing lines in the file; if a match is found, it is replaced rather than adding a new line. Valid options: String containing a regex. Default: Undefined.
-* `multiple`: Determines if `match` can change multiple lines. If set to false, an exception will be raised if more than one line matches. Valid options: 'true', 'false'. Default: Undefined.
-* `name`: Sets the name to use as the identity of the resource. This is necessary if you want the resource namevar to differ from the supplied `title` of the resource. Valid options: String. Default: Undefined. 
+* `multiple`: Determines if `match` and/or `after` can change multiple lines. If set to false, an exception will be raised if more than one line matches. Valid options: 'true', 'false'. Default: Undefined.
+* `name`: Sets the name to use as the identity of the resource. This is necessary if you want the resource namevar to differ from the supplied `title` of the resource. Valid options: String. Default: Undefined.
 * `path`: **Required.** Defines the file in which Puppet will ensure the line specified by `line`. Must be an absolute path to the file.
 
 

--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -61,20 +61,22 @@ Puppet::Type.type(:file_line).provide(:ruby) do
   def handle_create_with_after
     regex = Regexp.new(resource[:after])
     count = count_matches(regex)
-    case count
-    when 1 # find the line to put our line after
-      File.open(resource[:path], 'w') do |fh|
-        lines.each do |l|
-          fh.puts(l)
-          if regex.match(l) then
-            fh.puts(resource[:line])
-          end
+
+    if count > 1 && resource[:multiple].to_s != 'true'
+      raise Puppet::Error, "#{count} lines match pattern '#{resource[:after]}' in file '#{resource[:path]}'.  One or no line must match the pattern."
+    end
+
+    File.open(resource[:path], 'w') do |fh|
+      lines.each do |l|
+        fh.puts(l)
+        if regex.match(l) then
+          fh.puts(resource[:line])
         end
       end
-    when 0 # append the line to the end of the file
+    end
+
+    if (count == 0) # append the line to the end of the file
       append_line
-    else
-      raise Puppet::Error, "#{count} lines match pattern '#{resource[:after]}' in file '#{resource[:path]}'.  One or no line must match the pattern."
     end
   end
 

--- a/spec/unit/puppet/provider/file_line/ruby_spec.rb
+++ b/spec/unit/puppet/provider/file_line/ruby_spec.rb
@@ -201,7 +201,7 @@ describe provider_class do
         end
       end
 
-      context 'with two lines matching the after expression' do
+      context 'with multiple lines matching the after expression' do
         before :each do
           File.open(@tmpfile, 'w') do |fh|
             fh.write("foo1\nfoo = blah\nfoo2\nfoo1\nfoo = baz")
@@ -210,6 +210,22 @@ describe provider_class do
 
         it 'errors out stating "One or no line must match the pattern"' do
           expect { provider.create }.to raise_error(Puppet::Error, /One or no line must match the pattern/)
+        end
+
+        it 'adds the line after all lines matching the after expression' do
+          @resource = Puppet::Type::File_line.new(
+            {
+              :name     => 'foo',
+              :path     => @tmpfile,
+              :line     => 'inserted = line',
+              :after    => '^foo1$',
+              :multiple => true,
+            }
+          )
+          @provider = provider_class.new(@resource)
+          expect(@provider.exists?).to be_nil
+          @provider.create
+          expect(File.read(@tmpfile).chomp).to eql("foo1\ninserted = line\nfoo = blah\nfoo2\nfoo1\ninserted = line\nfoo = baz")
         end
       end
 


### PR DESCRIPTION
Without this, `file_line` resource without the `match` parameter but with the `after` param will throw an error if there are multiple matches for the after expression. This patch creates the handling for the `multiple` parameter in handle_create_with_after. This allows you to add a line after the `after` expression if it appears at multiple points in a file without specifying the `match` param.

Updated reference to `file_line` in the README to reflect that the multiple parameter can be set when using `after` and/or `match` as the matching regex.