### PR TITLE
Fix reference to validate_bool in function

### DIFF
--- a/lib/puppet/parser/functions/validate_ip_address.rb
+++ b/lib/puppet/parser/functions/validate_ip_address.rb
@@ -7,12 +7,12 @@ module Puppet::Parser::Functions
     The following values will pass:
     $my_ip = "1.2.3.4"
     validate_ip_address($my_ip)
-    validate_bool("8.8.8.8", "172.16.0.1", $my_ip)
+    validate_ip_address("8.8.8.8", "172.16.0.1", $my_ip)
     
     $my_ip = "3ffe:505:2"
     validate_ip_address(1)
     validate_ip_address($my_ip)
-    validate_bool("fe80::baf6:b1ff:fe19:7507", $my_ip)
+    validate_ip_address("fe80::baf6:b1ff:fe19:7507", $my_ip)
    
     The following values will fail, causing compilation to abort:
     $some_array = [ 1, true, false, "garbage string", "3ffe:505:2" ]


### PR DESCRIPTION
The documentation in `validate_ip_address` references `validate_bool`,
but I believe this should read `validate_ip_address` instead, which
makes more sense.

Looks like this was copied from `validate_ipv4_address`, which I fixed
in 7b068781.