### PR TITLE
Change all matched lines

### DIFF
--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -2,6 +2,8 @@ Puppet::Type.type(:file_line).provide(:ruby) do
   def exists?
     if resource[:replace].to_s != 'true' and count_matches(match_regex) > 0
       true
+    elsif resource[:replace].to_s != 'false' and count_matches(match_regex) > 1 and resource[:multiple].to_s != 'false'
+      false
     else
       lines.find do |line|
         line.chomp == resource[:line].chomp


### PR DESCRIPTION
When I add this:

```
file_line{ 'test':
  path => '/tmp/test.txt',
  line => 'new line',
  match => '^new(.*)',
  multiple => true,
  replace => true,
}
```

And I have this file (/tmp/test.txt):

```
new line
new line 2
```

Then there is nothing changed, because the line actually exists. I thought that file_line always ensured that all matched lines are changed, but it isn't. I'm not sure if this is a fix or more of a hack (I think the latter one). Also, is there an reason for not changing all matches?
