### PR TITLE
Permit undef passed as `nil` to validate_string

### DIFF
--- a/lib/puppet/parser/functions/validate_string.rb
+++ b/lib/puppet/parser/functions/validate_string.rb
@@ -30,7 +30,7 @@ module Puppet::Parser::Functions
     end
 
     args.each do |arg|
-      unless arg.is_a?(String)
+      unless arg.is_a?(String) || arg.nil?
         raise Puppet::ParseError, ("#{arg.inspect} is not a string.  It looks to be a #{arg.class}")
       end
     end

--- a/spec/acceptance/is_string_spec.rb
+++ b/spec/acceptance/is_string_spec.rb
@@ -95,6 +95,17 @@ describe 'is_string function', :unless => UNSUPPORTED_PLATFORMS.include?(fact('o
         expect(r.stdout).to match(/Notice: output correct/)
       end
     end
+    it 'is_strings undef' do
+      pp = <<-EOS
+      $a = undef
+      $o = is_string($a)
+      notice(inline_template('is_string is <%= @o.inspect %>'))
+      EOS
+
+      apply_manifest(pp, :catch_failures => true) do |r|
+        expect(r.stdout).to match(/is_string is true/)
+      end
+    end
   end
   describe 'failure' do
     it 'handles improper argument counts'

--- a/spec/acceptance/validate_string_spec.rb
+++ b/spec/acceptance/validate_string_spec.rb
@@ -20,6 +20,13 @@ describe 'validate_string function', :unless => UNSUPPORTED_PLATFORMS.include?(f
 
       apply_manifest(pp, :catch_failures => true)
     end
+    it 'validates undef' do
+      pp = <<-EOS
+      validate_string(undef)
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
     it 'validates a non-string' do
       {
         %{validate_string({ 'a' => 'hash' })} => "Hash",

--- a/spec/aliases/string_spec.rb
+++ b/spec/aliases/string_spec.rb
@@ -6,6 +6,7 @@ if Puppet.version.to_f >= 4.0
       [
         '',
         'one',
+        nil,
       ].each do |value|
         describe value.inspect do
           let(:params) {{ value: value }}
@@ -23,7 +24,7 @@ if Puppet.version.to_f >= 4.0
       ].each do |value|
         describe value.inspect do
           let(:params) {{ value: value }}
-          it { is_expected.to compile.and_raise_error(/parameter 'value' expects a Stdlib::Compat::String = String/) }
+          it { is_expected.to compile.and_raise_error(/parameter 'value' expects a String/) }
         end
       end
     end

--- a/spec/functions/validate_string_spec.rb
+++ b/spec/functions/validate_string_spec.rb
@@ -18,6 +18,7 @@ describe 'validate_string' do
 
     describe 'valid inputs' do
       it { is_expected.to run.with_params('') }
+      it { is_expected.to run.with_params(nil) }
       it { is_expected.to run.with_params('one') }
       it { is_expected.to run.with_params('one', 'two') }
     end

--- a/types/compat/string.pp
+++ b/types/compat/string.pp
@@ -1,2 +1,2 @@
 # Emulate the is_string and validate_string functions
-type Stdlib::Compat::String = String
+type Stdlib::Compat::String = Optional[String]


### PR DESCRIPTION
When validate_string is called via the Puppet 4 deprecation wrappers
from deprecation_gen (introduced in 970852d), `undef` is passed as `nil`
where it was previously passed as `''` from the Puppet 3-style function
API.

This change explicitly permits a `nil` value in validate_string, and
adds a test case to `is_string` which also accepts the same.

Fixes test failures in apt, concat etc:

    Error while evaluating a Function Call, nil is not a string.  It looks to be a NilClass at apt/manifests/source.pp:23:3 [..]
    # ./spec/fixtures/modules/stdlib/lib/puppet/parser/functions/validate_string.rb:34:in `block (2 levels) in <module:Functions>'
    # ./spec/fixtures/modules/stdlib/lib/puppet/parser/functions/validate_string.rb:32:in `each'
    # ./spec/fixtures/modules/stdlib/lib/puppet/parser/functions/validate_string.rb:32:in `block in <module:Functions>'
    # puppet-4.7.0/lib/puppet/parser/functions.rb:174:in `block (2 levels) in newfunction'
    # puppet-4.7.0/lib/puppet/util/profiler/around_profiler.rb:58:in `profile'
    # puppet-4.7.0/lib/puppet/util/profiler.rb:51:in `profile'
    # puppet-4.7.0/lib/puppet/parser/functions.rb:167:in `block in newfunction'
    # ./spec/fixtures/modules/stdlib/lib/puppet_x/puppetlabs/stdlib/deprecation_gen.rb:13:in `block (2 levels) in deprecation_gen'

(Introduced by #659)