### PR TITLE
(MODULES-3961) emit more deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Supported Release 4.13.1
+### Summary
+
+This bugfix release improves the user experience around function deprecations by emitting one warning per function(-name) instead of only one deprecation overall. This allows users to identify all deprecated functions used in one agent run, with less back-and-forth.
+
+This release also adds additional Puppet 4 overrides for the `is_` counterparts of the deprecated functions to emit the deprecations warnings in all cases.
+
 ## Supported Release 4.13.0
 ### Summary
 

--- a/lib/puppet/functions/is_absolute_path.rb
+++ b/lib/puppet/functions/is_absolute_path.rb
@@ -1,0 +1,10 @@
+Puppet::Functions.create_function(:is_absolute_path, Puppet::Functions::InternalFunction) do
+  dispatch :deprecation_gen do
+    scope_param
+    optional_repeated_param 'Any', :args
+  end
+  def deprecation_gen(scope, *args)
+    call_function('deprecation', 'is_absolute_path', "This method is deprecated, please use match expressions with Stdlib::Compat::Absolute_Path instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")
+    scope.send("function_is_absolute_path", args)
+  end
+end

--- a/lib/puppet/functions/is_array.rb
+++ b/lib/puppet/functions/is_array.rb
@@ -1,0 +1,10 @@
+Puppet::Functions.create_function(:is_array, Puppet::Functions::InternalFunction) do
+  dispatch :deprecation_gen do
+    scope_param
+    optional_repeated_param 'Any', :args
+  end
+  def deprecation_gen(scope, *args)
+    call_function('deprecation', 'is_array', "This method is deprecated, please use match expressions with Stdlib::Compat::Array instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")
+    scope.send("function_is_array", args)
+  end
+end

--- a/lib/puppet/functions/is_bool.rb
+++ b/lib/puppet/functions/is_bool.rb
@@ -1,0 +1,10 @@
+Puppet::Functions.create_function(:is_bool, Puppet::Functions::InternalFunction) do
+  dispatch :deprecation_gen do
+    scope_param
+    optional_repeated_param 'Any', :args
+  end
+  def deprecation_gen(scope, *args)
+    call_function('deprecation', 'is_bool', "This method is deprecated, please use match expressions with Stdlib::Compat::Bool instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")
+    scope.send("function_is_bool", args)
+  end
+end

--- a/lib/puppet/functions/is_float.rb
+++ b/lib/puppet/functions/is_float.rb
@@ -1,0 +1,10 @@
+Puppet::Functions.create_function(:is_float, Puppet::Functions::InternalFunction) do
+  dispatch :deprecation_gen do
+    scope_param
+    optional_repeated_param 'Any', :args
+  end
+  def deprecation_gen(scope, *args)
+    call_function('deprecation', 'is_float', "This method is deprecated, please use match expressions with Stdlib::Compat::Float instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")
+    scope.send("function_is_float", args)
+  end
+end

--- a/lib/puppet/functions/is_ip_address.rb
+++ b/lib/puppet/functions/is_ip_address.rb
@@ -1,0 +1,10 @@
+Puppet::Functions.create_function(:is_ip_address, Puppet::Functions::InternalFunction) do
+  dispatch :deprecation_gen do
+    scope_param
+    optional_repeated_param 'Any', :args
+  end
+  def deprecation_gen(scope, *args)
+    call_function('deprecation', 'is_ip_address', "This method is deprecated, please use match expressions with Stdlib::Compat::Ip_address instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")
+    scope.send("function_is_ip_address", args)
+  end
+end

--- a/lib/puppet/functions/is_ipv4_address.rb
+++ b/lib/puppet/functions/is_ipv4_address.rb
@@ -1,0 +1,10 @@
+Puppet::Functions.create_function(:is_ipv4_address, Puppet::Functions::InternalFunction) do
+  dispatch :deprecation_gen do
+    scope_param
+    optional_repeated_param 'Any', :args
+  end
+  def deprecation_gen(scope, *args)
+    call_function('deprecation', 'is_ipv4_address', "This method is deprecated, please use match expressions with Stdlib::Compat::Ipv4 instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")
+    scope.send("function_is_ipv4_address", args)
+  end
+end

