### PR TITLE
Allow package_provider fact to resolve on PE 3.x

### DIFF
--- a/lib/facter/package_provider.rb
+++ b/lib/facter/package_provider.rb
@@ -12,7 +12,7 @@ require 'puppet/type/package'
 
 Facter.add(:package_provider) do
   setcode do
-    if Gem::Version.new(Facter.value(:puppetversion)) >= Gem::Version.new('3.6')
+    if Gem::Version.new(Facter.value(:puppetversion).split(' ')[0]) >= Gem::Version.new('3.6')
       Puppet::Type.type(:package).newpackage(:name => 'dummy', :allow_virtual => 'true')[:provider].to_s
     else
       Puppet::Type.type(:package).newpackage(:name => 'dummy')[:provider].to_s

--- a/spec/unit/facter/package_provider_spec.rb
+++ b/spec/unit/facter/package_provider_spec.rb
@@ -7,31 +7,38 @@ describe 'package_provider', :type => :fact do
   before { Facter.clear }
   after { Facter.clear }
 
-  context "darwin" do
-    it "should return pkgdmg" do
-      provider = Puppet::Type.type(:package).provider(:pkgdmg)
-      Puppet::Type.type(:package).stubs(:defaultprovider).returns provider
+  ['4.2.2', '3.7.1 (Puppet Enterprise 3.2.1)'].each do |puppetversion|
+    describe "on puppet ''#{puppetversion}''" do
+      before :each do
+        Facter.stubs(:value).returns puppetversion
+      end
 
-      expect(Facter.fact(:package_provider).value).to eq('pkgdmg')
+      context "darwin" do
+        it "should return pkgdmg" do
+          provider = Puppet::Type.type(:package).provider(:pkgdmg)
+          Puppet::Type.type(:package).stubs(:defaultprovider).returns provider
+
+          expect(Facter.fact(:package_provider).value).to eq('pkgdmg')
+        end
+      end
+
+      context "centos 7" do
+        it "should return yum" do
+          provider = Puppet::Type.type(:package).provider(:yum)
+          Puppet::Type.type(:package).stubs(:defaultprovider).returns provider
+
+          expect(Facter.fact(:package_provider).value).to eq('yum')
+        end
+      end
+
+      context "ubuntu" do
+        it "should return apt" do
+          provider = Puppet::Type.type(:package).provider(:apt)
+          Puppet::Type.type(:package).stubs(:defaultprovider).returns provider
+
+          expect(Facter.fact(:package_provider).value).to eq('apt')
+        end
+      end
     end
   end
-
-  context "centos 7" do
-    it "should return yum" do
-      provider = Puppet::Type.type(:package).provider(:yum)
-      Puppet::Type.type(:package).stubs(:defaultprovider).returns provider
-
-      expect(Facter.fact(:package_provider).value).to eq('yum')
-    end
-  end
-
-  context "ubuntu" do
-    it "should return apt" do
-      provider = Puppet::Type.type(:package).provider(:apt)
-      Puppet::Type.type(:package).stubs(:defaultprovider).returns provider
-
-      expect(Facter.fact(:package_provider).value).to eq('apt')
-    end
-  end
-
 end


### PR DESCRIPTION
PE 3.x emits a puppetversion fact in the format "3.x.x (Puppet Enterprise 3.x.x)". This fact causes an error when invoked on PE 3.x: Could not retrieve fact='package_provider', resolution='<anonymous>': Malformed version number string 3.8.1 (Puppet Enterprise 3.8.1

This fix has been tested on PE 3.8.2 and should work for PE 3.3, 3.7, and 3.8.

Original-fix-by: Alex Harden <aharden@gmail.com>