### PR TITLE
Add package_provider fact

### DIFF
--- a/lib/facter/package_provider.rb
+++ b/lib/facter/package_provider.rb
@@ -1,0 +1,17 @@
+# Fact: package_provider
+#
+# Purpose: Returns the default provider Puppet will choose to manage packages
+#   on this system
+#
+# Resolution: Instantiates a dummy package resource and return the provider
+#
+# Caveats:
+#
+require 'puppet/type'
+require 'puppet/type/package'
+
+Facter.add(:package_provider) do
+  setcode do
+    Puppet::Type.type(:package).newpackage(:name => 'dummy')[:provider].to_s
+  end
+end

--- a/spec/unit/facter/package_provider_spec.rb
+++ b/spec/unit/facter/package_provider_spec.rb
@@ -1,0 +1,37 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+require 'puppet/type'
+require 'puppet/type/package'
+
+describe 'package_provider', :type => :fact do
+  before { Facter.clear }
+  after { Facter.clear }
+
+  context "darwin" do
+    it "should return pkgdmg" do
+      provider = Puppet::Type.type(:package).provider(:pkgdmg)
+      Puppet::Type.type(:package).stubs(:defaultprovider).returns provider
+
+      expect(Facter.fact(:package_provider).value).to eq('pkgdmg')
+    end
+  end
+
+  context "centos 7" do
+    it "should return yum" do
+      provider = Puppet::Type.type(:package).provider(:yum)
+      Puppet::Type.type(:package).stubs(:defaultprovider).returns provider
+
+      expect(Facter.fact(:package_provider).value).to eq('yum')
+    end
+  end
+
+  context "ubuntu" do
+    it "should return apt" do
+      provider = Puppet::Type.type(:package).provider(:apt)
+      Puppet::Type.type(:package).stubs(:defaultprovider).returns provider
+
+      expect(Facter.fact(:package_provider).value).to eq('apt')
+    end
+  end
+
+end


### PR DESCRIPTION
This adds a package_provider fact for situations where we need to be
able to know the client's package provider in a simple way.  Situations
such as: package { 'name': install_options => [] }  As those tend to be
package provider specific options.