### PR TITLE
Fix documentation error in upcase

### DIFF
--- a/lib/puppet/parser/functions/upcase.rb
+++ b/lib/puppet/parser/functions/upcase.rb
@@ -12,7 +12,7 @@ Converts a string or an array of strings to uppercase.
 
 Will return:
 
-    ASDF
+    ABCD
   EOS
   ) do |arguments|
 


### PR DESCRIPTION
The documentation example shows an incorrect response when using the
function, this PR corrects the example to agree with what the function
actually does.