### PR TITLE
Add puppet_server fact to return agent's server

### DIFF
--- a/lib/facter/puppet_settings.rb
+++ b/lib/facter/puppet_settings.rb
@@ -33,3 +33,11 @@ Facter.add(:puppet_environmentpath) do
     end
   end
 end
+
+Facter.add(:puppet_server) do
+  setcode do
+    Facter::Util::PuppetSettings.with_puppet do
+      Puppet[:server]
+    end
+  end
+end


### PR DESCRIPTION
It is frequently useful to configure an agent to retrieve a resource
from it's configured master, or make further configuration adjustments
to itself based on what server it's using. Similar to the rationale for
stdlib providing a puppet_vardir fact, this commit adds a puppet_server
fact.

Note that the closest equivalent available today is $settings::server,
which returns only the MASTER's configured server, not the AGENT's. This
makes $settings::server unreliable, and not useful in a multi-master
deployment or a deployment involving a load balancer.
