### PR TITLE
MODULES-3699 fixes deprecation msg test

### DIFF
--- a/spec/acceptance/deprecation_spec.rb
+++ b/spec/acceptance/deprecation_spec.rb
@@ -3,15 +3,12 @@ require 'spec_helper_acceptance'
 require 'shellwords'
 
 describe 'deprecation function' do
-  before :each do
-    FileUtils.rm_rf '/tmp/deprecation'
-  end
 
   context 'with --strict=error', if: get_puppet_version =~ /^4/ do
     before :all do
       pp = <<-EOS
       deprecation('key', 'message')
-      file { '/tmp/deprecation': ensure => present }
+      notify { 'deprecation msg': }
       EOS
       @result = on(default, puppet('apply', '--strict=error', '-e', Shellwords.shellescape(pp)), acceptable_exit_codes: (0...256))
     end
@@ -23,17 +20,13 @@ describe 'deprecation function' do
     it "should show the error message" do
       expect(@result.stderr).to match(/deprecation. key. message/)
     end
-
-    describe file('/tmp/deprecation') do
-      it { is_expected.not_to exist }
-    end
   end
 
   context 'with --strict=warning', if: get_puppet_version =~ /^4/ do
     before :all do
       pp = <<-EOS
       deprecation('key', 'message')
-      file { '/tmp/deprecation': ensure => present }
+      notify { 'deprecation msg': }
       EOS
       @result = on(default, puppet('apply', '--strict=warning', '-e', Shellwords.shellescape(pp)), acceptable_exit_codes: (0...256))
     end
@@ -45,17 +38,13 @@ describe 'deprecation function' do
     it "should show the error message" do
       expect(@result.stderr).to match(/Warning: message/)
     end
-
-    describe file('/tmp/deprecation') do
-      it { is_expected.to exist }
-    end
   end
 
   context 'with --strict=off', if: get_puppet_version =~ /^4/ do
     before :all do
       pp = <<-EOS
       deprecation('key', 'message')
-      file { '/tmp/deprecation': ensure => present }
+      notify { 'deprecation msg': }
       EOS
       @result = on(default, puppet('apply', '--strict=off', '-e', Shellwords.shellescape(pp)), acceptable_exit_codes: (0...256))
     end
@@ -66,10 +55,6 @@ describe 'deprecation function' do
 
     it "should not show the error message" do
       expect(@result.stderr).not_to match(/Warning: message/)
-    end
-
-    describe file('/tmp/deprecation') do
-      it { is_expected.to exist }
     end
   end
 end


### PR DESCRIPTION
The changed test originally created a file called /tmp/deprecation, which was not referenced anywhere else in the module and wasn't actually being used by the test except to run the catalog. Instead of going through changing the file location to better accommodate solaris and windows, I changed to a notify resource instead. It does the same thing as the file resource did for the test but is far less breakable. 