### PR TITLE
Add a simple fact to return PE roles

### DIFF
--- a/lib/facter/pe_roles.rb
+++ b/lib/facter/pe_roles.rb
@@ -1,0 +1,13 @@
+# Simply return an array of all PE profiles this node is classified with.
+# Clearly subject to a chicken and egg, but there's probably not a better way.
+Facter.add(:pe_roles) do
+  setcode do
+    begin
+      classes = File.readlines(Puppet.settings[:classfile])
+      classes = classes.grep(/puppet_enterprise::profile::([^:]*)$/) { |cl| $1.chomp }
+      classes.uniq
+    rescue
+      nil
+    end
+  end
+end


### PR DESCRIPTION
This just returns a list of the toplevel PE profiles that the node is
classified with. Clearly, this will only take effect on the second run,
but I don't think there is a cleaner/better way.