### PR TITLE
Improve fqdn_rotate/fqdn_rand_string acceptance tests

### DIFF
--- a/spec/acceptance/fqdn_rand_string_spec.rb
+++ b/spec/acceptance/fqdn_rand_string_spec.rb
@@ -39,6 +39,19 @@ describe 'fqdn_rand_string function', :unless => UNSUPPORTED_PLATFORMS.include?(
         expect(r.stdout).to match(/fqdn_rand_string is "7oDp0KOr1b"/)
       end
     end
+    it 'generates random alphanumeric strings with custom charsets' do
+      shell("echo fqdn=fakehost.localdomain > '#{facts_d}/fqdn.txt'")
+      pp = <<-eos
+      $l = 10
+      $c = '0123456789'
+      $o = fqdn_rand_string($l, $c)
+      notice(inline_template('fqdn_rand_string is <%= @o.inspect %>'))
+      eos
+
+      apply_manifest(pp, :catch_failures => true) do |r|
+        expect(r.stdout).to match(/fqdn_rand_string is "7203048515"/)
+      end
+    end
     it 'generates random alphanumeric strings with custom seeds' do
       shell("echo fqdn=fakehost.localdomain > '#{facts_d}/fqdn.txt'")
       pp = <<-eos
@@ -50,6 +63,20 @@ describe 'fqdn_rand_string function', :unless => UNSUPPORTED_PLATFORMS.include?(
 
       apply_manifest(pp, :catch_failures => true) do |r|
         expect(r.stdout).to match(/fqdn_rand_string is "3HS4mbuI3E"/)
+      end
+    end
+    it 'generates random alphanumeric strings with custom charsets and seeds' do
+      shell("echo fqdn=fakehost.localdomain > '#{facts_d}/fqdn.txt'")
+      pp = <<-eos
+      $l = 10
+      $c = '0123456789'
+      $s = 'seed'
+      $o = fqdn_rand_string($l, $c, $s)
+      notice(inline_template('fqdn_rand_string is <%= @o.inspect %>'))
+      eos
+
+      apply_manifest(pp, :catch_failures => true) do |r|
+        expect(r.stdout).to match(/fqdn_rand_string is "3104058232"/)
       end
     end
   end

--- a/spec/acceptance/fqdn_rotate_spec.rb
+++ b/spec/acceptance/fqdn_rotate_spec.rb
@@ -27,7 +27,7 @@ describe 'fqdn_rotate function', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
         shell("mkdir -p '#{facts_d}'")
       end
     end
-    it 'fqdn_rotates floats' do
+    it 'rotates arrays' do
       shell("echo fqdn=fakehost.localdomain > '#{facts_d}/fqdn.txt'")
       pp = <<-EOS
       $a = ['a','b','c','d']
@@ -39,9 +39,47 @@ describe 'fqdn_rotate function', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
         expect(r.stdout).to match(/fqdn_rotate is \["d", "a", "b", "c"\]/)
       end
     end
+    it 'rotates arrays with custom seeds' do
+      shell("echo fqdn=fakehost.localdomain > '#{facts_d}/fqdn.txt'")
+      pp = <<-EOS
+      $a = ['a','b','c','d']
+      $s = 'seed'
+      $o = fqdn_rotate($a, $s)
+      notice(inline_template('fqdn_rotate is <%= @o.inspect %>'))
+      EOS
+
+      apply_manifest(pp, :catch_failures => true) do |r|
+        expect(r.stdout).to match(/fqdn_rotate is \["c", "d", "a", "b"\]/)
+      end
+    end
+    it 'rotates strings' do
+      shell("echo fqdn=fakehost.localdomain > '#{facts_d}/fqdn.txt'")
+      pp = <<-EOS
+      $a = 'abcd'
+      $o = fqdn_rotate($a)
+      notice(inline_template('fqdn_rotate is <%= @o.inspect %>'))
+      EOS
+
+      apply_manifest(pp, :catch_failures => true) do |r|
+        expect(r.stdout).to match(/fqdn_rotate is "dabc"/)
+      end
+    end
+    it 'rotates strings with custom seeds' do
+      shell("echo fqdn=fakehost.localdomain > '#{facts_d}/fqdn.txt'")
+      pp = <<-EOS
+      $a = 'abcd'
+      $s = 'seed'
+      $o = fqdn_rotate($a, $s)
+      notice(inline_template('fqdn_rotate is <%= @o.inspect %>'))
+      EOS
+
+      apply_manifest(pp, :catch_failures => true) do |r|
+        expect(r.stdout).to match(/fqdn_rotate is "cdab"/)
+      end
+    end
   end
   describe 'failure' do
     it 'handles improper argument counts'
-    it 'handles non-numbers'
+    it 'handles invalid arguments'
   end
 end


### PR DESCRIPTION
This adds acceptance tests validating custom seed functionality in `fqdn_rotate()` and custom character set functionality in `fqdn_rand_string()`.

This depends on #462.