### PR TITLE
(#MODULES-2584) add new function 'parents'

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -541,6 +541,33 @@ Returns the lowest value of all arguments. Requires at least one argument. *Type
 
 Converts a number or a string representation of a number into a true boolean. Zero or anything non-numeric becomes 'false'. Numbers greater than 0 become 'true'. *Type*: rvalue.
 
+#### `parents`
+
+Returns an array containing the parent directories of a given absolute pathname. Very useful when using the file resource to avoid the Puppet error `Cannot create /xxx/yyy; parent directory /xxx does not exist`. *Type*: rvalue.
+
+Sample usage:
+~~~
+
+file {parents($install_dir):
+  ensure => directory,
+} ->
+
+file {$install_dir:
+  ensure => directory,
+}
+
+~~~
+
+Condensed form:
+~~~
+
+file {[ parents($install_dir), $install_dir ]:
+  ensure => directory,
+}
+
+~~~
+
+
 #### `parsejson`
 
 Converts a string of JSON into the correct Puppet structure. *Type*: rvalue.

--- a/lib/puppet/parser/functions/parents.rb
+++ b/lib/puppet/parser/functions/parents.rb
@@ -1,0 +1,39 @@
+# Custom Puppet function to return parent directories in a pathname
+module Puppet::Parser::Functions
+  newfunction(:parents, :type => :rvalue, :arity => 1, :doc => <<-'ENDHEREDOC') do |args|
+
+    Parents will return an array containing all the parent directories of the given pathname, not including the last node in the path.
+
+    It can be very useful to avoid the Puppet error that the parent directory does not exist. For example:
+
+    file {[ parents($install_dir), $install_dir ]:
+      ensure => directory,
+    }
+
+    ENDHEREDOC
+
+    path_name = args[0]
+
+    if path_name.is_a?(String)
+      unless function_validate_absolute_path([path_name])
+        raise(Puppet::ParseError, 'parents(): Requires an absolute pathname as an argument')
+      end
+    else
+      raise(Puppet::ParseError, 'parents(): Requires string as argument')
+    end
+
+    if path_name =~ /[a-zA-Z]:\\/
+      separator = "\\"
+    else
+      separator = '/'
+    end
+
+    item = path_name.split(separator)
+    for i in 1..item.length-1 do
+      item[i] = "#{item[ i-1 ]}#{separator}#{item[i]}"
+    end
+    item.shift
+    item.pop
+    item
+  end
+end

--- a/spec/functions/parents_spec.rb
+++ b/spec/functions/parents_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe 'parents' do
+
+  context 'Checking parameter validity' do
+    it { is_expected.not_to eq(nil) }
+    it do
+      is_expected.to run.with_params.and_raise_error(ArgumentError, /Wrong number of arguments/)
+    end
+    it do
+      is_expected.to run.with_params('one', 'two').and_raise_error(ArgumentError, /Wrong number of arguments/)
+    end
+    it do
+      is_expected.to run.with_params([]).and_raise_error(Puppet::ParseError)
+    end
+    it do
+      is_expected.to run.with_params({}).and_raise_error(Puppet::ParseError)
+    end
+    it do
+      is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError)
+    end
+    it do
+      is_expected.to run.with_params('../var/tmp/ssl').and_raise_error(Puppet::ParseError)
+    end
+  end
+
+  context 'Running with Unix style pathname' do
+    sample_text    = '/var/lib/puppet/facts.d'
+    desired_output = [
+      '/var',
+      '/var/lib',
+      '/var/lib/puppet',
+    ]
+
+    it 'should return correct array' do
+      should run.with_params(sample_text).and_return(desired_output)
+    end
+  end
+
+  context 'Running with Windows style pathname' do
+    sample_text    = 'C:\ProgramData\PuppetLabs\puppet\etc'
+    desired_output = [
+      'C:\ProgramData',
+      'C:\ProgramData\PuppetLabs',
+      'C:\ProgramData\PuppetLabs\puppet',
+    ]
+
+    it 'should return correct array' do
+      should run.with_params(sample_text).and_return(desired_output)
+    end
+  end
+end

--- a/spec/functions/parents_spec.rb~
+++ b/spec/functions/parents_spec.rb~
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'shared_contexts'
+
+describe 'parents' do
+
+  context 'Checking parameter validity' do
+    it { is_expected.not_to eq(nil) }
+    it do
+      is_expected.to run.with_params.and_raise_error(ArgumentError, /Wrong number of arguments/)
+    end
+    it do
+      is_expected.to run.with_params('one', 'two').and_raise_error(ArgumentError, /Wrong number of arguments/)
+    end
+    it do
+      is_expected.to run.with_params([]).and_raise_error(Puppet::ParseError)
+    end
+    it do
+      is_expected.to run.with_params({}).and_raise_error(Puppet::ParseError)
+    end
+    it do
+      is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError)
+    end
+    it do
+      is_expected.to run.with_params('../var/tmp/ssl').and_raise_error(Puppet::ParseError)
+    end
+  end
+
+  context 'Running with Unix style pathname' do
+    sample_text    = '/var/lib/puppet/facts.d'
+    desired_output = [
+      '/var',
+      '/var/lib',
+      '/var/lib/puppet',
+    ]
+
+    it 'should return correct array' do
+      should run.with_params(sample_text).and_return(desired_output)
+    end
+  end
+
+  context 'Running with Windows style pathname' do
+    sample_text    = 'C:\ProgramData\PuppetLabs\puppet\etc'
+    desired_output = [
+      'C:\ProgramData',
+      'C:\ProgramData\PuppetLabs',
+      'C:\ProgramData\PuppetLabs\puppet',
+    ]
+
+    it 'should return correct array' do
+      should run.with_params(sample_text).and_return(desired_output)
+    end
+  end
+end


### PR DESCRIPTION
I would like to submit a new function to stdlib called 'parents'.

#### `parents`

Returns an array containing the parent directories of a given absolute pathname. Very useful when using the file resource to avoid the Puppet error `Cannot create /xxx/yyy; parent directory /xxx does not exist`. *Type*: rvalue.

Sample usage:
~~~

file {parents($install_dir):
  ensure => directory,
} ->

file {$install_dir:
  ensure => directory,
}

~~~

Condensed form:
~~~

file {[ parents($install_dir), $install_dir ]:
  ensure => directory,
}

~~~
