### PR TITLE
(MODULES-1439) Adds any2bool function

### DIFF
--- a/lib/puppet/parser/functions/any2bool.rb
+++ b/lib/puppet/parser/functions/any2bool.rb
@@ -1,0 +1,55 @@
+#
+# any2bool.rb
+#
+
+module Puppet::Parser::Functions
+  newfunction(:any2bool, :type => :rvalue, :doc => <<-EOS
+This converts 'anything' to a boolean. In practise it does the following:
+
+* Strings such as Y,y,1,T,t,TRUE,yes,'true' will return true
+* Strings such as 0,F,f,N,n,FALSE,no,'false' will return false
+* Booleans will just return their original value
+* Number (or a string representation of a number) > 0 will return true, otherwise false
+* undef will return false
+* Anything else will return true
+    EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "any2bool(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size < 1
+
+    # If argument is already Boolean, return it
+    if !!arguments[0] == arguments[0]
+      return arguments[0]
+    end
+
+    arg = arguments[0]
+
+    if arg == nil
+      return false
+    end
+
+    if arg == :undef
+      return false
+    end
+
+    valid_float = !!Float(arg) rescue false
+
+    if arg.is_a?(Numeric)
+      return function_num2bool( [ arguments[0] ] )
+    end
+
+    if arg.is_a?(String)
+      if valid_float
+        return function_num2bool( [ arguments[0] ] )
+      else
+        return function_str2bool( [ arguments[0] ] )
+      end
+    end
+
+    return true
+
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/spec/functions/any2bool_spec.rb
+++ b/spec/functions/any2bool_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe 'any2bool' do
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }
+
+  it { is_expected.to run.with_params(true).and_return(true) }
+  it { is_expected.to run.with_params(false).and_return(false) }
+
+  it { is_expected.to run.with_params('1.5').and_return(true) }
+
+  describe 'when testing stringy values that mean "true"' do
+    [ 'TRUE','1', 't', 'y', 'true', 'yes'].each do |value|
+      it { is_expected.to run.with_params(value).and_return(true) }
+    end
+  end
+
+  describe 'when testing stringy values that mean "false"' do
+    [ 'FALSE','', '0', 'f', 'n', 'false', 'no', 'undef', 'undefined', nil, :undef ].each do |value|
+      it { is_expected.to run.with_params(value).and_return(false) }
+    end
+  end
+
+  describe 'when testing numeric values that mean "true"' do
+    [ 1,'1',1.5, '1.5'].each do |value|
+      it { is_expected.to run.with_params(value).and_return(true) }
+    end
+  end
+
+  describe 'when testing numeric that mean "false"' do
+    [ -1, '-1', -1.5, '-1.5', '0', 0 ].each do |value|
+      it { is_expected.to run.with_params(value).and_return(false) }
+    end
+  end
+
+  describe 'everything else returns true' do
+    [ [], {}, ['1'], [1], {:one => 1} ].each do |value|
+      it { is_expected.to run.with_params(value).and_return(true) }
+    end
+  end
+
+end


### PR DESCRIPTION
* Basically a combination of `string2bool` and `num2bool`

So there's a request for this to be added to stdlib (https://tickets.puppetlabs.com/browse/MODULES-1439).

Questions:

* Do we want to muddle the waters by the string casting to numeric part to the check? So should '-1' be true because it's a string, or false because when num2bool its false?
* There's already a `any2bool` as part of [puppi](https://github.com/example42/puppi/blob/master/lib/puppet/parser/functions/any2bool.rb), should we give this a different name? 