### PR TITLE
[MODULES-2370] file_line.rb: Fix `line` attribute validation

### DIFF
--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -111,8 +111,13 @@ Puppet::Type.newtype(:file_line) do
   end
 
   validate do
-    unless self[:line] and self[:path]
-      raise(Puppet::Error, "Both line and path are required attributes")
+    unless self[:line]
+      unless (self[:ensure].to_s == 'absent') and (self[:match_for_absence].to_s == 'true') and self[:match]
+        raise(Puppet::Error, "line is a required attribute")
+      end
+    end
+    unless self[:path]
+      raise(Puppet::Error, "path is a required attribute")
     end
   end
 end

--- a/spec/unit/puppet/type/file_line_spec.rb
+++ b/spec/unit/puppet/type/file_line_spec.rb
@@ -41,10 +41,13 @@ describe Puppet::Type.type(:file_line) do
     expect { file_line[:path] = 'file' }.to raise_error(Puppet::Error, /File paths must be fully qualified/)
   end
   it 'should require that a line is specified' do
-    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :path => '/tmp/file') }.to raise_error(Puppet::Error, /Both line and path are required attributes/)
+    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :path => '/tmp/file') }.to raise_error(Puppet::Error, /line is a required attribute/)
+  end
+  it 'should not require that a line is specified when matching for absence' do
+    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :path => '/tmp/file', :ensure => :absent, :match_for_absence => :true, :match => 'match') }.not_to raise_error
   end
   it 'should require that a file is specified' do
-    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :line => 'path') }.to raise_error(Puppet::Error, /Both line and path are required attributes/)
+    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :line => 'path') }.to raise_error(Puppet::Error, /path is a required attribute/)
   end
   it 'should default to ensure => present' do
     expect(file_line[:ensure]).to eq :present


### PR DESCRIPTION
`file_line` type: During validation, do not require `line` attribute if:
* `ensure` is `absent`,
* `match` is not empty,
* and `match_for_absence` is `true`.

Also update `spec` tests to reflect this.