### PR TITLE
(MODULES-2316) Change file_type boolean parameter to symbols

### DIFF
--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -1,6 +1,6 @@
 Puppet::Type.type(:file_line).provide(:ruby) do
   def exists?
-    if !resource[:replace] and count_matches(match_regex) > 0
+    if resource[:replace].to_s != 'true' and count_matches(match_regex) > 0
       true
     else
       lines.find do |line|
@@ -10,7 +10,7 @@ Puppet::Type.type(:file_line).provide(:ruby) do
   end
 
   def create
-    unless !resource[:replace] and count_matches(match_regex) > 0
+    unless resource[:replace].to_s != 'true' and count_matches(match_regex) > 0
       if resource[:match]
         handle_create_with_match
       elsif resource[:after]

--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -1,4 +1,3 @@
-require 'puppet/parameter/boolean'
 Puppet::Type.newtype(:file_line) do
 
   desc <<-EOT
@@ -79,8 +78,9 @@ Puppet::Type.newtype(:file_line) do
     end
   end
 
-  newparam(:replace, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+  newparam(:replace) do
     desc 'If true, replace line that matches. If false, do not write line if a match is found'
+    newvalues(true, false)
     defaultto true
   end
 

--- a/spec/unit/puppet/provider/file_line/ruby_spec.rb
+++ b/spec/unit/puppet/provider/file_line/ruby_spec.rb
@@ -85,7 +85,7 @@ describe provider_class do
             :replace  => 'asgadga',
           }
         )
-      }.to raise_error(Puppet::Error, /Invalid value "asgadga"\. Valid values are true, false, yes, no\./)
+      }.to raise_error(Puppet::Error, /Invalid value "asgadga"\. Valid values are true, false\./)
     end
   end
   context "when matching" do

--- a/spec/unit/puppet/type/file_line_spec.rb
+++ b/spec/unit/puppet/type/file_line_spec.rb
@@ -50,7 +50,7 @@ describe Puppet::Type.type(:file_line) do
     expect(file_line[:ensure]).to eq :present
   end
   it 'should default to replace => true' do
-    expect(file_line[:replace]).to eq true
+    expect(file_line[:replace]).to eq :true
   end
 
   it "should autorequire the file it manages" do


### PR DESCRIPTION
Puppet's boolean parameter type is only available in Puppet 3.3 and
higher, so change file_type's new "replace" parameter to a regular
parameter with true and false as possible values.  This matches the
existing "multiple" parameter.