### PR TITLE
[MODULES-2370] Do not require `line` when matching for absence

### DIFF
--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -111,8 +111,13 @@ Puppet::Type.newtype(:file_line) do
   end
 
   validate do
-    unless self[:line] and self[:path]
-      raise(Puppet::Error, "Both line and path are required attributes")
+    unless self[:path]
+      raise(Puppet::Error, "path is a required attribute")
+    end
+    unless self[:line]
+      unless self[:ensure] == 'absent' and self[:match_for_absence].to_s == 'true' and self[:match]
+        raise(Puppet::Error, "line is a required attribute")
+      end
     end
   end
 end


### PR DESCRIPTION
Only validate the required `line` parameter if:
* `ensure` is not absent
* `match` is not provided
* or `match_for_absence` is not true