### PR TITLE
(maint) Switch 3.x deprecation() to use Puppet warning logger

### DIFF
--- a/lib/puppet/parser/functions/deprecation.rb
+++ b/lib/puppet/parser/functions/deprecation.rb
@@ -10,6 +10,6 @@ EOS
     key = arguments[0]
     message = arguments[1]
 
-    warn("deprecation. #{key}. #{message}")
+    warning("deprecation. #{key}. #{message}")
   end
 end

--- a/spec/functions/deprecation_spec.rb
+++ b/spec/functions/deprecation_spec.rb
@@ -46,7 +46,7 @@ else
     it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }
 
     it 'should display a single warning' do
-      scope.expects(:warn).with(includes('heelo'))
+      scope.expects(:warning).with(includes('heelo'))
       is_expected.to run.with_params('key', 'heelo')
     end
   end

--- a/spec/functions/is_array_spec.rb
+++ b/spec/functions/is_array_spec.rb
@@ -4,7 +4,7 @@ describe 'is_array' do
   it { is_expected.not_to eq(nil) }
   # Checking for deprecation warning
   it 'should display a single deprecation' do
-    scope.expects(:warn).with(includes('This method is deprecated'))
+    scope.expects(:warning).with(includes('This method is deprecated'))
     is_expected.to run.with_params([])
   end
   it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }

--- a/spec/functions/is_bool_spec.rb
+++ b/spec/functions/is_bool_spec.rb
@@ -4,7 +4,7 @@ describe 'is_bool' do
   it { is_expected.not_to eq(nil) }
   # Checking for deprecation warning
   it 'should display a single deprecation' do
-    scope.expects(:warn).with(includes('This method is deprecated'))
+    scope.expects(:warning).with(includes('This method is deprecated'))
     is_expected.to run.with_params(true)
   end
   it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }

--- a/spec/functions/is_float_spec.rb
+++ b/spec/functions/is_float_spec.rb
@@ -5,7 +5,7 @@ describe 'is_float' do
 
   # Checking for deprecation warning
   it 'should display a single deprecation' do
-    scope.expects(:warn).with(includes('This method is deprecated'))
+    scope.expects(:warning).with(includes('This method is deprecated'))
     is_expected.to run.with_params(3)
   end
 

--- a/spec/functions/is_integer_spec.rb
+++ b/spec/functions/is_integer_spec.rb
@@ -5,7 +5,7 @@ describe 'is_integer' do
 
   # Checking for deprecation warning
   it 'should display a single deprecation' do
-    scope.expects(:warn).with(includes('This method is deprecated'))
+    scope.expects(:warning).with(includes('This method is deprecated'))
     is_expected.to run.with_params(3)
   end
 

--- a/spec/functions/is_numeric_spec.rb
+++ b/spec/functions/is_numeric_spec.rb
@@ -5,7 +5,7 @@ describe 'is_numeric' do
 
   # Checking for deprecation warning
   it 'should display a single deprecation' do
-    scope.expects(:warn).with(includes('This method is deprecated'))
+    scope.expects(:warning).with(includes('This method is deprecated'))
     is_expected.to run.with_params(3)
   end
 

--- a/spec/functions/is_string_spec.rb
+++ b/spec/functions/is_string_spec.rb
@@ -4,7 +4,7 @@ describe 'is_string' do
   it { is_expected.not_to eq(nil) }
   # Checking for deprecation warning
   it 'should display a single deprecation' do
-    scope.expects(:warn).with(includes('This method is deprecated'))
+    scope.expects(:warning).with(includes('This method is deprecated'))
     is_expected.to run.with_params('ha')
   end
   it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }

--- a/spec/functions/validate_absolute_path_spec.rb
+++ b/spec/functions/validate_absolute_path_spec.rb
@@ -4,7 +4,7 @@ describe 'validate_absolute_path' do
   # Checking for deprecation warning
   it 'should display a single deprecation' do
     # called twice because validate_absolute_path calls is_absolute_path
-    scope.expects(:warn).with(includes('This method is deprecated')).twice
+    scope.expects(:warning).with(includes('This method is deprecated')).twice
     is_expected.to run.with_params('c:/')
   end
 

--- a/spec/functions/validate_array_spec.rb
+++ b/spec/functions/validate_array_spec.rb
@@ -5,7 +5,7 @@ describe 'validate_array' do
     it { is_expected.not_to eq(nil) }
     # Checking for deprecation warning
     it 'should display a single deprecation' do
-      scope.expects(:warn).with(includes('This method is deprecated'))
+      scope.expects(:warning).with(includes('This method is deprecated'))
       is_expected.to run.with_params([])
     end
     it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }

--- a/spec/functions/validate_bool_spec.rb
+++ b/spec/functions/validate_bool_spec.rb
@@ -4,7 +4,7 @@ describe 'validate_bool' do
   # Checking for deprecation warning
   it 'should display a single deprecation' do
     #called twice, because validate_bool calls is_bool
-    scope.expects(:warn).with(includes('This method is deprecated')).twice
+    scope.expects(:warning).with(includes('This method is deprecated')).twice
     is_expected.to run.with_params(true)
   end
 

--- a/spec/functions/validate_integer_spec.rb
+++ b/spec/functions/validate_integer_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'validate_integer' do
   # Checking for deprecation warning
   it 'should display a single deprecation' do
-    scope.expects(:warn).with(includes('This method is deprecated'))
+    scope.expects(:warning).with(includes('This method is deprecated'))
     is_expected.to run.with_params(3)
   end
 

--- a/spec/functions/validate_numeric_spec.rb
+++ b/spec/functions/validate_numeric_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'validate_numeric' do
   # Checking for deprecation warning
   it 'should display a single deprecation' do
-    scope.expects(:warn).with(includes('This method is deprecated'))
+    scope.expects(:warning).with(includes('This method is deprecated'))
     is_expected.to run.with_params(3)
   end
 

--- a/spec/functions/validate_re_spec.rb
+++ b/spec/functions/validate_re_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'validate_re' do
   # Checking for deprecation warning
   it 'should display a single deprecation' do
-    scope.expects(:warn).with(includes('This method is deprecated'))
+    scope.expects(:warning).with(includes('This method is deprecated'))
     is_expected.to run.with_params('', '')
   end
 

--- a/spec/functions/validate_string_spec.rb
+++ b/spec/functions/validate_string_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'validate_string' do
   # Checking for deprecation warning
   it 'should display a single deprecation' do
-    scope.expects(:warn).with(includes('This method is deprecated'))
+    scope.expects(:warning).with(includes('This method is deprecated'))
     is_expected.to run.with_params('', '')
   end
 


### PR DESCRIPTION
The deprecation function was calling the `Kernel#warn` function which
prints to stderr, rather than the Puppet logger. This causes problems
for Puppet module tests on Travis CI, which has a cap on the amount of
stdout/err permitted in its logs and also prevents users from finding
the deprecation warnings when running under a Puppet master.