### PR TITLE
Also catch :undefined_variable as thrown by future parser

### DIFF
--- a/lib/puppet/parser/functions/getvar.rb
+++ b/lib/puppet/parser/functions/getvar.rb
@@ -20,7 +20,9 @@ module Puppet::Parser::Functions
     end
 
     begin
-      self.lookupvar("#{args[0]}")
+      catch(:undefined_variable) do
+        self.lookupvar("#{args[0]}")
+      end
     rescue Puppet::ParseError # Eat the exception if strict_variables = true is set
     end
 


### PR DESCRIPTION
Also eat the throw from the future parser when strict_variables is true.