### PR TITLE
improve suffix function to support the same feature set as prefix

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -904,7 +904,12 @@ Removes leading and trailing whitespace from a string or from every string insid
 
 #### `suffix`
 
-Applies a suffix to all elements in an array. For example, `suffix(['a','b','c'], 'p')` returns ['ap','bp','cp']. *Type*: rvalue.
+Applies a suffix to all elements in an array, or to the keys in a hash.
+For example:
+* `suffix(['a','b','c'], 'p')` returns ['ap','bp','cp']
+* `suffix({'a'=>'b','b'=>'c','c'=>'d'}, 'p')` returns {'ap'=>'b','bp'=>'c','cp'=>'d'}.
+
+*Type*: rvalue.
 
 #### `swapcase`
 

--- a/lib/puppet/parser/functions/suffix.rb
+++ b/lib/puppet/parser/functions/suffix.rb
@@ -4,7 +4,8 @@
 
 module Puppet::Parser::Functions
   newfunction(:suffix, :type => :rvalue, :doc => <<-EOS
-This function applies a suffix to all elements in an array.
+This function applies a suffix to all elements in an array, or to the keys
+in a hash.
 
 *Examples:*
 
@@ -18,10 +19,10 @@ Will return: ['ap','bp','cp']
     raise(Puppet::ParseError, "suffix(): Wrong number of arguments " +
       "given (#{arguments.size} for 1)") if arguments.size < 1
 
-    array = arguments[0]
+    enumerable = arguments[0]
 
-    unless array.is_a?(Array)
-      raise Puppet::ParseError, "suffix(): expected first argument to be an Array, got #{array.inspect}"
+    unless enumerable.is_a?(Array) or enumerable.is_a?(Hash)
+      raise Puppet::ParseError, "suffix(): expected first argument to be an Array or a Hash, got #{enumerable.inspect}"
     end
 
     suffix = arguments[1] if arguments[1]
@@ -32,10 +33,17 @@ Will return: ['ap','bp','cp']
       end
     end
 
-    # Turn everything into string same as join would do ...
-    result = array.collect do |i|
-      i = i.to_s
-      suffix ? i + suffix : i
+    if enumerable.is_a?(Array)
+      # Turn everything into string same as join would do ...
+      result = enumerable.collect do |i|
+        i = i.to_s
+        suffix ? i + suffix : i
+      end
+    else
+      result = Hash[enumerable.map do |k,v|
+        k = k.to_s
+        [ suffix ? k + suffix : k, v ]
+      end]
     end
 
     return result

--- a/spec/functions/suffix_spec.rb
+++ b/spec/functions/suffix_spec.rb
@@ -16,29 +16,23 @@ describe 'suffix' do
   it { is_expected.to run.with_params(['one'], 'post').and_return(['onepost']) }
   it { is_expected.to run.with_params(['one', 'two', 'three'], 'post').and_return(['onepost', 'twopost', 'threepost']) }
   it {
-    pending("implementation of Hash functionality matching prefix")
     is_expected.to run.with_params({}).and_return({})
   }
   it {
-    pending("implementation of Hash functionality matching prefix")
     is_expected.to run.with_params({ 'key1' => 'value1', 2 => 3}).and_return({ 'key1' => 'value1', '2' => 3 })
   }
   it {
-    pending("implementation of Hash functionality matching prefix")
     is_expected.to run.with_params({}, '').and_return({})
   }
   it {
-    pending("implementation of Hash functionality matching prefix")
     is_expected.to run.with_params({ 'key' => 'value' }, '').and_return({ 'key' => 'value' })
   }
   it {
-    pending("implementation of Hash functionality matching prefix")
     is_expected.to run.with_params({ 'key' => 'value' }, 'post').and_return({ 'keypost' => 'value' })
   }
   it {
-    pending("implementation of Hash functionality matching prefix")
     is_expected.to run \
-      .with_params({ 'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3' }, 'pre') \
+      .with_params({ 'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3' }, 'post') \
       .and_return({ 'key1post' => 'value1', 'key2post' => 'value2', 'key3post' => 'value3' })
   }
 end


### PR DESCRIPTION
At the moment the function prefix allows a hash as input, but the function suffix only allows arrays. This patch adds the same feature set to suffix as the function prefix already has.