### PR TITLE
Fix time() on 1.8.7

### DIFF
--- a/lib/puppet/parser/functions/time.rb
+++ b/lib/puppet/parser/functions/time.rb
@@ -33,13 +33,14 @@ Will return something like: 1311972653
 
       ENV['TZ'] = time_zone
 
-      time = local_time.localtime
+      result = local_time.localtime.strftime('%s')
 
       ENV['TZ'] = original_zone
+    else
+      result = time.localtime.strftime('%s')
     end
 
     # Calling Time#to_i on a receiver changes it.  Trust me I am the Doctor.
-    result = time.strftime('%s')
     result = result.to_i
 
     return result

--- a/spec/functions/time_spec.rb
+++ b/spec/functions/time_spec.rb
@@ -7,7 +7,7 @@ describe 'time' do
   context 'when running at a specific time' do
     before(:each) {
       # get a value before stubbing the function
-      test_time = Time.utc(2006, 10, 13, 8, 15, 11, '+01:00')
+      test_time = Time.utc(2006, 10, 13, 8, 15, 11)
       Time.expects(:new).with().returns(test_time).once
     }
     it { is_expected.to run.with_params().and_return(1160727311) }
@@ -16,13 +16,6 @@ describe 'time' do
     it { is_expected.to run.with_params({}).and_return(1160727311) }
     it { is_expected.to run.with_params('foo').and_return(1160727311) }
     it { is_expected.to run.with_params('UTC').and_return(1160727311) }
-
-    context 'when running on modern rubies', :unless => RUBY_VERSION == '1.8.7' do
-      it { is_expected.to run.with_params('America/Los_Angeles').and_return(1160727311) }
-    end
-
-    context 'when running on ruby 1.8.7, which garbles the TZ', :if => RUBY_VERSION == '1.8.7' do
-      it { is_expected.to run.with_params('America/Los_Angeles').and_return(1160702111) }
-    end
+    it { is_expected.to run.with_params('America/New_York').and_return(1160727311) }
   end
 end


### PR DESCRIPTION
The time() function takes an argument of a timezone, and always returns
time in epoch format. The epoch format is the number of seconds that
have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
seconds. This means that it is universally the same regardless of
timezones.

I don't know what the timezone argument is supposed to do, and it is not
documented. So lets just make 1.8.7 work like > 1.8.7