### PR TITLE
add functionality to bool2str function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -170,6 +170,22 @@ Converts a boolean to a number. Converts values:
   * 'true', 't', '1', 'y', and 'yes' to 1.
   Requires a single boolean or string as an input. *Type*: rvalue.
 
+#### `bool2str`
+
+Converts a boolean to a string using optionally supplied arguments. The optional
+second and third arguments represent what true and false will be converted to
+respectively. If only one argument is given, it will be converted from a boolean
+to a string containing 'true' or 'false'.
+
+*Examples:*
+~~~
+bool2str(true)                    => 'true'
+bool2str(true, 'yes', 'no')       => 'yes'
+bool2str(false, 't', 'f')         => 'f'
+~~~
+
+Requires a single boolean as input. *Type*: rvalue.
+
 #### `capitalize`
 
 Capitalizes the first letter of a string or array of strings. Requires either a single string or an array as an input. *Type*: rvalue.

--- a/lib/puppet/parser/functions/bool2str.rb
+++ b/lib/puppet/parser/functions/bool2str.rb
@@ -4,15 +4,29 @@
 
 module Puppet::Parser::Functions
   newfunction(:bool2str, :type => :rvalue, :doc => <<-EOS
-    Converts a boolean to a string.
+    Converts a boolean to a string using optionally supplied arguments. The
+    optional second and third arguments represent what true and false will be
+    converted to respectively. If only one argument is given, it will be
+    converted from a boolean to a string containing 'true' or 'false'.
+
+    *Examples:*
+
+    bool2str(true)                    => 'true'
+    bool2str(true, 'yes', 'no')       => 'yes'
+    bool2str(false, 't', 'f')         => 'f'
+
     Requires a single boolean as an input.
     EOS
   ) do |arguments|
 
-    raise(Puppet::ParseError, "bool2str(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size < 1
+    unless arguments.size == 1 or arguments.size == 3
+      raise(Puppet::ParseError, "bool2str(): Wrong number of arguments " +
+                                "given (#{arguments.size} for 3)")
+    end
 
     value = arguments[0]
+    true_string = arguments[1] || 'true'
+    false_string = arguments[2] || 'false'
     klass = value.class
 
     # We can have either true or false, and nothing else
@@ -20,7 +34,11 @@ module Puppet::Parser::Functions
       raise(Puppet::ParseError, 'bool2str(): Requires a boolean to work with')
     end
 
-    return value.to_s
+    unless [true_string, false_string].all?{|x| x.kind_of?(String)}
+      raise(Puppet::ParseError, "bool2str(): Requires strings to convert to" )
+    end
+
+    return value ? true_string : false_string
   end
 end
 

--- a/spec/functions/bool2str_spec.rb
+++ b/spec/functions/bool2str_spec.rb
@@ -6,6 +6,12 @@ describe 'bool2str' do
   [ 'true', 'false', nil, :undef, ''].each do |invalid|
     it { is_expected.to run.with_params(invalid).and_raise_error(Puppet::ParseError) }
   end
+  it { is_expected.to run.with_params(true, 'yes', 'no', 'maybe').and_raise_error(Puppet::ParseError) }
+  it { is_expected.to run.with_params(true, 'maybe').and_raise_error(Puppet::ParseError) }
+  it { is_expected.to run.with_params(true, 0, 1).and_raise_error(Puppet::ParseError) }
   it { is_expected.to run.with_params(true).and_return("true") }
   it { is_expected.to run.with_params(false).and_return("false") }
+  it { is_expected.to run.with_params(true, 'yes', 'no').and_return("yes") }
+  it { is_expected.to run.with_params(false, 'yes', 'no').and_return("no") }
+
 end


### PR DESCRIPTION
The bool2str function already exists and converts a boolean true/false to a string true/false. It is not documented in the README.

There are cases when something expects a boolean value to be something other than true/false, such as yes/no, t/f, Yes/No, on/off, etc.

This pull request add an optional two element array that bool2str will accept and convert the boolean true/false to the corresponding value in the array. If no array is given, it converts boolean true/false to a string true/false (which also preserves backwards compatibility).


Examples:

```
bool2str(true)                   => 'true'
bool2str(true, ['yes', 'no'])    => 'yes'
bool2str(false, ['t', 'f'])      => 'f' 
```
