### PR TITLE
Fix reference to validate_bool in IP4 function

### DIFF
--- a/lib/puppet/parser/functions/validate_ipv4_address.rb
+++ b/lib/puppet/parser/functions/validate_ipv4_address.rb
@@ -8,7 +8,7 @@ module Puppet::Parser::Functions
 
     $my_ip = "1.2.3.4"
     validate_ipv4_address($my_ip)
-    validate_bool("8.8.8.8", "172.16.0.1", $my_ip)
+    validate_ipv4_address("8.8.8.8", "172.16.0.1", $my_ip)
 
     The following values will fail, causing compilation to abort:
 


### PR DESCRIPTION
The documentation in `validate_ipv4_address` references `validate_bool`,
but I believe this should read `validate_ipv4_address` instead, which
makes more sense.