### PR TITLE
accept any case of boolean strings

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -623,7 +623,7 @@ Returns a new string where runs of the same character that occur in this set are
 
 #### `str2bool`
 
-Converts a string to a boolean. This attempts to convert strings that contain values such as '1', 't', 'y', and 'yes' to 'true' and strings that contain values such as '0', 'f', 'n', and 'no' to 'false'. *Type*: rvalue.
+Converts a string to a boolean regardless of case. This attempts to convert strings that contain values such as '1', 't', 'y', 'Y', 'YES','yes', and 'TRUE' to 'true' and strings that contain values such as '0', 'f','F', 'N','n', 'NO','FALSE', and 'no' to 'false'. *Type*: rvalue.  
 
 #### `str2saltedsha512`
 

--- a/lib/puppet/parser/functions/str2bool.rb
+++ b/lib/puppet/parser/functions/str2bool.rb
@@ -5,8 +5,8 @@
 module Puppet::Parser::Functions
   newfunction(:str2bool, :type => :rvalue, :doc => <<-EOS
 This converts a string to a boolean. This attempt to convert strings that
-contain things like: y, 1, t, true to 'true' and strings that contain things
-like: 0, f, n, false, no to 'false'.
+contain things like: Y,y, 1, T,t, TRUE,true to 'true' and strings that contain things
+like: 0, F,f, N,n, false, FALSE, no to 'false'.
     EOS
   ) do |arguments|
 
@@ -32,8 +32,8 @@ like: 0, f, n, false, no to 'false'.
       # We yield false in this case.
       #
       when /^$/, '' then false # Empty string will be false ...
-      when /^(1|t|y|true|yes)$/  then true
-      when /^(0|f|n|false|no)$/  then false
+      when /^(1|t|y|true|yes)$/i  then true
+      when /^(0|f|n|false|no)$/i  then false
       when /^(undef|undefined)$/ then false # This is not likely to happen ...
       else
         raise(Puppet::ParseError, 'str2bool(): Unknown type of boolean given')

--- a/spec/functions/str2bool_spec.rb
+++ b/spec/functions/str2bool_spec.rb
@@ -10,13 +10,13 @@ describe 'str2bool' do
   it { is_expected.to run.with_params('one').and_raise_error(Puppet::ParseError, /Unknown type of boolean given/) }
 
   describe 'when testing values that mean "true"' do
-    [ '1', 't', 'y', 'true', 'yes', true ].each do |value|
+    [ 'TRUE','1', 't', 'y', 'true', 'yes', true ].each do |value|
       it { is_expected.to run.with_params(value).and_return(true) }
     end
   end
 
   describe 'when testing values that mean "false"' do
-    [ '', '0', 'f', 'n', 'false', 'no', false, 'undef', 'undefined' ].each do |value|
+    [ 'FALSE','', '0', 'f', 'n', 'false', 'no', false, 'undef', 'undefined' ].each do |value|
       it { is_expected.to run.with_params(value).and_return(false) }
     end
   end


### PR DESCRIPTION
  * previously the str2bool function did not accept 'TRUE' as a bool
    type. This causes the function to now accept TRUE | FALSE strings
    as a boolean type in order to be converted to a proper boolean.
  * This would also cause Y, N, YES, NO to be accepted as boolean types
    as well.