### PR TITLE
Add support for Solaris 12

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -71,7 +71,8 @@
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
         "10",
-        "11"
+        "11",
+        "12"
       ]
     },
     {


### PR DESCRIPTION
Fairly self-explanatory.  This simply adds Solaris 12 to metadata.json.