### PR TITLE
Empower sort to (recursively) sort a hash

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -964,7 +964,7 @@ Returns the number of elements in a string, an array or a hash. *Type*: rvalue.
 
 #### `sort`
 
-Sorts strings and arrays lexically. *Type*: rvalue.
+Sorts strings, arrays and hashes (recursively) lexically. It cannot sort hashes with keys of different types since they are not comparable. *Type*: rvalue.
 
 #### `squeeze`
 

--- a/lib/puppet/parser/functions/sort.rb
+++ b/lib/puppet/parser/functions/sort.rb
@@ -1,10 +1,19 @@
 #
 # sort.rb
 #
+def recursive_hash_sort(value)
+  value.keys.sort.reduce({}) do |seed, key|
+    seed[key] = value[key]
+    if seed[key].is_a?(Hash)
+      seed[key] = recursive_hash_sort(seed[key])
+    end
+    seed
+  end
+end
 
 module Puppet::Parser::Functions
   newfunction(:sort, :type => :rvalue, :doc => <<-EOS
-Sorts strings and arrays lexically.
+Sorts strings, arrays and hashes (recursively) lexically.
     EOS
   ) do |arguments|
 
@@ -19,8 +28,13 @@ Sorts strings and arrays lexically.
       value.sort
     elsif value.is_a?(String) then
       value.split("").sort.join("")
+    elsif value.is_a?(Hash) then
+      begin
+        recursive_hash_sort(value)
+      rescue ArgumentError
+        raise(Puppet::ParseError, "sort(): hash contains mixed key types")
+      end
     end
-
   end
 end
 

--- a/spec/functions/sort_spec.rb
+++ b/spec/functions/sort_spec.rb
@@ -21,4 +21,9 @@ describe 'sort' do
     it { is_expected.to run.with_params('a').and_return('a') }
     it { is_expected.to run.with_params('cbda').and_return('abcd') }
   end
+  context 'when called with a hash' do
+    it { is_expected.to run.with_params({ 'c' => 1, 'a' => 2 }).and_return({ 'a' => 2, 'c' => 1}) }
+    it { is_expected.to run.with_params({ 'c' => 1, 5 => 2 }).and_raise_error(Puppet::ParseError, /mixed key types/) }
+    it { is_expected.to run.with_params({ 'c' => 1, 'a' => 2, 'b' => { 'i' => 'am', 'because' => 'we are'}  }).and_return({ 'a' => 2, 'b' => { 'because' => 'we are', 'i' => 'am' }, 'c' => 1}) }
+  end
 end


### PR DESCRIPTION
This only allows for sorting based on the key and will throw an error if the keys are of different types. It's mostly meant to help out with cases where we're dealing with JSON as input or output and want to guarantee that the order of things don't change between Puppet runs, potentially breaking idempotency.
