### PR TITLE
Fix backwards compatibility from #511

### DIFF
--- a/lib/puppet/parser/functions/parsejson.rb
+++ b/lib/puppet/parser/functions/parsejson.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:parsejson, :type => :rvalue, :arity => -2, :doc => <<-EOS
+  newfunction(:parsejson, :type => :rvalue, :doc => <<-EOS
 This function accepts JSON as a string and converts it into the correct
 Puppet structure.
 
@@ -15,8 +15,12 @@ be returned if the parsing of YAML string have failed.
 
     begin
       PSON::load(arguments[0]) || arguments[1]
-    rescue Exception
-      arguments[1]
+    rescue Exception => e
+      if arguments[1]
+        arguments[1]
+      else
+        raise e
+      end
     end
 
   end

--- a/lib/puppet/parser/functions/parseyaml.rb
+++ b/lib/puppet/parser/functions/parseyaml.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:parseyaml, :type => :rvalue, :arity => -2, :doc => <<-EOS
+  newfunction(:parseyaml, :type => :rvalue, :doc => <<-EOS
 This function accepts YAML as a string and converts it into the correct
 Puppet structure.
 
@@ -16,8 +16,12 @@ be returned if the parsing of YAML string have failed.
 
     begin
       YAML::load(arguments[0]) || arguments[1]
-    rescue Exception
-      arguments[1]
+    rescue Exception => e
+      if arguments[1]
+        arguments[1]
+      else
+        raise e
+      end
     end
 
   end

--- a/spec/acceptance/parsejson_spec.rb
+++ b/spec/acceptance/parsejson_spec.rb
@@ -21,12 +21,24 @@ describe 'parsejson function', :unless => UNSUPPORTED_PLATFORMS.include?(fact('o
     it 'raises error on incorrect json' do
       pp = <<-EOS
       $a = '{"hunter": "washere", "tests": "passing",}'
-      $ao = parsejson($a, {'tests' => 'using the default value'})
+      $ao = parsejson($a, 'tests are using the default value')
       notice(inline_template('a is <%= @ao.inspect %>'))
       EOS
 
       apply_manifest(pp, :catch_failures => true) do |r|
-        expect(r.stdout).to match(/tests are "using the default value"/)
+        expect(r.stdout).to match(/tests are using the default value/)
+      end
+    end
+
+    it 'raises error on incorrect json' do
+      pp = <<-EOS
+      $a = '{"hunter": "washere", "tests": "passing",}'
+      $ao = parsejson($a)
+      notice(inline_template('a is <%= @ao.inspect %>'))
+      EOS
+
+      apply_manifest(pp, :expect_failures => true) do |r|
+        expect(r.stderr).to match(/expected next name/)
       end
     end
 

--- a/spec/acceptance/parseyaml_spec.rb
+++ b/spec/acceptance/parseyaml_spec.rb
@@ -31,6 +31,20 @@ describe 'parseyaml function', :unless => UNSUPPORTED_PLATFORMS.include?(fact('o
       end
     end
 
+    it 'raises error on incorrect yaml' do
+      pp = <<-EOS
+      $a = "---\nhunter: washere\ntests: passing\n:"
+      $o = parseyaml($a)
+      $tests = $o['tests']
+      notice(inline_template('tests are <%= @tests.inspect %>'))
+      EOS
+
+      apply_manifest(pp, :expect_failures => true) do |r|
+        expect(r.stderr).to match(/(syntax error|did not find expected key)/)
+      end
+    end
+
+
     it 'raises error on incorrect number of arguments' do
       pp = <<-EOS
       $o = parseyaml()

--- a/spec/functions/parsejson_spec.rb
+++ b/spec/functions/parsejson_spec.rb
@@ -41,10 +41,10 @@ describe 'parsejson' do
 
   end
 
-  context 'with incorrect YAML data' do
-    it 'should return "nil" if a default value should be returned but is not provided' do
+  context 'with incorrect JSON data' do
+    it 'should raise an error with invalid JSON and no default' do
       is_expected.to run.with_params('').
-                         and_return(nil)
+                         and_raise_error(PSON::ParserError)
     end
 
     it 'should support a structure for a default value' do

--- a/spec/functions/parseyaml_spec.rb
+++ b/spec/functions/parseyaml_spec.rb
@@ -40,12 +40,21 @@ describe 'parseyaml' do
 
   end
 
-  context 'with incorrect YAML data' do
-    it 'should return "nil" if a default value should be returned but is not provided' do
-      is_expected.to run.with_params('').
-                         and_return(nil)
+  context 'on a modern ruby', :unless => RUBY_VERSION == '1.8.7' do
+    it 'should raise an error with invalid YAML and no default' do
+      is_expected.to run.with_params('["one"').
+                         and_raise_error(Psych::SyntaxError)
+    end
+  end
+
+    context 'when running on ruby 1.8.7, which does not have Psych', :if => RUBY_VERSION == '1.8.7' do
+      it 'should raise an error with invalid YAML and no default' do
+        is_expected.to run.with_params('["one"').
+          and_raise_error(ArgumentError)
+      end
     end
 
+  context 'with incorrect YAML data' do
     it 'should support a structure for a default value' do
       is_expected.to run.with_params('', {'a' => '1'}).
                          and_return({'a' => '1'})


### PR DESCRIPTION
Maintain the old behavior in the case where the optional second
parameter isn't passed. Also, adding arity is backwards incompatible since
stdlib still supports 2.7, so remove that.