### PR TITLE
Add load_metadata_json function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -449,6 +449,17 @@ Loads a YAML file containing an array, string, or hash, and returns the data in 
 
 *Type*: rvalue.
 
+#### `load_module_metadata`
+
+Loads the metadata.json of a target module. Can be used to determine module version and authorship for dynamic support of modules.
+
+  ~~~
+  $metadata = load_module_metadata('archive')
+  notify { $metadata['author']: }
+  ~~~
+
+*Type*: rvalue.
+
 #### `lstrip`
 
 Strips spaces to the left of a string. *Type*: rvalue.

--- a/lib/puppet/parser/functions/load_module_metadata.rb
+++ b/lib/puppet/parser/functions/load_module_metadata.rb
@@ -1,0 +1,16 @@
+module Puppet::Parser::Functions
+  newfunction(:load_module_metadata, :type => :rvalue, :doc => <<-EOT
+  EOT
+  ) do |args|
+    raise(Puppet::ParseError, "load_module_metadata(): Wrong number of arguments, expects one") unless args.size == 1
+    mod = args[0]
+    module_path = function_get_module_path([mod])
+    metadata_json = File.join(module_path, 'metadata.json')
+
+    raise(Puppet::ParseError, "load_module_metadata(): No metadata.json file for module #{mod}") unless File.exists?(metadata_json)
+
+    metadata = PSON.load(File.read(metadata_json))
+
+    return metadata
+  end
+end

--- a/spec/functions/load_module_metadata.rb
+++ b/spec/functions/load_module_metadata.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'load_module_metadata' do
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }
+  it { is_expected.to run.with_params("one", "two").and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }
+
+  it "should json parse the file" do
+     allow(scope).to receive(:function_get_module_path).with(['science']).and_return('/path/to/module/')
+     allow(File).to receive(:exists?).with(/metadata.json/).and_return(true)
+     allow(File).to receive(:read).with(/metadata.json/).and_return('{"name": "spencer-science"}')
+
+     result = subject.call(['science'])
+     expect(result['name']).to eq('spencer-science')
+  end
+end


### PR DESCRIPTION
This function loads the metadata.json into a puppet variable. This enables a number of neat things such as:

* Which version of the module am I using? 2.x? 3.x?
* Which author of the module am I using? puppetlabs? example42?