### PR TITLE
Add test for basename on path with scheme

### DIFF
--- a/spec/functions/basename_spec.rb
+++ b/spec/functions/basename_spec.rb
@@ -10,4 +10,5 @@ describe 'basename' do
   it { is_expected.to run.with_params('relative_path/to/a/file.ext').and_return('file.ext') }
   it { is_expected.to run.with_params('/path/to/a/file.ext', '.ext').and_return('file') }
   it { is_expected.to run.with_params('relative_path/to/a/file.ext', '.ext').and_return('file') }
+  it { is_expected.to run.with_params('scheme:///path/to/a/file.ext').and_return('file.ext') }
 end


### PR DESCRIPTION
I didn't see explicit documentation on whether or not this would work, so I added a test to confirm. Test passes, so I assume this is intended behavior. A test makes this behavior explicit.