### PR TITLE
(MODULES-3354) Use 1.8.7 hash in validate_email_address function

### DIFF
--- a/lib/puppet/parser/functions/validate_email_address.rb
+++ b/lib/puppet/parser/functions/validate_email_address.rb
@@ -1,5 +1,5 @@
 module Puppet::Parser::Functions
-  newfunction(:validate_email_address, doc: <<-ENDHEREDOC
+  newfunction(:validate_email_address, :doc => <<-ENDHEREDOC
     Validate that all values passed are valid email addresses.
     Fail compilation if any value fails this check.
     The following values will pass:


### PR DESCRIPTION
Otherwise you get this on 1.8.7:

```
/usr/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:31:in `gem_original_require': /usr/share/foreman-installer/modules/stdlib/lib/puppet/parser/functions/validate_email_address.rb:2: syntax error, unexpected ':', expecting ')' (SyntaxError)
newfunction(:validate_email_address, doc: <<-ENDHEREDOC
```