### PR TITLE
catch and rescue from looking up non-existent facts

### DIFF
--- a/lib/puppet/parser/functions/has_interface_with.rb
+++ b/lib/puppet/parser/functions/has_interface_with.rb
@@ -38,8 +38,11 @@ has_interface_with("lo")                        => true
     # Bug with 3.7.1 - 3.7.3  when using future parser throws :undefined_variable
     # https://tickets.puppetlabs.com/browse/PUP-3597
     factval = nil
-    catch :undefined_variable do
-      factval = lookupvar(kind)
+    begin
+      catch :undefined_variable do
+        factval = lookupvar(kind)
+      end
+    rescue Puppet::ParseError # Eat the exception if strict_variables = true is set
     end
     if factval == value
       return true


### PR DESCRIPTION
facter (2.x) only provides facts without interface suffix for
 * ipaddress
 * netmask

'macaddress' and 'network' facts will always have the related interface
name appended. in turns lookupvar throws errors when strict_variables is
enabled.