### PR TITLE
Gemfile: specify minimum rspec-puppet version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 group :development, :unit_tests do
   gem 'rake', '~> 10.1.0',       :require => false
   gem 'rspec', '~> 3.1.0',       :require => false
-  gem 'rspec-puppet',            :require => false
+  gem 'rspec-puppet', '~> 2.2',  :require => false
   gem 'mocha',                   :require => false
   # keep for its rake task for now
   gem 'puppetlabs_spec_helper',  :require => false


### PR DESCRIPTION
Only 2.2 contains all the features we're currently using. Documenting
that in the Gemfile should make that clear.