--- a/lib/puppet/functions/is_ipv6_address.rb
+++ b/lib/puppet/functions/is_ipv6_address.rb
@@ -1,0 +1,10 @@
+Puppet::Functions.create_function(:is_ipv6_address, Puppet::Functions::InternalFunction) do
+  dispatch :deprecation_gen do
+    scope_param
+    optional_repeated_param 'Any', :args
+  end
+  def deprecation_gen(scope, *args)
+    call_function('deprecation', 'is_ipv4_address', "This method is deprecated, please use match expressions with Stdlib::Compat::Ipv6 instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")
+    scope.send("function_is_ipv6_address", args)
+  end
+end

--- a/lib/puppet/functions/is_numeric.rb
+++ b/lib/puppet/functions/is_numeric.rb
@@ -1,0 +1,10 @@
+Puppet::Functions.create_function(:is_numeric, Puppet::Functions::InternalFunction) do
+  dispatch :deprecation_gen do
+    scope_param
+    optional_repeated_param 'Any', :args
+  end
+  def deprecation_gen(scope, *args)
+    call_function('deprecation', 'is_numeric', "This method is deprecated, please use match expressions with Stdlib::Compat::Numeric instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")
+    scope.send("function_is_numeric", args)
+  end
+end

--- a/lib/puppet/functions/is_string.rb
+++ b/lib/puppet/functions/is_string.rb
@@ -1,0 +1,10 @@
+Puppet::Functions.create_function(:is_string, Puppet::Functions::InternalFunction) do
+  dispatch :deprecation_gen do
+    scope_param
+    optional_repeated_param 'Any', :args
+  end
+  def deprecation_gen(scope, *args)
+    call_function('deprecation', 'is_string', "This method is deprecated, please use match expressions with Stdlib::Compat::String instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")
+    scope.send("function_is_string", args)
+  end
+end

