### PR TITLE
Add validate_slength's optional 3rd arg to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -938,13 +938,14 @@ test, and the second argument should be a stringified regular expression (withou
 
 #### `validate_slength`
 
-Validates that the first argument is a string (or an array of strings), and is less than or equal to the length of the second argument. It fails if the first argument is not a string or array of strings, or if arg 2 is not convertable to a number.
+Validates that the first argument is a string (or an array of strings), and is less than or equal to the length of the second argument. It fails if the first argument is not a string or array of strings, or if arg 2 is not convertable to a number.  Optionally, a minimum string length can be given as the third argument.
 
   The following values pass:
 
   ~~~
   validate_slength("discombobulate",17)
   validate_slength(["discombobulate","moo"],17)
+  validate_slength(["discombobulate","moo"],17,3)
   ~~~
 
   The following values fail:
@@ -952,6 +953,7 @@ Validates that the first argument is a string (or an array of strings), and is l
   ~~~
   validate_slength("discombobulate",1)
   validate_slength(["discombobulate","thermometer"],5)
+  validate_slength(["discombobulate","moo"],17,10)
   ~~~
 
 *Type*: statement.

--- a/lib/puppet/parser/functions/validate_slength.rb
+++ b/lib/puppet/parser/functions/validate_slength.rb
@@ -43,9 +43,7 @@ module Puppet::Parser::Functions
       min_length = 0
     end
 
-    if min_length > max_length
-      raise Puppet::ParseError, "validate_slength(): Expected second argument to be equal to or larger than third argument"
-    end
+    raise Puppet::ParseError, "validate_slength(): Expected second argument to be equal to or larger than third argument" unless max_length >= min_length
 
     validator = lambda do |str|
       unless str.length <= max_length and str.length >= min_length

--- a/lib/puppet/parser/functions/validate_slength.rb
+++ b/lib/puppet/parser/functions/validate_slength.rb
@@ -3,7 +3,7 @@ module Puppet::Parser::Functions
   newfunction(:validate_slength, :doc => <<-'ENDHEREDOC') do |args|
     Validate that the first argument is a string (or an array of strings), and
     less/equal to than the length of the second argument. An optional third
-    parameter can be given a the minimum length. It fails if the first
+    parameter can be given the minimum length. It fails if the first
     argument is not a string or array of strings, and if arg 2 and arg 3 are
     not convertable to a number.
 
@@ -44,7 +44,7 @@ module Puppet::Parser::Functions
     end
 
     if min_length > max_length
-      raise Puppet::ParseError, "validate_slength(): Expected second argument to be larger than third argument"
+      raise Puppet::ParseError, "validate_slength(): Expected second argument to be equal to or larger than third argument"
     end
 
     validator = lambda do |str|

--- a/spec/functions/validate_slength_spec.rb
+++ b/spec/functions/validate_slength_spec.rb
@@ -10,7 +10,7 @@ describe 'validate_slength' do
     it { is_expected.to run.with_params('', -1).and_raise_error(Puppet::ParseError, /second argument to be a positive Numeric/) }
     it { is_expected.to run.with_params('', 1, '').and_raise_error(Puppet::ParseError, /third argument to be unset or a positive Numeric/) }
     it { is_expected.to run.with_params('', 1, -1).and_raise_error(Puppet::ParseError, /third argument to be unset or a positive Numeric/) }
-    it { is_expected.to run.with_params('', 1, 2).and_raise_error(Puppet::ParseError, /argument to be larger than third argument/) }
+    it { is_expected.to run.with_params('', 1, 2).and_raise_error(Puppet::ParseError, /argument to be equal to or larger than third argument/) }
   end
 
   context "with a maximum length of 10" do


### PR DESCRIPTION
I was thinking about creating a validate_non_empty_string function or a validate_minimum_slength function when I discovered validate_slength could already take a minimum string length as its 3rd argument.