### PR TITLE
ensure_packages.rb: Modifed to pass hiera parameters (as hash,array) as first argument

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -346,7 +346,15 @@ Returns true if the argument is an array or hash that contains no elements, or a
 
 #### `ensure_packages`
 
-Takes a list of packages and only installs them if they don't already exist. It optionally takes a hash as a second parameter to be passed as the third argument to the `ensure_resource()` function. *Type*: statement.
+Takes a list of packages array/hash and only installs them if they don't already exist. It optionally takes a hash as a second parameter to be passed as the third argument to the `ensure_resource()` or `ensure_resources()` function. *Type*: statement.
+
+For Array:
+
+    ensure_packages(['ksh','openssl'], {'ensure' => 'present'})
+
+For Hash:
+
+    ensure_packages({'ksh' => { enure => '20120801-1' } ,  'mypackage' => { source => '/tmp/myrpm-1.0.0.x86_64.rpm', provider => "rpm" }}, {'ensure' => 'present'})
 
 #### `ensure_resource`
 
@@ -370,7 +378,37 @@ An array of resources can also be passed in, and each will be created with the t
 
 *Type*: statement.
 
-#### `flatten`
+#### `ensure_resources`
+
+Takes a resource type, title (only hash), and a hash of attributes that describe the resource(s).
+
+~~~
+user { 'dan':
+  gid => 'mygroup',
+  ensure => present,
+}
+
+ensure_resources($user)
+~~~
+
+An hash of resources should be passed in and each will be created with the type and parameters specified if it doesn't already exist:
+
+    ensure_resources('user', {'dan' => { gid => 'mygroup', uid => '600' } ,  'alex' => { gid => 'mygroup' }}, {'ensure' => 'present'})
+
+From Hiera Backend:
+
+~~~
+userlist:
+dan:
+  gid: 'mygroup'
+uid: '600'
+alex:
+gid: 'mygroup'
+
+ensure_resources('user', hiera_hash('userlist'), {'ensure' => 'present'})
+~~~
+
+### `flatten`
 
 Flattens deeply nested arrays and returns a single flat array as a result. For example, `flatten(['a', ['b', ['c']]])` returns ['a','b','c']. *Type*: rvalue.
 

--- a/lib/puppet/parser/functions/ensure_packages.rb
+++ b/lib/puppet/parser/functions/ensure_packages.rb
@@ -17,18 +17,29 @@ third argument to the ensure_resource() function.
       raise(Puppet::ParseError, 'ensure_packages(): Requires second argument to be a Hash')
     end
 
-    packages = Array(arguments[0])
+    if arguments[0].is_a?(Hash)
+      if arguments[1]
+        defaults = { 'ensure' => 'present' }.merge(arguments[1])
+      else
+        defaults = { 'ensure' => 'present' }
+      end
 
-    if arguments[1]
-      defaults = { 'ensure' => 'present' }.merge(arguments[1])
+      Puppet::Parser::Functions.function(:ensure_resources)
+      function_ensure_resources(['package', Hash(arguments[0]), defaults ])
     else
-      defaults = { 'ensure' => 'present' }
-    end
+      packages = Array(arguments[0])
 
-    Puppet::Parser::Functions.function(:ensure_resource)
-    packages.each { |package_name|
-      function_ensure_resource(['package', package_name, defaults ])
+      if arguments[1]
+        defaults = { 'ensure' => 'present' }.merge(arguments[1])
+      else
+        defaults = { 'ensure' => 'present' }
+      end
+
+      Puppet::Parser::Functions.function(:ensure_resource)
+      packages.each { |package_name|
+        function_ensure_resource(['package', package_name, defaults ])
     }
+    end
   end
 end
 

--- a/lib/puppet/parser/functions/ensure_resources.rb
+++ b/lib/puppet/parser/functions/ensure_resources.rb
@@ -1,0 +1,54 @@
+require 'puppet/parser/functions'
+
+Puppet::Parser::Functions.newfunction(:ensure_resources,
+                                      :type => :statement,
+                                      :doc => <<-'ENDOFDOC'
+Takes a resource type, title (only hash), and a list of attributes that describe a
+resource.
+
+    user { 'dan':
+      gid => 'mygroup',
+      ensure => present,
+    }
+
+An hash of resources should be passed in and each will be created with
+the type and parameters specified if it doesn't already exist.
+
+    ensure_resources('user', {'dan' => { gid => 'mygroup', uid => '600' } ,  'alex' => { gid => 'mygroup' }}, {'ensure' => 'present'})
+
+From Hiera Backend:
+
+userlist:
+  dan:
+    gid: 'mygroup'
+ uid: '600'
+  alex:
+ gid: 'mygroup'
+
+Call:
+ensure_resources('user', hiera_hash('userlist'), {'ensure' => 'present'})
+
+ENDOFDOC
+) do |vals|
+  type, title, params = vals
+  raise(ArgumentError, 'Must specify a type') unless type
+  raise(ArgumentError, 'Must specify a title') unless title
+  params ||= {}
+
+  if title.is_a?(Hash)
+    resource_hash = Hash(title)
+    resources = resource_hash.keys
+
+    Puppet::Parser::Functions.function(:ensure_resource)
+    resources.each { |resource_name|
+    if resource_hash[resource_name]
+        params_merged = params.merge(resource_hash[resource_name])
+    else
+        params_merged = params
+    end
+    function_ensure_resource([ type, resource_name, params_merged ])
+    }
+  else
+       raise(Puppet::ParseError, 'ensure_resources(): Requires second argument to be a Hash')
+  end
+end


### PR DESCRIPTION
This change will allow to pass values from hiera backend variables as hash in first argument with additional parameters needed.
Existing implementation did not support this as it considers first argument as array by default. So, if additional parameters were needed from hash, like ex. "providers => rpm" etc, will not work. It will by default pass whole hash value as string to "ensure_resource". 

It will merge the hash values for package name (key) with defaults & pass each package name to function_ensure_resource in required format for further processing. 

Use:
hiera:
```yaml
packagelist:
  ksh:
    ensure: latest
  mlocate: {}
  myrpm:
    provider: rpm
    source: "/tmp/myrpm-1.0.0.x86_64.rpm"
    install_options:
      --prefix:
        /users/home
  openssl:
    provider: rpm
    source: "/tmp/openssl-1.0.1e-42.el7.x86_64.rpm"
```
Call:
```puppet
ensure_packages($packagelist)
```
It will support array by default if first argument in not hash.