### PR TITLE
catch StandardError rather than the gratuitous Exception

### DIFF
--- a/lib/facter/facter_dot_d.rb
+++ b/lib/facter/facter_dot_d.rb
@@ -48,7 +48,7 @@ class Facter::Util::DotD
         end
       end
     end
-  rescue Exception => e
+  rescue StandardError => e
     Facter.warn("Failed to handle #{file} as text facts: #{e.class}: #{e}")
   end
 
@@ -65,7 +65,7 @@ class Facter::Util::DotD
         setcode { v }
       end
     end
-  rescue Exception => e
+  rescue StandardError => e
     Facter.warn("Failed to handle #{file} as json facts: #{e.class}: #{e}")
   end
 
@@ -77,7 +77,7 @@ class Facter::Util::DotD
         setcode { v }
       end
     end
-  rescue Exception => e
+  rescue StandardError => e
     Facter.warn("Failed to handle #{file} as yaml facts: #{e.class}: #{e}")
   end
 
@@ -106,7 +106,7 @@ class Facter::Util::DotD
         end
       end
     end
-  rescue Exception => e
+  rescue StandardError => e
     Facter.warn("Failed to handle #{file} as script facts: #{e.class}: #{e}")
     Facter.debug(e.backtrace.join("\n\t"))
   end

--- a/lib/puppet/parser/functions/hash.rb
+++ b/lib/puppet/parser/functions/hash.rb
@@ -29,7 +29,7 @@ Would return: {'a'=>1,'b'=>2,'c'=>3}
       # This is to make it compatible with older version of Ruby ...
       array  = array.flatten
       result = Hash[*array]
-    rescue Exception
+    rescue StandardError
       raise(Puppet::ParseError, 'hash(): Unable to compute ' +
         'hash from array given')
     end

--- a/lib/puppet/parser/functions/parsejson.rb
+++ b/lib/puppet/parser/functions/parsejson.rb
@@ -15,7 +15,7 @@ be returned if the parsing of YAML string have failed.
 
     begin
       PSON::load(arguments[0]) || arguments[1]
-    rescue Exception => e
+    rescue StandardError => e
       if arguments[1]
         arguments[1]
       else

--- a/lib/puppet/parser/functions/parseyaml.rb
+++ b/lib/puppet/parser/functions/parseyaml.rb
@@ -16,7 +16,7 @@ be returned if the parsing of YAML string have failed.
 
     begin
       YAML::load(arguments[0]) || arguments[1]
-    rescue Exception => e
+    rescue StandardError => e
       if arguments[1]
         arguments[1]
       else

--- a/lib/puppet/parser/functions/validate_cmd.rb
+++ b/lib/puppet/parser/functions/validate_cmd.rb
@@ -53,7 +53,7 @@ module Puppet::Parser::Functions
     rescue Puppet::ExecutionFailure => detail
       msg += "\n#{detail}"
       raise Puppet::ParseError, msg
-    rescue Exception => detail
+    rescue StandardError => detail
       msg += "\n#{detail.class.name} #{detail}"
       raise Puppet::ParseError, msg
     ensure


### PR DESCRIPTION
Catching `Exception` is gratuitous and makes Ruby behave weirdly in case of badly timed SIGINTs, SIGTERMs etc.

All proper errors should descend from `StandardError` rather than `Exception` directly (`Puppet::Error` does this). Catching those is much less problematic.