### PR TITLE
(MODULES-2331) Provide class for creating non-class resources with ENC

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -67,7 +67,23 @@ The `stdlib::stages` class declares various run stages for deploying infrastruct
 
 #### Public Classes
 
-  The stdlib class has no parameters.
+* `stdlib`: The stdlib class has no parameters.
+
+* `stdlib::hash_resources`: Takes a single 'resources' parameter to create multiple resources in the catalogue. They can be defined types, built-in resources, or other classes.  An example with an ENC's YAML:
+
+  ~~~
+  ---
+  classes:
+    stdlib::hash_resources:
+      resources:
+        file:
+          /tmp/foo:
+            ensure: present
+            content: test
+          /tmp/bar:
+            ensure: present
+            content: test
+  ~~~
 
 #### Private Classes
 
@@ -471,7 +487,7 @@ Returns the highest value of all arguments. Requires at least one argument. *Typ
 
 #### `member`
 
-This function determines if a variable is a member of an array. The variable can be either a string, array, or fixnum. For example, `member(['a','b'], 'b')` and `member(['a','b','c'], ['b','c'])` return 'true', while `member(['a','b'], 'c')` and `member(['a','b','c'], ['c','d'])` return 'false'. *Note*: This function does not support nested arrays. If the first argument contains nested arrays, it will not recurse through them. 
+This function determines if a variable is a member of an array. The variable can be either a string, array, or fixnum. For example, `member(['a','b'], 'b')` and `member(['a','b','c'], ['b','c'])` return 'true', while `member(['a','b'], 'c')` and `member(['a','b','c'], ['c','d'])` return 'false'. *Note*: This function does not support nested arrays. If the first argument contains nested arrays, it will not recurse through them.
 
 *Type*: rvalue.
 
@@ -519,10 +535,10 @@ From a list of values, returns the first value that is not undefined or an empty
 
 #### `prefix`
 
-Applies a prefix to all elements in an array, or to the keys in a hash.  
-For example: 
+Applies a prefix to all elements in an array, or to the keys in a hash.
+For example:
 * `prefix(['a','b','c'], 'p')` returns ['pa','pb','pc']
-* `prefix({'a'=>'b','b'=>'c','c'=>'d'}, 'p')` returns {'pa'=>'b','pb'=>'c','pc'=>'d'}.  
+* `prefix({'a'=>'b','b'=>'c','c'=>'d'}, 'p')` returns {'pa'=>'b','pb'=>'c','pc'=>'d'}.
 
 *Type*: rvalue.
 
@@ -1002,7 +1018,7 @@ Instead, use:
 
 #### `values`
 
-Returns the values of a given hash. For example, given `$hash = {'a'=1, 'b'=2, 'c'=3} values($hash)` returns [1,2,3]. 
+Returns the values of a given hash. For example, given `$hash = {'a'=1, 'b'=2, 'c'=3} values($hash)` returns [1,2,3].
 
 *Type*: rvalue.
 

--- a/lib/puppet/parser/functions/hash_resources.rb
+++ b/lib/puppet/parser/functions/hash_resources.rb
@@ -1,0 +1,14 @@
+# A wrapper to take multiple resources and pass each one to create_resources
+module Puppet::Parser::Functions
+  newfunction(:hash_resources) do |args|
+    hash = args[0]
+    raise Puppet::ParserError, "Must provide a hash" unless hash.is_a? Hash
+
+    Puppet::Parser::Functions.autoloader.load(:create_resources) \
+      unless Puppet::Parser::Functions.autoloader.loaded?(:create_resources)
+
+    hash.each do |resource, objects|
+      function_create_resources([resource, objects])
+    end
+  end
+end

--- a/manifests/hash_resources.pp
+++ b/manifests/hash_resources.pp
@@ -1,0 +1,47 @@
+# Class: hash_resources
+#
+# hash_resources can help you pass a hash of defined types, built-in
+# resources, classes, etc.  This is best used with an ENC.
+#
+# Parameters
+#
+# $resources::   A hash of resources
+#
+# Examples
+#
+# @example
+#  class { 'hash_resources':
+#    resources => {
+#      'file': {
+#        '/tmp/foo': {
+#          'ensure'   => 'present',
+#          'content' => 'test',
+#        },
+#        '/tmp/bar': {
+#          'ensure'   => 'present',
+#          'content' => 'test',
+#        }
+#      }
+#    }
+#  }
+#
+# @example
+#  ---
+#  classes:
+#    hash_resources:
+#      resources:
+#        file:
+#          /tmp/foo:
+#            ensure: present
+#            content: test
+#          /tmp/bar:
+#            ensure: present
+#            content: test
+#
+class stdlib::hash_resources(
+  $resources = {},
+) {
+
+  hash_resources($resources)
+
+}

--- a/spec/classes/stdlib_hash_resources_spec.rb
+++ b/spec/classes/stdlib_hash_resources_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'stdlib::hash_resources' do
+  let(:params) do {
+    :resources => {
+      'file' => {
+        '/tmp/foo' => {'ensure'=> 'present', 'content'=> 'foo'},
+        '/tmp/bar' => {'ensure'=> 'present', 'content'=> 'bar'},
+      }
+    }
+  } end
+
+  it { should contain_file('/tmp/foo').with_content('foo') }
+  it { should contain_file('/tmp/bar').with_content('bar') }
+end


### PR DESCRIPTION
PUP-1202 is a long desired feature when working with External Node Classifiers, to be able to create non-class resources. For example, a non-trivial amount of modules on the forge only provide defines, for use of the module as a library (e.g. something like puppetlabs-logrotate).

It would be nice if a helper would be included with stdlib to create multiple resources via an ENC.

I have this packaged as a [separate module](https://forge.puppetlabs.com/stbenjam/hash_resources), I wasn't sure if its generic enough for inclusion in stdlib, and I really understand why you might not want to include this.