### PR TITLE
(MODULES-2410) Add new functions dos2unix and unix2dos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+##2015-08-13 - Supported Release 4.8.1
+###Summary
+
+Adds some new functions.
+
+####Features
+- Add new functions: `dos2unix` and `unix2dos`
+
+####Bugfixes
+- n/a
+
+####Improvements
+- n/a
+
 ## 2015-08-10 - Supported Release 4.8.0
 ### Summary
 This release adds a function for reading metadata.json from any module, and expands file\_line's abilities.

--- a/README.markdown
+++ b/README.markdown
@@ -199,6 +199,19 @@ Returns the difference between two arrays. The returned array is a copy of the o
 
 Returns the `dirname` of a path. For example, `dirname('/path/to/a/file.ext')` returns '/path/to/a'. *Type*: rvalue.
 
+#### `dos2unix`
+
+Returns the Unix version of the given string. Very useful when using a File resource with a cross-platform template. *Type*: rvalue.
+
+~~~
+file{$config_file:
+  ensure  => file,
+  content => dos2unix(template('my_module/settings.conf.erb')),
+}
+~~~
+
+See also [unix2dos](#unix2dos).
+
 #### `downcase`
 
 Converts the case of a string or of all strings in an array to lowercase. *Type*: rvalue.
@@ -471,7 +484,7 @@ Returns the highest value of all arguments. Requires at least one argument. *Typ
 
 #### `member`
 
-This function determines if a variable is a member of an array. The variable can be either a string, array, or fixnum. For example, `member(['a','b'], 'b')` and `member(['a','b','c'], ['b','c'])` return 'true', while `member(['a','b'], 'c')` and `member(['a','b','c'], ['c','d'])` return 'false'. *Note*: This function does not support nested arrays. If the first argument contains nested arrays, it will not recurse through them. 
+This function determines if a variable is a member of an array. The variable can be either a string, array, or fixnum. For example, `member(['a','b'], 'b')` and `member(['a','b','c'], ['b','c'])` return 'true', while `member(['a','b'], 'c')` and `member(['a','b','c'], ['c','d'])` return 'false'. *Note*: This function does not support nested arrays. If the first argument contains nested arrays, it will not recurse through them.
 
 *Type*: rvalue.
 
@@ -520,7 +533,7 @@ From a list of values, returns the first value that is not undefined or an empty
 #### `prefix`
 
 Applies a prefix to all elements in an array, or to the keys in a hash.  
-For example: 
+For example:
 * `prefix(['a','b','c'], 'p')` returns ['pa','pb','pc']
 * `prefix({'a'=>'b','b'=>'c','c'=>'d'}, 'p')` returns {'pa'=>'b','pb'=>'c','pc'=>'d'}.  
 
@@ -696,6 +709,19 @@ Returns a union of two arrays, without duplicates. For example, `union(["a","b",
 #### `unique`
 
 Removes duplicates from strings and arrays. For example, `unique("aabbcc")` returns 'abc', and `unique(["a","a","b","b","c","c"])` returns ["a","b","c"]. *Type*: rvalue.
+
+#### `unix2dos`
+
+Returns the DOS version of the given string. Very useful when using a File resource with a cross-platform template. *Type*: rvalue.
+
+~~~
+file{$config_file:
+  ensure  => file,
+  content => unix2dos(template('my_module/settings.conf.erb')),
+}
+~~~
+
+See also [dos2unix](#dos2unix).
 
 #### `upcase`
 
@@ -1002,7 +1028,7 @@ Instead, use:
 
 #### `values`
 
-Returns the values of a given hash. For example, given `$hash = {'a'=1, 'b'=2, 'c'=3} values($hash)` returns [1,2,3]. 
+Returns the values of a given hash. For example, given `$hash = {'a'=1, 'b'=2, 'c'=3} values($hash)` returns [1,2,3].
 
 *Type*: rvalue.
 
@@ -1048,7 +1074,3 @@ To report or research a bug with any part of this module, please go to
 ##Contributors
 
 The list of contributors can be found at: https://github.com/puppetlabs/puppetlabs-stdlib/graphs/contributors
-
-
-
-

--- a/lib/puppet/parser/functions/dos2unix.rb
+++ b/lib/puppet/parser/functions/dos2unix.rb
@@ -1,0 +1,15 @@
+# Custom Puppet function to convert dos to unix format
+module Puppet::Parser::Functions
+  newfunction(:dos2unix, :type => :rvalue, :arity => 1, :doc => <<-EOS
+    Returns the Unix version of the given string.
+    Takes a single string argument.
+    EOS
+  ) do |arguments|
+
+    unless arguments[0].is_a?(String)
+      raise(Puppet::ParseError, 'dos2unix(): Requires string as argument')
+    end
+
+    arguments[0].gsub(/\r\n/, "\n")
+  end
+end

--- a/lib/puppet/parser/functions/unix2dos.rb
+++ b/lib/puppet/parser/functions/unix2dos.rb
@@ -1,0 +1,15 @@
+# Custom Puppet function to convert unix to dos format
+module Puppet::Parser::Functions
+  newfunction(:unix2dos, :type => :rvalue, :arity => 1, :doc => <<-EOS
+    Returns the DOS version of the given string.
+    Takes a single string argument.
+    EOS
+  ) do |arguments|
+
+    unless arguments[0].is_a?(String)
+      raise(Puppet::ParseError, 'unix2dos(): Requires string as argument')
+    end
+
+    arguments[0].gsub(/\r*\n/, "\r\n")
+  end
+end

--- a/spec/functions/dos2unix_spec.rb
+++ b/spec/functions/dos2unix_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'dos2unix' do
+  context 'Checking parameter validity' do
+    it { is_expected.not_to eq(nil) }
+    it do
+      is_expected.to run.with_params.and_raise_error(ArgumentError, /Wrong number of arguments/)
+    end
+    it do
+      is_expected.to run.with_params('one', 'two').and_raise_error(ArgumentError, /Wrong number of arguments/)
+    end
+    it do
+      is_expected.to run.with_params([]).and_raise_error(Puppet::ParseError)
+    end
+    it do
+      is_expected.to run.with_params({}).and_raise_error(Puppet::ParseError)
+    end
+    it do
+      is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError)
+    end
+  end
+
+  context 'Converting from dos to unix format' do
+    sample_text    = "Hello\r\nWorld\r\n"
+    desired_output = "Hello\nWorld\n"
+
+    it 'should output unix format' do
+      should run.with_params(sample_text).and_return(desired_output)
+    end
+  end
+
+  context 'Converting from unix to unix format' do
+    sample_text    = "Hello\nWorld\n"
+    desired_output = "Hello\nWorld\n"
+
+    it 'should output unix format' do
+      should run.with_params(sample_text).and_return(desired_output)
+    end
+  end
+end

--- a/spec/functions/unix2dos_spec.rb
+++ b/spec/functions/unix2dos_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'unix2dos' do
+  context 'Checking parameter validity' do
+    it { is_expected.not_to eq(nil) }
+    it do
+      is_expected.to run.with_params.and_raise_error(ArgumentError, /Wrong number of arguments/)
+    end
+    it do
+      is_expected.to run.with_params('one', 'two').and_raise_error(ArgumentError, /Wrong number of arguments/)
+    end
+    it do
+      is_expected.to run.with_params([]).and_raise_error(Puppet::ParseError)
+    end
+    it do
+      is_expected.to run.with_params({}).and_raise_error(Puppet::ParseError)
+    end
+    it do
+      is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError)
+    end
+  end
+
+  context 'Converting from unix to dos format' do
+    sample_text    = "Hello\nWorld\n"
+    desired_output = "Hello\r\nWorld\r\n"
+
+    it 'should output dos format' do
+      should run.with_params(sample_text).and_return(desired_output)
+    end
+  end
+
+  context 'Converting from dos to dos format' do
+    sample_text    = "Hello\r\nWorld\r\n"
+    desired_output = "Hello\r\nWorld\r\n"
+
+    it 'should output dos format' do
+      should run.with_params(sample_text).and_return(desired_output)
+    end
+  end
+end


### PR DESCRIPTION
Add dos2unix and unix2dos functions to stdlib so that when using File resources with cross platform templates, the correct line endings can be enforced.

To show usage, here's an extract from README.md:
#### `dos2unix`
 
Returns the Unix version of the given string. Very useful when using a File resource with a cross-platform template.
 
~~~
file{$config_file:
  ensure  => file,
  content => dos2unix(template('my_module/settings.conf.erb')),
}
~~~
 
#### `unix2dos`
 
Returns the DOS version of the given string. Very useful when using a File resource with a cross-platform template.
 
~~~
file{$config_file:
  ensure  => file,
  content => unix2dos(template('my_module/settings.conf.erb')),
}
~~~