### PR TITLE
(FM-3773) Fix root_home fact on AIX 5.x

### DIFF
--- a/lib/facter/root_home.rb
+++ b/lib/facter/root_home.rb
@@ -35,7 +35,7 @@ Facter.add(:root_home) do
   confine :kernel => :aix
   root_home = nil
   setcode do
-    str = Facter::Util::Resolution.exec("lsuser -C -a home root")
+    str = Facter::Util::Resolution.exec("lsuser -c -a home root")
     str && str.split("\n").each do |line|
       next if line =~ /^#/
       root_home = line.split(/:/)[1]

--- a/spec/unit/facter/root_home_spec.rb
+++ b/spec/unit/facter/root_home_spec.rb
@@ -58,7 +58,7 @@ describe 'root_home', :type => :fact do
     sample_lsuser = File.read(fixtures('lsuser','root'))
 
     it "should return /root" do
-      Facter::Util::Resolution.stubs(:exec).with("lsuser -C -a home root").returns(sample_lsuser)
+      Facter::Util::Resolution.stubs(:exec).with("lsuser -c -a home root").returns(sample_lsuser)
       expect(Facter.fact(:root_home).value).to eq(expected_root_home)
     end
   end


### PR DESCRIPTION
The -C (capital C) flag to lsuser is incorrect. It should be -c (lowercase).

this commit updates the aix root_home fact to use `lsuser -c`, rather than `lsuser -C`.