### PR TITLE
Add enclose_ipv6 function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -344,6 +344,11 @@ Converts the case of a string or of all strings in an array to lowercase. *Type*
 
 Returns true if the argument is an array or hash that contains no elements, or an empty string. Returns false when the argument is a numerical value. *Type*: rvalue.
 
+#### `enclose_ipv6`
+
+Takes an array of ip addresses and encloses the ipv6 addresses with square
+brackets. *Type*: rvalue.
+
 #### `ensure_packages`
 
 Takes a list of packages and only installs them if they don't already exist. It optionally takes a hash as a second parameter to be passed as the third argument to the `ensure_resource()` function. *Type*: statement.

--- a/lib/puppet/parser/functions/enclose_ipv6.rb
+++ b/lib/puppet/parser/functions/enclose_ipv6.rb
@@ -1,0 +1,45 @@
+#
+# enclose_ipv6.rb
+#
+
+module Puppet::Parser::Functions
+  newfunction(:enclose_ipv6, :type => :rvalue, :doc => <<-EOS
+Takes an array of ip addresses and encloses the ipv6 addresses with square brackets.
+    EOS
+  ) do |arguments|
+
+    require 'ipaddr'
+
+    rescuable_exceptions = [ ArgumentError ]
+    if defined?(IPAddr::InvalidAddressError)
+	    rescuable_exceptions << IPAddr::InvalidAddressError
+    end
+
+    if (arguments.size != 1) then
+      raise(Puppet::ParseError, "enclose_ipv6(): Wrong number of arguments "+
+        "given #{arguments.size} for 1")
+    end
+    unless arguments[0].is_a?(String) or arguments[0].is_a?(Array) then
+      raise(Puppet::ParseError, "enclose_ipv6(): Wrong argument type "+
+        "given #{arguments[0].class} expected String or Array")
+    end
+
+    input = [arguments[0]].flatten.compact
+    result = []
+
+    input.each do |val|
+      unless val == '*'
+        begin
+          ip = IPAddr.new(val)
+        rescue *rescuable_exceptions
+          raise(Puppet::ParseError, "enclose_ipv6(): Wrong argument "+
+                "given #{val} is not an ip address.")
+        end
+        val = "[#{ip.to_s}]" if ip.ipv6?
+      end
+      result << val
+    end
+
+    return result.uniq
+  end
+end

--- a/spec/unit/puppet/parser/functions/enclose_ipv6_spec.rb
+++ b/spec/unit/puppet/parser/functions/enclose_ipv6_spec.rb
@@ -1,0 +1,69 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe "the enclose_ipv6 function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    expect(Puppet::Parser::Functions.function("enclose_ipv6")).to eq("function_enclose_ipv6")
+  end
+
+  it "should raise a ParseError if there is less than 1 arguments" do
+    expect { scope.function_enclose_ipv6([]) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should raise a ParseError if there is more than 1 arguments" do
+    expect { scope.function_enclose_ipv6(['argument1','argument2']) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should raise a ParseError when given garbage" do
+    expect { scope.function_enclose_ipv6(['garbage']) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should raise a ParseError when given something else than a string or an array" do
+    expect { scope.function_enclose_ipv6([['1' => '127.0.0.1']]) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should not raise a ParseError when given a single ip string" do
+    expect { scope.function_enclose_ipv6(['127.0.0.1']) }.to_not raise_error
+  end
+
+  it "should not raise a ParseError when given * as ip string" do
+    expect { scope.function_enclose_ipv6(['*']) }.to_not raise_error
+  end
+
+  it "should not raise a ParseError when given an array of ip strings" do
+    expect { scope.function_enclose_ipv6([['127.0.0.1','fe80::1']]) }.to_not raise_error
+  end
+
+  it "should not raise a ParseError when given differently notations of ip addresses" do
+    expect { scope.function_enclose_ipv6([['127.0.0.1','fe80::1','[fe80::1]']]) }.to_not raise_error
+  end
+
+  it "should raise a ParseError when given a wrong ipv4 address" do
+    expect { scope.function_enclose_ipv6(['127..0.0.1']) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should raise a ParseError when given a ipv4 address with square brackets" do
+    expect { scope.function_enclose_ipv6(['[127.0.0.1]']) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should raise a ParseError when given a wrong ipv6 address" do
+    expect { scope.function_enclose_ipv6(['fe80:::1']) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should embrace ipv6 adresses within an array of ip addresses" do
+    result = scope.function_enclose_ipv6([['127.0.0.1','fe80::1','[fe80::2]']])
+    expect(result).to(eq(['127.0.0.1','[fe80::1]','[fe80::2]']))
+  end
+
+  it "should embrace a single ipv6 adresse" do
+    result = scope.function_enclose_ipv6(['fe80::1'])
+    expect(result).to(eq(['[fe80::1]']))
+  end
+
+  it "should not embrace a single ipv4 adresse" do
+    result = scope.function_enclose_ipv6(['127.0.0.1'])
+    expect(result).to(eq(['127.0.0.1']))
+  end
+end


### PR DESCRIPTION
Copy a function from puppetlabs/apache, created by Benedikt Bock by
https://github.com/puppetlabs/puppetlabs-apache/commit/55cc3b4e8f4bc859a1255cb57be2c7923005d822.

This function encloses IPv6 addresses in square brackets.
It takes an array of ip addresses and encloses the ipv6 addresses with
square brackets.

This Function is very useful and I would like to use it in other Puppet modules.

Co-Authored-By: Benedikt Bock <benedikt_bock@web.de>