### PR TITLE
adds new parser called is_absolute_path

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -474,6 +474,10 @@ Boolean check to determine whether a variable is of a given data type. This is e
 See the [the Puppet type system](https://docs.puppetlabs.com/references/latest/type.html#about-resource-types) for more information about types.
 See the [`assert_type()`](https://docs.puppetlabs.com/references/latest/function.html#asserttype) function for flexible ways to assert the type of a value.
 
+#### `is_absolute_path`
+
+Returns 'true' if the given path is absolute. *Type*: rvalue.
+
 #### `is_array`
 
 Returns 'true' if the variable passed to this function is an array. *Type*: rvalue.

--- a/lib/puppet/parser/functions/is_absolute_path.rb
+++ b/lib/puppet/parser/functions/is_absolute_path.rb
@@ -1,0 +1,50 @@
+module Puppet::Parser::Functions
+  newfunction(:is_absolute_path, :type => :rvalue, :arity => 1, :doc => <<-'ENDHEREDOC') do |args|
+    Returns boolean true if the string represents an absolute path in the filesystem.  This function works
+    for windows and unix style paths.
+
+    The following values will return true:
+
+        $my_path = 'C:/Program Files (x86)/Puppet Labs/Puppet'
+        is_absolute_path($my_path)
+        $my_path2 = '/var/lib/puppet'
+        is_absolute_path($my_path2)
+        $my_path3 = ['C:/Program Files (x86)/Puppet Labs/Puppet']
+        is_absolute_path($my_path3)
+        $my_path4 = ['/var/lib/puppet']
+        is_absolute_path($my_path4)
+
+    The following values will return false:
+
+        is_absolute_path(true)
+        is_absolute_path('../var/lib/puppet')
+        is_absolute_path('var/lib/puppet')
+        $undefined = undef
+        is_absolute_path($undefined)
+
+  ENDHEREDOC
+
+    require 'puppet/util'
+
+    path = args[0]
+    # This logic was borrowed from
+    # [lib/puppet/file_serving/base.rb](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/file_serving/base.rb)
+    # Puppet 2.7 and beyond will have Puppet::Util.absolute_path? Fall back to a back-ported implementation otherwise.
+    if Puppet::Util.respond_to?(:absolute_path?) then
+      value = (Puppet::Util.absolute_path?(path, :posix) or Puppet::Util.absolute_path?(path, :windows))
+    else
+      # This code back-ported from 2.7.x's lib/puppet/util.rb Puppet::Util.absolute_path?
+      # Determine in a platform-specific way whether a path is absolute. This
+      # defaults to the local platform if none is specified.
+      # Escape once for the string literal, and once for the regex.
+      slash = '[\\\\/]'
+      name = '[^\\\\/]+'
+      regexes = {
+        :windows => %r!^(([A-Z]:#{slash})|(#{slash}#{slash}#{name}#{slash}#{name})|(#{slash}#{slash}\?#{slash}#{name}))!i,
+        :posix => %r!^/!
+      }
+      value = (!!(path =~ regexes[:posix])) || (!!(path =~ regexes[:windows]))
+    end
+    value
+  end
+end

--- a/lib/puppet/parser/functions/validate_absolute_path.rb
+++ b/lib/puppet/parser/functions/validate_absolute_path.rb
@@ -40,28 +40,10 @@ module Puppet::Parser::Functions
       unless arg.is_a?(Array) then
         candidates = Array.new(1,arg)
       end
-      # iterate over all pathes within the candidates array
+      # iterate over all paths within the candidates array
       candidates.each do |path|
-        # This logic was borrowed from
-        # [lib/puppet/file_serving/base.rb](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/file_serving/base.rb)
-        # Puppet 2.7 and beyond will have Puppet::Util.absolute_path? Fall back to a back-ported implementation otherwise.
-        if Puppet::Util.respond_to?(:absolute_path?) then
-          unless Puppet::Util.absolute_path?(path, :posix) or Puppet::Util.absolute_path?(path, :windows)
-            raise Puppet::ParseError, ("#{path.inspect} is not an absolute path.")
-          end
-        else
-          # This code back-ported from 2.7.x's lib/puppet/util.rb Puppet::Util.absolute_path?
-          # Determine in a platform-specific way whether a path is absolute. This
-          # defaults to the local platform if none is specified.
-          # Escape once for the string literal, and once for the regex.
-          slash = '[\\\\/]'
-          name = '[^\\\\/]+'
-          regexes = {
-            :windows => %r!^(([A-Z]:#{slash})|(#{slash}#{slash}#{name}#{slash}#{name})|(#{slash}#{slash}\?#{slash}#{name}))!i,
-            :posix => %r!^/!,
-          }
-          rval = (!!(path =~ regexes[:posix])) || (!!(path =~ regexes[:windows]))
-          rval or raise Puppet::ParseError, ("#{path.inspect} is not an absolute path.")
+        unless function_is_absolute_path([path])
+          raise Puppet::ParseError, ("#{path.inspect} is not an absolute path.")
         end
       end
     end

--- a/spec/unit/puppet/parser/functions/is_absolute_path_spec.rb
+++ b/spec/unit/puppet/parser/functions/is_absolute_path_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe :is_absolute_path do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  let(:function_args) do
+    []
+  end
+
+  let(:function) do
+    scope.function_is_absolute_path(function_args)
+  end
+
+
+  describe 'validate arity' do
+    let(:function_args) do
+       [1,2]
+    end
+    it "should raise a ParseError if there is more than 1 arguments" do
+      lambda { function }.should( raise_error(ArgumentError))
+    end
+
+  end
+  
+  it "should exist" do
+    Puppet::Parser::Functions.function(subject).should == "function_#{subject}"
+  end
+
+  # help enforce good function defination
+  it 'should contain arity' do
+
+  end
+
+  it "should raise a ParseError if there is less than 1 arguments" do
+    lambda { function }.should( raise_error(ArgumentError))
+  end
+
+
+  describe 'should retrun true' do
+    let(:return_value) do
+      true
+    end
+
+    describe 'windows' do
+      let(:function_args) do
+        ['c:\temp\test.txt']
+      end
+      it 'should return data' do
+        function.should eq(return_value)
+      end
+    end
+
+    describe 'non-windows' do
+      let(:function_args) do
+        ['/temp/test.txt']
+      end
+
+      it 'should return data' do
+        function.should eq(return_value)
+      end
+    end
+  end
+
+  describe 'should return false' do
+    let(:return_value) do
+      false
+    end
+    describe 'windows' do
+      let(:function_args) do
+        ['..\temp\test.txt']
+      end
+      it 'should return data' do
+        function.should eq(return_value)
+      end
+    end
+
+    describe 'non-windows' do
+      let(:function_args) do
+        ['../var/lib/puppet']
+      end
+      it 'should return data' do
+        function.should eq(return_value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
  I really like the validate_absolute_path function and needed similar functionality to perform conditional logic on installer locations so I created the is_absolute_path function.

This uses the same code as the validate function but only accepts one argument and also returns a value.