### PR TITLE
[MODULES-2370] allow `match` parameter to influence `ensure => absent` behavior.

### DIFF
--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -34,6 +34,20 @@ Puppet::Type.newtype(:file_line) do
     In this code example match will look for a line beginning with export 
     followed by HTTP_PROXY and replace it with the value in line.
 
+    Match Example With `ensure => absent`:
+
+        file_line { 'bashrc_proxy':
+          ensure            => absent,
+          path              => '/etc/bashrc',
+          line              => 'export HTTP_PROXY=http://squid.puppetlabs.vm:3128',
+          match             => '^export\ HTTP_PROXY\=',
+          match_for_absence => true,
+        }
+
+    In this code example match will look for a line beginning with export
+    followed by HTTP_PROXY and delete it.  If multiple lines match, an
+    error will be raised unless the `multiple => true` parameter is set.
+
     **Autorequires:** If Puppet is managing the file that will contain the line
     being managed, the file_line resource will autorequire that file.
 
@@ -53,6 +67,14 @@ Puppet::Type.newtype(:file_line) do
          ' If a match is found, we replace that line rather than adding a new line.' +
          ' A regex comparisson is performed against the line value and if it does not' +
          ' match an exception will be raised. '
+  end
+
+  newparam(:match_for_absence) do
+    desc 'An optional value to determine if match should be applied when ensure => absent.' +
+         ' If set to true and match is set, the line that matches match will be deleted.' +
+         ' If set to false (the default), match is ignored when ensure => absent.'
+    newvalues(true, false)
+    defaultto false
   end
 
   newparam(:multiple) do

--- a/spec/unit/puppet/provider/file_line/ruby_spec.rb
+++ b/spec/unit/puppet/provider/file_line/ruby_spec.rb
@@ -341,4 +341,100 @@ describe provider_class do
       expect(File.read(@tmpfile)).to eql("foo1\nfoo2\n")
     end
   end
+
+  context "when removing with a match" do
+    before :each do
+      # TODO: these should be ported over to use the PuppetLabs spec_helper
+      #  file fixtures once the following pull request has been merged:
+      # https://github.com/puppetlabs/puppetlabs-stdlib/pull/73/files
+      tmp = Tempfile.new('tmp')
+      @tmpfile = tmp.path
+      tmp.close!
+      @resource = Puppet::Type::File_line.new(
+        {
+          :name              => 'foo',
+          :path              => @tmpfile,
+          :line              => 'foo2',
+          :ensure            => 'absent',
+          :match             => 'o$',
+          :match_for_absence => true,
+        }
+      )
+      @provider = provider_class.new(@resource)
+    end
+
+    it 'should remove one line if it matches' do
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write("foo1\nfoo\nfoo2")
+      end
+      @provider.destroy
+      expect(File.read(@tmpfile)).to eql("foo1\nfoo2")
+    end
+
+    it 'should raise an error if more than one line matches' do
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write("foo1\nfoo\nfoo2\nfoo\nfoo")
+      end
+      expect { @provider.destroy }.to raise_error(Puppet::Error, /More than one line/)
+    end
+
+    it 'should remove multiple lines if :multiple is true' do
+      @resource = Puppet::Type::File_line.new(
+        {
+          :name              => 'foo',
+          :path              => @tmpfile,
+          :line              => 'foo2',
+          :ensure            => 'absent',
+          :match             => 'o$',
+          :multiple          => true,
+          :match_for_absence => true,
+        }
+      )
+      @provider = provider_class.new(@resource)
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write("foo1\nfoo\nfoo2\nfoo\nfoo")
+      end
+      @provider.destroy
+      expect(File.read(@tmpfile)).to eql("foo1\nfoo2\n")
+    end
+
+    it 'should ignore the match if match_for_absense is not specified' do
+      @resource = Puppet::Type::File_line.new(
+        {
+          :name     => 'foo',
+          :path     => @tmpfile,
+          :line     => 'foo2',
+          :ensure   => 'absent',
+          :match    => 'o$',
+        }
+      )
+      @provider = provider_class.new(@resource)
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write("foo1\nfoo\nfoo2")
+      end
+      @provider.destroy
+      expect(File.read(@tmpfile)).to eql("foo1\nfoo\n")
+    end
+
+    it 'should ignore the match if match_for_absense is false' do
+      @resource = Puppet::Type::File_line.new(
+        {
+          :name              => 'foo',
+          :path              => @tmpfile,
+          :line              => 'foo2',
+          :ensure            => 'absent',
+          :match             => 'o$',
+          :match_for_absence => false,
+        }
+      )
+      @provider = provider_class.new(@resource)
+      File.open(@tmpfile, 'w') do |fh|
+        fh.write("foo1\nfoo\nfoo2")
+      end
+      @provider.destroy
+      expect(File.read(@tmpfile)).to eql("foo1\nfoo\n")
+    end
+
+  end
+
 end


### PR DESCRIPTION
Split the `destroy` method of the file_type::ruby provider into two
private methods:  `handle_destroy_line` which is the same as the previous
`destroy` method, and `handle_destroy_with_match` which will destroy any
line which matches the `match` parameter, raising an error if multiple
lines match and the `multiple` parameter is not `true`.  This new
behavior is only used if the new boolean parameter `match_for_absence`
is `true` (it defaults to `false`).