### PR TITLE
Add a service_provider fact

### DIFF
--- a/lib/facter/service_provider.rb
+++ b/lib/facter/service_provider.rb
@@ -1,0 +1,14 @@
+# Fact: service_provider
+#
+# Purpose: Returns the default provider Puppet will choose to manage services
+#   on this system
+#
+# Resolution: Instantiates a dummy service resource and return the provider
+#
+# Caveats:
+#
+Facter.add(:service_provider) do
+  setcode do
+    Puppet::Type.type(:service).newservice(:name => 'dummy')[:provider].to_s
+  end
+end

--- a/spec/unit/facter/service_provider_spec.rb
+++ b/spec/unit/facter/service_provider_spec.rb
@@ -1,0 +1,37 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+require 'puppet/type'
+require 'puppet/type/service'
+
+describe 'service_provider', :type => :fact do
+  before { Facter.clear }
+  after { Facter.clear }
+
+  context "macosx" do
+    it "should return launchd" do
+      provider = Puppet::Type.type(:service).provider(:launchd)
+      Puppet::Type.type(:service).stubs(:defaultprovider).returns provider
+
+      expect(Facter.fact(:service_provider).value).to eq('launchd')
+    end
+  end
+
+  context "systemd" do
+    it "should return systemd" do
+      provider = Puppet::Type.type(:service).provider(:systemd)
+      Puppet::Type.type(:service).stubs(:defaultprovider).returns provider
+
+      expect(Facter.fact(:service_provider).value).to eq('systemd')
+    end
+  end
+
+  context "redhat" do
+    it "should return redhat" do
+      provider = Puppet::Type.type(:service).provider(:redhat)
+      Puppet::Type.type(:service).stubs(:defaultprovider).returns provider
+
+      expect(Facter.fact(:service_provider).value).to eq('redhat')
+    end
+  end
+
+end


### PR DESCRIPTION
This returns the default provider Puppet will choose to manage services
on this system by instantiating a dummy service resource type and
returning the provider chosen.

The original suggestion came from @asasfu but I'm not sure how to credit him.