### PR TITLE
(MODULES-3246) Fix concat with Hash arguments.

### DIFF
--- a/lib/puppet/parser/functions/concat.rb
+++ b/lib/puppet/parser/functions/concat.rb
@@ -31,7 +31,7 @@ Would result in:
     arguments.shift
 
     arguments.each do |x|
-      result = result + Array(x)
+      result = result + (x.is_a?(Array) ? x : [x])
     end
 
     return result

--- a/spec/acceptance/concat_spec.rb
+++ b/spec/acceptance/concat_spec.rb
@@ -36,5 +36,19 @@ describe 'concat function', :unless => UNSUPPORTED_PLATFORMS.include?(fact('oper
 
       apply_manifest(pp, :catch_failures => true)
     end
+    it 'should concat hash arguments' do
+      pp = <<-EOS
+      $output = concat([{"a" => "b"}], {"c" => "d", "e" => "f"})
+      validate_array($output)
+      if size($output) != 2 {
+        fail("${output} should have 2 elements.")
+      }
+      if $output[1] != {"c" => "d", "e" => "f"} {
+        fail("${output} does not have the expected hash for the second element.")
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
   end
 end

--- a/spec/functions/concat_spec.rb
+++ b/spec/functions/concat_spec.rb
@@ -11,6 +11,7 @@ describe 'concat' do
   it { is_expected.to run.with_params(['1','2','3'],[['4','5'],'6']).and_return(['1','2','3',['4','5'],'6']) }
   it { is_expected.to run.with_params(['1','2'],['3','4'],['5','6']).and_return(['1','2','3','4','5','6']) }
   it { is_expected.to run.with_params(['1','2'],'3','4',['5','6']).and_return(['1','2','3','4','5','6']) }
+  it { is_expected.to run.with_params([{"a" => "b"}], {"c" => "d", "e" => "f"}).and_return([{"a" => "b"}, {"c" => "d", "e" => "f"}]) }
 
   it "should leave the original array intact" do
     argument1 = ['1','2','3']


### PR DESCRIPTION
85d5ead Updated the concat function so that it wouldn't modify the
original array. A side-effect of this change is that it now always calls
`Array()` on the second argument. If thit is a Hash, this results in
`to_a` being called on the hash, which converts it to an array or
tuples. This is undesired.

Update the behaviour so that it doesn't (indirectly) call `to_a` on
anything, instead test for the type of the argument, wrapping it in an
array if it's not already an array.