### PR TITLE
[PUP-6611] Unexpected result from getparam if param is false

### DIFF
--- a/lib/puppet/parser/functions/getparam.rb
+++ b/lib/puppet/parser/functions/getparam.rb
@@ -28,7 +28,7 @@ ENDOFDOC
   return '' if param.empty?
 
   if resource = findresource(reference.to_s)
-    return resource[param] if resource[param]
+    return resource[param] if resource[param].class != NilClass
   end
 
   return ''


### PR DESCRIPTION
Return if resource[param] is found (instead of if the value of resource[param] evaluates to true)