### PR TITLE
(MODULES-3543) Fix define_with_params to handle undef properly

### DIFF
--- a/lib/puppet/parser/functions/defined_with_params.rb
+++ b/lib/puppet/parser/functions/defined_with_params.rb
@@ -26,7 +26,7 @@ ENDOFDOC
   ret = false
   if resource = findresource(reference.to_s)
     matches = params.collect do |key, value|
-      resource[key] == value
+      resource[key] == (value.eql?(:undef) ? nil : value)  # eql? avoids bugs caused by monkeypatching in puppet
     end
     ret = params.empty? || !matches.include?(false)
   end

--- a/spec/functions/defined_with_params_spec.rb
+++ b/spec/functions/defined_with_params_spec.rb
@@ -23,4 +23,13 @@ describe 'defined_with_params' do
     it { is_expected.to run.with_params('User[dan]', {'ensure' => 'present', 'managehome' => false}).and_return(true) }
     it { is_expected.to run.with_params('User[dan]', {'ensure' => 'absent', 'managehome' => false}).and_return(false) }
   end
+
+  describe 'when passing undef values' do
+    let :pre_condition do
+      'file { "/tmp/a": }'
+    end
+
+    it { is_expected.to run.with_params('File[/tmp/a]', {}).and_return(true) }
+    it { is_expected.to run.with_params('File[/tmp/a]', { 'owner' => :undef }).and_return(true) }
+  end
 end

--- a/spec/functions/ensure_resource_spec.rb
+++ b/spec/functions/ensure_resource_spec.rb
@@ -28,6 +28,13 @@ describe 'ensure_resource' do
       it { expect(lambda { catalogue }).to contain_user('username2').without_ensure }
     end
 
+    describe 'after running ensure_resource("user", "username1", { "gid" => undef })' do
+      before { subject.call(['User', 'username1', { "gid" => :undef }]) }
+
+      # this lambda is required due to strangeness within rspec-puppet's expectation handling
+      it { expect(lambda { catalogue }).to contain_user('username1').with_ensure('present') }
+    end
+
     describe 'after running ensure_resource("user", ["username1", "username2"], {})' do
       before { subject.call(['User', ['username1', 'username2'], {}]) }
 


### PR DESCRIPTION
As described in PUP-6422,

	ensure_resources('File[/tmp/a]', { owner => undef })

would not actually create the file. This fixes it, and adds tests to prove
it.