### PR TITLE
Undo changing delete() to delete regex matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ This release provides several new functions, bugfixes, modulesync changes, and s
 - Extends `suffix` to support applying a suffix to keys in a hash.
 - Apply modulesync changes.
 - Add validate_email_address function.
-- Add support for regular expressions to delete.
 
 ####Bugfixes
 - Fixes `fqdn_rand_string` tests, since Puppet 4.4.0 and later have a higher `fqdn_rand` ceiling.

--- a/README.markdown
+++ b/README.markdown
@@ -265,7 +265,7 @@ Takes a resource reference and an optional hash of attributes. Returns 'true' if
 
 #### `delete`
 
-Deletes all instances of a given element from an array, substring from a string, or key from a hash. Arrays and hashes may also match on regular expressions. For example, `delete(['a','b','c','b'], 'b')` returns ['a','c']; `delete('abracadabra', 'bra')` returns 'acada'. `delete({'a' => 1,'b' => 2,'c' => 3},['b','c'])` returns {'a'=> 1}, `delete(['abf', 'ab', 'ac'], '^ab.*')` returns ['ac']. *Type*: rvalue.
+Deletes all instances of a given element from an array, substring from a string, or key from a hash. For example, `delete(['a','b','c','b'], 'b')` returns ['a','c']; `delete('abracadabra', 'bra')` returns 'acada'. `delete({'a' => 1,'b' => 2,'c' => 3},['b','c'])` returns {'a'=> 1}. *Type*: rvalue.
 
 #### `delete_at`
 

--- a/lib/puppet/parser/functions/delete.rb
+++ b/lib/puppet/parser/functions/delete.rb
@@ -2,6 +2,8 @@
 # delete.rb
 #
 
+# TODO(Krzysztof Wilczynski): We need to add support for regular expression ...
+
 module Puppet::Parser::Functions
   newfunction(:delete, :type => :rvalue, :doc => <<-EOS
 Deletes all instances of a given element from an array, substring from a
@@ -32,7 +34,7 @@ string, or key from a hash.
     Array(arguments[1]).each do |item|
       case collection
         when Array, Hash
-          collection.delete_if { |coll_item| coll_item =~ %r{#{item}} }
+          collection.delete item
         when String
           collection.gsub! item, ''
         else

--- a/spec/functions/delete_spec.rb
+++ b/spec/functions/delete_spec.rb
@@ -13,6 +13,7 @@ describe 'delete' do
     it { is_expected.to run.with_params(['two'], 'two').and_return([]) }
     it { is_expected.to run.with_params(['two', 'two'], 'two').and_return([]) }
     it { is_expected.to run.with_params(['one', 'two', 'three'], 'four').and_return(['one', 'two', 'three']) }
+    it { is_expected.to run.with_params(['one', 'two', 'three'], 'e').and_return(['one', 'two', 'three']) }
     it { is_expected.to run.with_params(['one', 'two', 'three'], 'two').and_return(['one', 'three']) }
     it { is_expected.to run.with_params(['two', 'one', 'two', 'three', 'two'], 'two').and_return(['one', 'three']) }
     it { is_expected.to run.with_params(['one', 'two', 'three', 'two'], ['one', 'two']).and_return(['three']) }

--- a/spec/functions/delete_spec.rb
+++ b/spec/functions/delete_spec.rb
@@ -12,7 +12,6 @@ describe 'delete' do
     it { is_expected.to run.with_params([], 'two').and_return([]) }
     it { is_expected.to run.with_params(['two'], 'two').and_return([]) }
     it { is_expected.to run.with_params(['two', 'two'], 'two').and_return([]) }
-    it { is_expected.to run.with_params(['one', 'two', 'three'], '^t.*').and_return(['one']) }
     it { is_expected.to run.with_params(['one', 'two', 'three'], 'four').and_return(['one', 'two', 'three']) }
     it { is_expected.to run.with_params(['one', 'two', 'three'], 'two').and_return(['one', 'three']) }
     it { is_expected.to run.with_params(['two', 'one', 'two', 'three', 'two'], 'two').and_return(['one', 'three']) }
@@ -33,7 +32,7 @@ describe 'delete' do
     it { is_expected.to run.with_params('barfoobar', ['foo', 'barbar']).and_return('') }
   end
 
-  describe 'deleting from a hash' do
+  describe 'deleting from an array' do
     it { is_expected.to run.with_params({}, '').and_return({}) }
     it { is_expected.to run.with_params({}, 'key').and_return({}) }
     it { is_expected.to run.with_params({'key' => 'value'}, 'key').and_return({}) }
@@ -44,10 +43,6 @@ describe 'delete' do
     it { is_expected.to run \
       .with_params({'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3'}, ['key1', 'key2']) \
       .and_return( {'key3' => 'value3'})
-    }
-    it { is_expected.to run \
-      .with_params({'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3'}, ['^key\d']) \
-      .and_return({})
     }
   end
 


### PR DESCRIPTION
This changed exact matches to regex/substring matches in the default case, so backing out for the release.