### PR TITLE
Adds an is_a() function

### DIFF
--- a/lib/puppet/functions/is_a.rb
+++ b/lib/puppet/functions/is_a.rb
@@ -1,0 +1,26 @@
+# Boolean check to determine whether a variable is of a given data type.
+#
+# @example how to check a data type
+#   # check a data type
+#       foo = 3
+#       $bar = [1,2,3]
+#       $baz = 'A string!'
+#
+#       if $foo.is_a(Integer) {
+#         notify  { 'foo!': }
+#       }
+#       if $bar.is_a(Array) {
+#         notify { 'bar!': }
+#       }
+#       if $baz.is_a(String) {
+#         notify { 'baz!': }
+#       }
+#
+# See the documentation for "The Puppet Type System" for more information about types.
+# See the `assert_type()` function for flexible ways to assert the type of a value.
+#
+Puppet::Functions.create_function(:is_a) do
+  def is_a(type, value)
+    Puppet::Pops::Types::TypeCalculator.instance?(value,type)
+  end
+end

--- a/spec/functions/is_a.rb
+++ b/spec/functions/is_a.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+if ENV["FUTURE_PARSER"] == 'yes'
+  describe 'type_of' do
+    pending 'teach rspec-puppet to load future-only functions under 3.7.5'
+  end
+end
+
+if Puppet.version.to_f >= 4.0
+  describe 'is_a' do
+    it { is_expected.to run.with_params().and_raise_error(ArgumentError) }
+    it { is_expected.to run.with_params('', '').and_raise_error(ArgumentError) }
+
+    it 'succeeds when comparing a string and a string' do
+      expect(subject.call({}, 'hello world', String)).to be_true
+    end
+
+    it 'fails when comparing an integer and a string' do
+      expect(subject.call({}, 5, String)).to be_false
+    end
+  end
+end


### PR DESCRIPTION
The data type system is very hard to understand. Many people don't understand why

    type_of([1,2,3]) == Array

will fail, but

    type_of([1,2,3]) <= Array

passes. This does a simpler validation that doesn't rely on explicit data types. Instead, use

    $foo = [1,2,3]
    if $foo.is_a(Array) {
      notify { 'This is an array': }
    }