### PR TITLE
prevent deprecation warning about the allow_virtual parameter

### DIFF
--- a/lib/facter/package_provider.rb
+++ b/lib/facter/package_provider.rb
@@ -12,6 +12,10 @@ require 'puppet/type/package'
 
 Facter.add(:package_provider) do
   setcode do
-    Puppet::Type.type(:package).newpackage(:name => 'dummy')[:provider].to_s
+    if Gem::Version.new(Facter.value(:puppetversion)) >= Gem::Version.new('3.6')
+      Puppet::Type.type(:package).newpackage(:name => 'dummy', :allow_virtual => 'true')[:provider].to_s
+    else
+      Puppet::Type.type(:package).newpackage(:name => 'dummy')[:provider].to_s
+    end
   end
 end


### PR DESCRIPTION
#534 introduces the (re)appearance of the allow_virtual deprecation warning of packages resources with Puppet versions above 3.6 although one has
```
Package {
  allow_virtual => true,
}
```
in the site.pp.
This PR fixes this by adding the allow_virtual parameter explicitly to the dummy Package if the Puppet version is 3.6 or higher.