### PR TITLE
Add ensure_latest function.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -206,6 +206,10 @@ Converts the case of a string or of all strings in an array to lowercase. *Type*
 
 Returns 'true' if the variable is empty. *Type*: rvalue.
 
+#### `ensure_latest`
+
+Takes a list of packages and only installs them if they don't already exist. It optionally takes a hash as a second parameter to be passed as the third argument to the `ensure_resource()` function. By contrast to the `ensure_packages()` function, this function installs packages with `ensure=>'latest'` by default. *Type*: statement.
+
 #### `ensure_packages`
 
 Takes a list of packages and only installs them if they don't already exist. It optionally takes a hash as a second parameter to be passed as the third argument to the `ensure_resource()` function. *Type*: statement.

--- a/lib/puppet/parser/functions/ensure_latest.rb
+++ b/lib/puppet/parser/functions/ensure_latest.rb
@@ -1,0 +1,27 @@
+module Puppet::Parser::Functions
+  newfunction(:ensure_latest, :type => :statement, :doc => <<-EOS
+Takes a list of packages and only installs them if they don't already exist.
+It optionally takes a hash as a second parameter to be passed as the third
+argument to the ensure_resource() function. By contrast to the
+ensure_packages() function, this function installs packages with
+ensure=>'latest' by default.
+    EOS
+  ) do |arguments|
+
+    if arguments.size > 2 or arguments.size == 0
+      raise(Puppet::ParseError, "ensure_latest(): Wrong number of arguments " +
+        "given (#{arguments.size} for 1 or 2)")
+    elsif arguments.size == 2 and !arguments[1].is_a?(Hash)
+      raise(Puppet::ParseError, 'ensure_latest(): Requires second argument to be a Hash')
+    end
+
+    if arguments[1]
+      defaults = { 'ensure' => 'latest' }.merge(arguments[1])
+    else
+      defaults = { 'ensure' => 'latest' }
+    end
+
+    Puppet::Parser::Functions.function(:ensure_packages)
+    function_ensure_packages([arguments[0], defaults])
+  end
+end


### PR DESCRIPTION
This provides a convenient way to idempotently ask for a package, but also
makes it effortless to always get the latest version.  This prevents the
"version sprawl" enabled by ensure_packages, where machines in a fleet that
are provisioned over time get different package versions.  At the same time,
we are maintaining the familiar interface provided by ensure_packages.