### PR TITLE
Ignore :undefined_variable "reason" in getvar

### DIFF
--- a/lib/puppet/parser/functions/getvar.rb
+++ b/lib/puppet/parser/functions/getvar.rb
@@ -21,8 +21,10 @@ module Puppet::Parser::Functions
 
     begin
       catch(:undefined_variable) do
-        self.lookupvar("#{args[0]}")
+        return self.lookupvar("#{args[0]}")
       end
+      
+      nil # throw was caught
     rescue Puppet::ParseError # Eat the exception if strict_variables = true is set
     end
 


### PR DESCRIPTION
`catch` returns value of second argument to `throw`, which until https://github.com/puppetlabs/puppet/commit/860a2761f334c964068038b3ef6853f08beb1df5#diff-bb62983f077c2b43d065be52de182209R514 was `nil`, but now is non-falsey reason for error. short-circuit using return and eval to nil if `throw` was caught.