### PR TITLE
MODULES-3201 - Fixed typo 'absense' to 'absence'

### DIFF
--- a/spec/unit/puppet/provider/file_line/ruby_spec.rb
+++ b/spec/unit/puppet/provider/file_line/ruby_spec.rb
@@ -398,7 +398,7 @@ describe provider_class do
       expect(File.read(@tmpfile)).to eql("foo1\nfoo2\n")
     end
 
-    it 'should ignore the match if match_for_absense is not specified' do
+    it 'should ignore the match if match_for_absence is not specified' do
       @resource = Puppet::Type::File_line.new(
         {
           :name     => 'foo',
@@ -416,7 +416,7 @@ describe provider_class do
       expect(File.read(@tmpfile)).to eql("foo1\nfoo\n")
     end
 
-    it 'should ignore the match if match_for_absense is false' do
+    it 'should ignore the match if match_for_absence is false' do
       @resource = Puppet::Type::File_line.new(
         {
           :name              => 'foo',


### PR DESCRIPTION
Believe that the 'match_for_absense' should actually be 'match_for_absence'