### PR TITLE
Add function destringify

### DIFF
--- a/lib/puppet/parser/functions/destringify.rb
+++ b/lib/puppet/parser/functions/destringify.rb
@@ -1,0 +1,63 @@
+#
+# destringify.rb
+#
+# Loads a fact or other variable, and in case of a stringified fact containing an
+# array, string, or hash, it returns the data in the corresponding native data type.
+#
+# Puppet 3.x will sometimes convert all fact values to strings
+# (e.g. "false" instead of false), depending on the stringify_facts setting
+# and the installed Facter version.
+#
+# If you’re writing code that might be used with pre-4.0 versions of Puppet,
+# you’ll need to take extra care when dealing with structured facts.
+#
+# For example:
+#
+# if the '::processors' fact is stringified as follow:
+#   "{\"count\"=>8, \"speed\"=>\"2.7 GHz\"}"
+#
+#   $my_destringified_processors_fact = destringify(::processors)
+#
+#   => {"count"=>8, "speed"=>"2.7 GHz"}
+#
+#
+# This could also be done with following puppet/stdlib functions:
+#
+#   $_fact = $::my_structured_fact
+#   if is_string($_fact) {
+#     $_yaml = regsubst($_fact,'=>',': ', 'G')
+#     $_destringified_fact = parseyaml($_yaml)
+#   } else {
+#     $_destringified_fact = $_fact
+#   }
+#
+# But using this function it will be reduced to:
+#
+#   $_destringified_fact = destringify($::my_structured_fact)
+#
+#
+
+require 'yaml'
+
+module Puppet::Parser::Functions
+  newfunction(:destringify, :type => :rvalue, :doc => <<-EOS
+Returns hashes, arrays, boolean and integers flattened (stringified) to strings.
+EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "destringify(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size != 1
+
+    value = arguments[0]
+
+    if value.is_a?(String)
+      result = YAML.load(value.gsub( /=>/, ': '))
+    else
+      result = value
+    end
+
+    return result
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/spec/functions/destringify_spec.rb
+++ b/spec/functions/destringify_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe "the destringify function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    expect(Puppet::Parser::Functions.function("destringify")).to eq("function_destringify")
+  end
+
+  it "should raise a ParseError if there is less than 1 arguments" do
+    expect { scope.function_destringify([]) }.to( raise_error(Puppet::ParseError))
+  end
+
+  it "should raise a ParseError if there is more than 1 arguments" do
+    expect { scope.function_destringify(['a','b']) }.to( raise_error(Puppet::ParseError))
+  end
+
+  it "should destringify a stringified hash" do
+    result = scope.function_destringify(["{\"key1\"=>{\"key11\"=>11, \"key12\"=>12}}"])
+    expect(result).to(eq({'key1' => { 'key11' => 11 ,'key12' => 12}}))
+  end
+
+  it "should destringify a stringified array" do
+    result = scope.function_destringify(["[\"one\", true, 100]"])
+    expect(result).to(eq(['one', true, 100]))
+  end
+
+  it "should destringify a stringified boolean" do
+    result = scope.function_destringify(["true"])
+    expect(result).to(eq(true))
+  end
+
+  it "should destringify a stringified integer" do
+    result = scope.function_destringify(["1000"])
+    expect(result).to(eq(1000))
+  end
+
+  it "should passthrough a hash" do
+    result = scope.function_destringify([{'key1' => { 'key11' => 11 ,'key12' => 12}}])
+    expect(result).to(eq({'key1' => { 'key11' => 11 ,'key12' => 12}}))
+  end
+
+  it "should passthrough an array" do
+    result = scope.function_destringify([['one', true, 100]])
+    expect(result).to(eq(['one', true, 100]))
+  end
+
+  it "should passthrough an integer" do
+    result = scope.function_destringify([1000])
+    expect(result).to(eq(1000))
+  end
+
+  it "should passthrough a boolean" do
+    result = scope.function_destringify([true])
+    expect(result).to(eq(true))
+  end
+
+  it "should passthrough a standard string" do
+    result = scope.function_destringify(["hello there, i'm a standard string"])
+    expect(result).to(eq("hello there, i'm a standard string"))
+  end
+
+end


### PR DESCRIPTION
Loads a fact or other variable, and in case of a stringified fact
containing an
array, string, or hash, it returns the data in the corresponding
native data type.

Puppet 3.x will sometimes convert all fact values to strings
(e.g. "false" instead of false), depending on the stringify_facts
setting
and the installed Facter version.

If you’re writing code that might be used with pre-4.0 versions of
Puppet,
you’ll need to take extra care when dealing with structured facts.

For example:

if the '::processors' fact is stringified as follow:
```ruby
  "{\"count\"=>8, \"speed\"=>\"2.7 GHz\"}"

  $my_destringified_processors_fact = destringify(::processors)
    => {"count"=>8, "speed"=>"2.7 GHz"}
```

This could also be done with following puppet/stdlib functions:
```puppet
  $_fact = $::my_structured_fact
  if is_string($_fact) {
    $_yaml = regsubst($_fact,'=>',': ', 'G')
    $_destringified_fact = parseyaml($_yaml)
  } else {
    $_destringified_fact = $_fact
  }
```

But using this function it will be reduced to:
```puppet
$_destringified_fact = destringify($::my_structured_fact)
```