### PR TITLE
Ticket/MODULES-2478 Make root_home fact work on AIX using native lsuser command

### DIFF
--- a/lib/facter/root_home.rb
+++ b/lib/facter/root_home.rb
@@ -30,3 +30,16 @@ Facter.add(:root_home) do
     hash['dir'].strip
   end
 end
+
+Facter.add(:root_home) do
+  confine :kernel => :aix
+  root_home = nil
+  setcode do
+    str = Facter::Util::Resolution.exec("lsuser -C -a home root")
+    str && str.split("\n").each do |line|
+      next if line =~ /^#/
+      root_home = line.split(/:/)[1]
+    end
+    root_home
+  end
+end

--- a/spec/fixtures/lsuser/root
+++ b/spec/fixtures/lsuser/root
@@ -1,0 +1,2 @@
+#name:home
+root:/root

--- a/spec/unit/facter/root_home_spec.rb
+++ b/spec/unit/facter/root_home_spec.rb
@@ -49,4 +49,17 @@ describe 'root_home', :type => :fact do
     end
   end
 
+  context "aix" do
+    before do
+      Facter.fact(:kernel).stubs(:value).returns("AIX")
+      Facter.fact(:osfamily).stubs(:value).returns("AIX")
+    end
+    let(:expected_root_home) { "/root" }
+    sample_lsuser = File.read(fixtures('lsuser','root'))
+
+    it "should return /root" do
+      Facter::Util::Resolution.stubs(:exec).with("lsuser -C -a home root").returns(sample_lsuser)
+      expect(Facter.fact(:root_home).value).to eq(expected_root_home)
+    end
+  end
 end


### PR DESCRIPTION
The root_home fact returns nil on AIX due to the operating system not providing getent. The recommended replacement for this is the 'lsuser' command.

This PR adds a new fact, confined to kernel=>aix to use libuser to return root's configured home directory.