--- a/lib/puppet/functions/validate_absolute_path.rb
+++ b/lib/puppet/functions/validate_absolute_path.rb
@@ -4,7 +4,7 @@ Puppet::Functions.create_function(:validate_absolute_path, Puppet::Functions::In
     optional_repeated_param 'Any', :args
   end
   def deprecation_gen(scope, *args)
-    call_function('deprecation', 'puppet_3_type_check', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Absolute_Path. There is further documentation for validate_legacy function in the README.")
+    call_function('deprecation', 'validate_absolute_path', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Absolute_Path. There is further documentation for validate_legacy function in the README.")
     scope.send("function_validate_absolute_path", args)
   end
 end

--- a/lib/puppet/functions/validate_array.rb
+++ b/lib/puppet/functions/validate_array.rb
@@ -4,7 +4,7 @@ Puppet::Functions.create_function(:validate_array, Puppet::Functions::InternalFu
     optional_repeated_param 'Any', :args
   end
   def deprecation_gen(scope, *args)
-    call_function('deprecation', 'puppet_3_type_check', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Array. There is further documentation for validate_legacy function in the README.")
+    call_function('deprecation', 'validate_array', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Array. There is further documentation for validate_legacy function in the README.")
     scope.send("function_validate_array", args)
   end
 end

--- a/lib/puppet/functions/validate_bool.rb
+++ b/lib/puppet/functions/validate_bool.rb
@@ -4,7 +4,7 @@ Puppet::Functions.create_function(:validate_bool, Puppet::Functions::InternalFun
     optional_repeated_param 'Any', :args
   end
   def deprecation_gen(scope, *args)
-    call_function('deprecation', 'puppet_3_type_check', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Bool. There is further documentation for validate_legacy function in the README.")
+    call_function('deprecation', 'validate_bool', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Bool. There is further documentation for validate_legacy function in the README.")
     scope.send("function_validate_bool", args)
   end
 end

--- a/lib/puppet/functions/validate_hash.rb
+++ b/lib/puppet/functions/validate_hash.rb
@@ -4,7 +4,7 @@ Puppet::Functions.create_function(:validate_hash, Puppet::Functions::InternalFun
     optional_repeated_param 'Any', :args
   end
   def deprecation_gen(scope, *args)
-    call_function('deprecation', 'puppet_3_type_check', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Hash. There is further documentation for validate_legacy function in the README.")
+    call_function('deprecation', 'validate_hash', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Hash. There is further documentation for validate_legacy function in the README.")
     scope.send("function_validate_hash", args)
   end
 end

--- a/lib/puppet/functions/validate_integer.rb
+++ b/lib/puppet/functions/validate_integer.rb
@@ -4,7 +4,7 @@ Puppet::Functions.create_function(:validate_integer, Puppet::Functions::Internal
     optional_repeated_param 'Any', :args
   end
   def deprecation_gen(scope, *args)
-    call_function('deprecation', 'puppet_3_type_check', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Integer. There is further documentation for validate_legacy function in the README.")
+    call_function('deprecation', 'validate_integer', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Integer. There is further documentation for validate_legacy function in the README.")
     scope.send("function_validate_integer", args)
   end
 end

--- a/lib/puppet/functions/validate_ip_address.rb
+++ b/lib/puppet/functions/validate_ip_address.rb
@@ -4,7 +4,7 @@ Puppet::Functions.create_function(:validate_ip_address, Puppet::Functions::Inter
     optional_repeated_param 'Any', :args
   end
   def deprecation_gen(scope, *args)
-    call_function('deprecation', 'puppet_3_type_check', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ip_Address. There is further documentation for validate_legacy function in the README.")
+    call_function('deprecation', 'validate_ip_address', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ip_Address. There is further documentation for validate_legacy function in the README.")
     scope.send("function_validate_ip_address", args)
   end
 end

--- a/lib/puppet/functions/validate_ipv4_address.rb
+++ b/lib/puppet/functions/validate_ipv4_address.rb
@@ -4,7 +4,7 @@ Puppet::Functions.create_function(:validate_ipv4_address, Puppet::Functions::Int
     optional_repeated_param 'Any', :args
   end
   def deprecation_gen(scope, *args)
-    call_function('deprecation', 'puppet_3_type_check', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv4_Address. There is further documentation for validate_legacy function in the README.")
+    call_function('deprecation', 'validate_ipv4_address', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv4_Address. There is further documentation for validate_legacy function in the README.")
     scope.send("function_validate_ipv4_address", args)
   end
 end

--- a/lib/puppet/functions/validate_ipv6_address.rb
+++ b/lib/puppet/functions/validate_ipv6_address.rb
@@ -4,7 +4,7 @@ Puppet::Functions.create_function(:validate_ipv6_address, Puppet::Functions::Int
     optional_repeated_param 'Any', :args
   end
   def deprecation_gen(scope, *args)
-    call_function('deprecation', 'puppet_3_type_check', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv6_address. There is further documentation for validate_legacy function in the README.")
+    call_function('deprecation', 'validate_ipv6_address', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv6_address. There is further documentation for validate_legacy function in the README.")
     scope.send("function_validate_ipv6_address", args)
   end
 end

--- a/lib/puppet/functions/validate_numeric.rb
+++ b/lib/puppet/functions/validate_numeric.rb
@@ -4,7 +4,7 @@ Puppet::Functions.create_function(:validate_numeric, Puppet::Functions::Internal
     optional_repeated_param 'Any', :args
   end
   def deprecation_gen(scope, *args)
-    call_function('deprecation', 'puppet_3_type_check', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Numeric. There is further documentation for validate_legacy function in the README.")
+    call_function('deprecation', 'validate_numeric', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Numeric. There is further documentation for validate_legacy function in the README.")
     scope.send("function_validate_numeric", args)
   end
 end

--- a/lib/puppet/functions/validate_re.rb
+++ b/lib/puppet/functions/validate_re.rb
@@ -4,7 +4,7 @@ Puppet::Functions.create_function(:validate_re, Puppet::Functions::InternalFunct
     optional_repeated_param 'Any', :args
   end
   def deprecation_gen(scope, *args)
-    call_function('deprecation', 'puppet_3_type_check', "This method is deprecated, please use the stdlib validate_legacy function, with Pattern[]. There is further documentation for validate_legacy function in the README.")
+    call_function('deprecation', 'validate_re', "This method is deprecated, please use the stdlib validate_legacy function, with Pattern[]. There is further documentation for validate_legacy function in the README.")
     scope.send("function_validate_re", args)
   end
 end

--- a/lib/puppet/functions/validate_slength.rb
+++ b/lib/puppet/functions/validate_slength.rb
@@ -4,7 +4,7 @@ Puppet::Functions.create_function(:validate_slength, Puppet::Functions::Internal
     optional_repeated_param 'Any', :args
   end
   def deprecation_gen(scope, *args)
-    call_function('deprecation', 'puppet_3_type_check', "This method is deprecated, please use the stdlib validate_legacy function, with String[]. There is further documentation for validate_legacy function in the README.")
+    call_function('deprecation', 'validate_slength', "This method is deprecated, please use the stdlib validate_legacy function, with String[]. There is further documentation for validate_legacy function in the README.")
     scope.send("function_validate_slength", args)
   end
 end

--- a/lib/puppet/functions/validate_string.rb
+++ b/lib/puppet/functions/validate_string.rb
@@ -4,7 +4,7 @@ Puppet::Functions.create_function(:validate_string, Puppet::Functions::InternalF
     optional_repeated_param 'Any', :args
   end
   def deprecation_gen(scope, *args)
-    call_function('deprecation', 'puppet_3_type_check', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::String. There is further documentation for validate_legacy function in the README.")
+    call_function('deprecation', 'validate_string', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::String. There is further documentation for validate_legacy function in the README.")
     scope.send("function_validate_string", args)
   end
 end

--- a/lib/puppet/parser/functions/is_absolute_path.rb
+++ b/lib/puppet/parser/functions/is_absolute_path.rb
@@ -23,7 +23,7 @@ module Puppet::Parser::Functions
         is_absolute_path($undefined)
 
   ENDHEREDOC
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Absolute_path. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:is_absolute_path, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Absolute_path. There is further documentation for validate_legacy function in the README.'])
     require 'puppet/util'
 
     path = args[0]

--- a/lib/puppet/parser/functions/is_array.rb
+++ b/lib/puppet/parser/functions/is_array.rb
@@ -8,7 +8,7 @@ Returns true if the variable passed to this function is an array.
     EOS
   ) do |arguments|
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Array. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:is_array, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Array. There is further documentation for validate_legacy function in the README.'])
 
     raise(Puppet::ParseError, "is_array(): Wrong number of arguments " +
       "given (#{arguments.size} for 1)") if arguments.size < 1

--- a/lib/puppet/parser/functions/is_bool.rb
+++ b/lib/puppet/parser/functions/is_bool.rb
@@ -8,7 +8,7 @@ Returns true if the variable passed to this function is a boolean.
     EOS
   ) do |arguments|
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Bool. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:is_bool, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Bool. There is further documentation for validate_legacy function in the README.'])
 
     raise(Puppet::ParseError, "is_bool(): Wrong number of arguments " +
       "given (#{arguments.size} for 1)") if arguments.size != 1

--- a/lib/puppet/parser/functions/is_float.rb
+++ b/lib/puppet/parser/functions/is_float.rb
@@ -8,7 +8,7 @@ Returns true if the variable passed to this function is a float.
     EOS
   ) do |arguments|
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Float. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:is_float, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Float. There is further documentation for validate_legacy function in the README.'])
 
     if (arguments.size != 1) then
       raise(Puppet::ParseError, "is_float(): Wrong number of arguments "+

--- a/lib/puppet/parser/functions/is_ip_address.rb
+++ b/lib/puppet/parser/functions/is_ip_address.rb
@@ -10,7 +10,7 @@ Returns true if the string passed to this function is a valid IP address.
 
     require 'ipaddr'
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ip_address. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:is_ip_address, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ip_address. There is further documentation for validate_legacy function in the README.'])
 
     if (arguments.size != 1) then
       raise(Puppet::ParseError, "is_ip_address(): Wrong number of arguments "+

--- a/lib/puppet/parser/functions/is_ipv4_address.rb
+++ b/lib/puppet/parser/functions/is_ipv4_address.rb
@@ -10,7 +10,7 @@ Returns true if the string passed to this function is a valid IPv4 address.
 
     require 'ipaddr'
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv4. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:is_ipv4_address, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv4. There is further documentation for validate_legacy function in the README.'])
 
     if (arguments.size != 1) then
       raise(Puppet::ParseError, "is_ipv4_address(): Wrong number of arguments "+

--- a/lib/puppet/parser/functions/is_ipv6_address.rb
+++ b/lib/puppet/parser/functions/is_ipv6_address.rb
@@ -8,7 +8,7 @@ Returns true if the string passed to this function is a valid IPv6 address.
     EOS
   ) do |arguments|
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv6. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:is_ipv6_address, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv6. There is further documentation for validate_legacy function in the README.'])
 
     require 'ipaddr'
 

--- a/lib/puppet/parser/functions/is_numeric.rb
+++ b/lib/puppet/parser/functions/is_numeric.rb
@@ -24,7 +24,7 @@ Valid examples:
     EOS
   ) do |arguments|
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Numeric. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:is_numeric, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Numeric. There is further documentation for validate_legacy function in the README.'])
 
     if (arguments.size != 1) then
       raise(Puppet::ParseError, "is_numeric(): Wrong number of arguments "+

--- a/lib/puppet/parser/functions/is_string.rb
+++ b/lib/puppet/parser/functions/is_string.rb
@@ -8,14 +8,15 @@ Returns true if the variable passed to this function is a string.
     EOS
   ) do |arguments|
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::String. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:is_string, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::String. There is further documentation for validate_legacy function in the README.'])
 
     raise(Puppet::ParseError, "is_string(): Wrong number of arguments " +
       "given (#{arguments.size} for 1)") if arguments.size < 1
 
     type = arguments[0]
 
-    result = type.is_a?(String)
+    # when called through the v4 API shim, undef gets translated to nil
+    result = type.is_a?(String) || type.nil?
 
     if result and (type == type.to_f.to_s or type == type.to_i.to_s) then
       return false

--- a/lib/puppet/parser/functions/validate_absolute_path.rb
+++ b/lib/puppet/parser/functions/validate_absolute_path.rb
@@ -27,7 +27,7 @@ module Puppet::Parser::Functions
     ENDHEREDOC
 
     # The deprecation function was being called twice, as validate_absolute_path calls is_absolute_path. I have removed it from here so it only calls deprecation once within is_absolute_path.
-    # function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Absolute_path. There is further documentation for validate_legacy function in the README.'])
+    # function_deprecation([:validate_absolute_path, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Absolute_path. There is further documentation for validate_legacy function in the README.'])
 
     require 'puppet/util'
 

--- a/lib/puppet/parser/functions/validate_array.rb
+++ b/lib/puppet/parser/functions/validate_array.rb
@@ -18,7 +18,7 @@ module Puppet::Parser::Functions
 
     ENDHEREDOC
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Array. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:validate_array, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Array. There is further documentation for validate_legacy function in the README.'])
 
     unless args.length > 0 then
       raise Puppet::ParseError, ("validate_array(): wrong number of arguments (#{args.length}; must be > 0)")

--- a/lib/puppet/parser/functions/validate_bool.rb
+++ b/lib/puppet/parser/functions/validate_bool.rb
@@ -20,7 +20,7 @@ module Puppet::Parser::Functions
     ENDHEREDOC
 
     # The deprecation function was being called twice, as validate_bool calls is_bool. I have removed it from here so it only calls deprecation once within is_bool.
-    # function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Bool. There is further documentation for validate_legacy function in the README.'])
+    # function_deprecation([:validate_bool, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Bool. There is further documentation for validate_legacy function in the README.'])
 
     unless args.length > 0 then
       raise Puppet::ParseError, ("validate_bool(): wrong number of arguments (#{args.length}; must be > 0)")

--- a/lib/puppet/parser/functions/validate_hash.rb
+++ b/lib/puppet/parser/functions/validate_hash.rb
@@ -18,7 +18,7 @@ module Puppet::Parser::Functions
 
     ENDHEREDOC
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Hash. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:validate_hash, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Hash. There is further documentation for validate_legacy function in the README.'])
 
     unless args.length > 0 then
       raise Puppet::ParseError, ("validate_hash(): wrong number of arguments (#{args.length}; must be > 0)")

--- a/lib/puppet/parser/functions/validate_integer.rb
+++ b/lib/puppet/parser/functions/validate_integer.rb
@@ -2,7 +2,7 @@ module Puppet::Parser::Functions
 
   newfunction(:validate_integer, :doc => <<-'ENDHEREDOC') do |args|
     Validate that the first argument is an integer (or an array of integers). Abort catalog compilation if any of the checks fail.
-    
+
     The second argument is optional and passes a maximum. (All elements of) the first argument has to be less or equal to this max.
 
     The third argument is optional and passes a minimum.  (All elements of) the first argument has to be greater or equal to this min.
@@ -53,7 +53,7 @@ module Puppet::Parser::Functions
 
     ENDHEREDOC
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Integer. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:validate_integer, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Integer. There is further documentation for validate_legacy function in the README.'])
 
     # tell the user we need at least one, and optionally up to two other parameters
     raise Puppet::ParseError, "validate_integer(): Wrong number of arguments; must be 1, 2 or 3, got #{args.length}" unless args.length > 0 and args.length < 4

--- a/lib/puppet/parser/functions/validate_ip_address.rb
+++ b/lib/puppet/parser/functions/validate_ip_address.rb
@@ -8,12 +8,12 @@ module Puppet::Parser::Functions
     $my_ip = "1.2.3.4"
     validate_ip_address($my_ip)
     validate_ip_address("8.8.8.8", "172.16.0.1", $my_ip)
-    
+
     $my_ip = "3ffe:505:2"
     validate_ip_address(1)
     validate_ip_address($my_ip)
     validate_ip_address("fe80::baf6:b1ff:fe19:7507", $my_ip)
-   
+
     The following values will fail, causing compilation to abort:
     $some_array = [ 1, true, false, "garbage string", "3ffe:505:2" ]
     validate_ip_address($some_array)
@@ -23,7 +23,7 @@ module Puppet::Parser::Functions
     require "ipaddr"
     rescuable_exceptions = [ ArgumentError ]
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ip_address. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:validate_ip_address, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ip_address. There is further documentation for validate_legacy function in the README.'])
 
     if defined?(IPAddr::InvalidAddressError)
       rescuable_exceptions << IPAddr::InvalidAddressError

--- a/lib/puppet/parser/functions/validate_ipv4_address.rb
+++ b/lib/puppet/parser/functions/validate_ipv4_address.rb
@@ -18,7 +18,7 @@ module Puppet::Parser::Functions
     ENDHEREDOC
   ) do |args|
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv4. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:validate_ipv4_address, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv4. There is further documentation for validate_legacy function in the README.'])
 
     require "ipaddr"
     rescuable_exceptions = [ ArgumentError ]

--- a/lib/puppet/parser/functions/validate_ipv6_address.rb
+++ b/lib/puppet/parser/functions/validate_ipv6_address.rb
@@ -19,7 +19,7 @@ module Puppet::Parser::Functions
     ENDHEREDOC
   ) do |args|
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv6. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:validate_ipv6_address, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv6. There is further documentation for validate_legacy function in the README.'])
 
     require "ipaddr"
     rescuable_exceptions = [ ArgumentError ]

--- a/lib/puppet/parser/functions/validate_numeric.rb
+++ b/lib/puppet/parser/functions/validate_numeric.rb
@@ -2,7 +2,7 @@ module Puppet::Parser::Functions
 
   newfunction(:validate_numeric, :doc => <<-'ENDHEREDOC') do |args|
     Validate that the first argument is a numeric value (or an array of numeric values). Abort catalog compilation if any of the checks fail.
-    
+
     The second argument is optional and passes a maximum. (All elements of) the first argument has to be less or equal to this max.
 
     The third argument is optional and passes a minimum.  (All elements of) the first argument has to be greater or equal to this min.
@@ -15,7 +15,7 @@ module Puppet::Parser::Functions
 
     ENDHEREDOC
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Numeric. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:validate_numeric, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Numeric. There is further documentation for validate_legacy function in the README.'])
 
     # tell the user we need at least one, and optionally up to two other parameters
     raise Puppet::ParseError, "validate_numeric(): Wrong number of arguments; must be 1, 2 or 3, got #{args.length}" unless args.length > 0 and args.length < 4

--- a/lib/puppet/parser/functions/validate_re.rb
+++ b/lib/puppet/parser/functions/validate_re.rb
@@ -30,7 +30,7 @@ module Puppet::Parser::Functions
 
     ENDHEREDOC
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Re. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:validate_re, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Re. There is further documentation for validate_legacy function in the README.'])
 
     if (args.length < 2) or (args.length > 3) then
       raise Puppet::ParseError, "validate_re(): wrong number of arguments (#{args.length}; must be 2 or 3)"

--- a/lib/puppet/parser/functions/validate_slength.rb
+++ b/lib/puppet/parser/functions/validate_slength.rb
@@ -21,7 +21,7 @@ module Puppet::Parser::Functions
 
     ENDHEREDOC
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with String[]. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:validate_slength, 'This method is deprecated, please use the stdlib validate_legacy function, with String[]. There is further documentation for validate_legacy function in the README.'])
 
     raise Puppet::ParseError, "validate_slength(): Wrong number of arguments (#{args.length}; must be 2 or 3)" unless args.length == 2 or args.length == 3
 

--- a/lib/puppet/parser/functions/validate_string.rb
+++ b/lib/puppet/parser/functions/validate_string.rb
@@ -13,23 +13,24 @@ module Puppet::Parser::Functions
 
         validate_string(true)
         validate_string([ 'some', 'array' ])
-        
+
     Note: validate_string(undef) will not fail in this version of the
     functions API (incl. current and future parser). Instead, use:
-    
+
         if $var == undef {
           fail('...')
         }
-    
+
     ENDHEREDOC
 
-    function_deprecation([:puppet_3_type_check, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::String. There is further documentation for validate_legacy function in the README.'])
+    function_deprecation([:validate_string, 'This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::String. There is further documentation for validate_legacy function in the README.'])
 
     unless args.length > 0 then
       raise Puppet::ParseError, ("validate_string(): wrong number of arguments (#{args.length}; must be > 0)")
     end
 
     args.each do |arg|
+      # when called through the v4 API shim, undef gets translated to nil
       unless arg.is_a?(String) || arg.nil?
         raise Puppet::ParseError, ("#{arg.inspect} is not a string.  It looks to be a #{arg.class}")
       end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-stdlib",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "author": "puppetlabs",
   "summary": "Standard library of resources for Puppet modules.",
   "license": "Apache-2.0",


### PR DESCRIPTION
This now emits one deprecation warning for each function used (but not for each call-site). Prior to this, only a single deprecation warning would have been triggered, potentially misleading users.

Additionally this adds v4 deprecation stubs for the functions that were missed.