### PR TITLE
Allow package_provider fact to resolve on PE 3.x

### DIFF
--- a/lib/facter/package_provider.rb
+++ b/lib/facter/package_provider.rb
@@ -12,7 +12,7 @@ require 'puppet/type/package'
 
 Facter.add(:package_provider) do
   setcode do
-    if Gem::Version.new(Facter.value(:puppetversion)) >= Gem::Version.new('3.6')
+    if Gem::Version.new(Facter.value(:puppetversion).split(' ')[0]) >= Gem::Version.new('3.6')
       Puppet::Type.type(:package).newpackage(:name => 'dummy', :allow_virtual => 'true')[:provider].to_s
     else
       Puppet::Type.type(:package).newpackage(:name => 'dummy')[:provider].to_s


### PR DESCRIPTION
PE 3.x emits a puppetversion fact in the format "3.x.x (Puppet Enterprise 3.x.x)".  This fact causes an error when invoked on PE 3.x: Could not retrieve fact='package_provider', resolution='<anonymous>': Malformed version number string 3.8.1 (Puppet Enterprise 3.8.1). 

This fix has been tested on PE 3.8.2 and should work for PE 3.3, 3.7, and 3.8.