### PR TITLE
(MODULES-3962) Rework v4 function shims to work on puppet 3.7 and 4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 2.1.5
     bundler_args: --without system_tests
+    env: PUPPET_GEM_VERSION="~> 3.7.0" FUTURE_PARSER="yes"
+  - rvm: 2.1.5
+    bundler_args: --without system_tests
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 1.9.3
     bundler_args: --without system_tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## Supported Release 4.13.1
 ### Summary
 
-This bugfix release improves the user experience around function deprecations by emitting one warning per function(-name) instead of only one deprecation overall. This allows users to identify all deprecated functions used in one agent run, with less back-and-forth.
+This bugfix release addresses the `undefined method 'optional_repeated_param'` error messages seen by users of puppet 3.7.
 
-This release also adds additional Puppet 4 overrides for the `is_` counterparts of the deprecated functions to emit the deprecations warnings in all cases.
+It also improves the user experience around function deprecations by emitting one warning per function(-name) instead of only one deprecation overall. This allows users to identify all deprecated functions used in one agent run, with less back-and-forth.
+
+Finally, this release adds additional Puppet 4 overrides for the `is_` counterparts of the deprecated functions to emit the deprecations warnings in all cases.
 
 ## Supported Release 4.13.0
 ### Summary

--- a/lib/puppet/functions/is_absolute_path.rb
+++ b/lib/puppet/functions/is_absolute_path.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:is_absolute_path, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:is_absolute_path) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'is_absolute_path', "This method is deprecated, please use match expressions with Stdlib::Compat::Absolute_Path instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")

--- a/lib/puppet/functions/is_array.rb
+++ b/lib/puppet/functions/is_array.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:is_array, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:is_array) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'is_array', "This method is deprecated, please use match expressions with Stdlib::Compat::Array instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")

--- a/lib/puppet/functions/is_bool.rb
+++ b/lib/puppet/functions/is_bool.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:is_bool, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:is_bool) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'is_bool', "This method is deprecated, please use match expressions with Stdlib::Compat::Bool instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")

--- a/lib/puppet/functions/is_float.rb
+++ b/lib/puppet/functions/is_float.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:is_float, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:is_float) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'is_float', "This method is deprecated, please use match expressions with Stdlib::Compat::Float instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")

--- a/lib/puppet/functions/is_ip_address.rb
+++ b/lib/puppet/functions/is_ip_address.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:is_ip_address, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:is_ip_address) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'is_ip_address', "This method is deprecated, please use match expressions with Stdlib::Compat::Ip_address instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")

--- a/lib/puppet/functions/is_ipv4_address.rb
+++ b/lib/puppet/functions/is_ipv4_address.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:is_ipv4_address, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:is_ipv4_address) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'is_ipv4_address', "This method is deprecated, please use match expressions with Stdlib::Compat::Ipv4 instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")

--- a/lib/puppet/functions/is_ipv6_address.rb
+++ b/lib/puppet/functions/is_ipv6_address.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:is_ipv6_address, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:is_ipv6_address) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'is_ipv4_address', "This method is deprecated, please use match expressions with Stdlib::Compat::Ipv6 instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")

--- a/lib/puppet/functions/is_numeric.rb
+++ b/lib/puppet/functions/is_numeric.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:is_numeric, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:is_numeric) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'is_numeric', "This method is deprecated, please use match expressions with Stdlib::Compat::Numeric instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")

--- a/lib/puppet/functions/is_string.rb
+++ b/lib/puppet/functions/is_string.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:is_string, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:is_string) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'is_string', "This method is deprecated, please use match expressions with Stdlib::Compat::String instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions.")

--- a/lib/puppet/functions/validate_absolute_path.rb
+++ b/lib/puppet/functions/validate_absolute_path.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:validate_absolute_path, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:validate_absolute_path) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'validate_absolute_path', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Absolute_Path. There is further documentation for validate_legacy function in the README.")

--- a/lib/puppet/functions/validate_array.rb
+++ b/lib/puppet/functions/validate_array.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:validate_array, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:validate_array) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'validate_array', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Array. There is further documentation for validate_legacy function in the README.")

--- a/lib/puppet/functions/validate_bool.rb
+++ b/lib/puppet/functions/validate_bool.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:validate_bool, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:validate_bool) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'validate_bool', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Bool. There is further documentation for validate_legacy function in the README.")

--- a/lib/puppet/functions/validate_hash.rb
+++ b/lib/puppet/functions/validate_hash.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:validate_hash, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:validate_hash) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'validate_hash', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Hash. There is further documentation for validate_legacy function in the README.")

--- a/lib/puppet/functions/validate_integer.rb
+++ b/lib/puppet/functions/validate_integer.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:validate_integer, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:validate_integer) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'validate_integer', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Integer. There is further documentation for validate_legacy function in the README.")

--- a/lib/puppet/functions/validate_ip_address.rb
+++ b/lib/puppet/functions/validate_ip_address.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:validate_ip_address, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:validate_ip_address) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'validate_ip_address', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ip_Address. There is further documentation for validate_legacy function in the README.")

--- a/lib/puppet/functions/validate_ipv4_address.rb
+++ b/lib/puppet/functions/validate_ipv4_address.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:validate_ipv4_address, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:validate_ipv4_address) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'validate_ipv4_address', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv4_Address. There is further documentation for validate_legacy function in the README.")

--- a/lib/puppet/functions/validate_ipv6_address.rb
+++ b/lib/puppet/functions/validate_ipv6_address.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:validate_ipv6_address, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:validate_ipv6_address) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'validate_ipv6_address', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Ipv6_address. There is further documentation for validate_legacy function in the README.")

--- a/lib/puppet/functions/validate_legacy.rb
+++ b/lib/puppet/functions/validate_legacy.rb
@@ -1,20 +1,26 @@
-Puppet::Functions.create_function(:validate_legacy, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:validate_legacy) do
   # The function checks a value against both the target_type (new) and the previous_validation function (old).
 
   dispatch :validate_legacy do
-    scope_param
+    param 'Any', :scope
     param 'Type', :target_type
     param 'String', :function_name
     param 'Any', :value
-    optional_repeated_param 'Any', :args
+    repeated_param 'Any', :args
   end
 
   dispatch :validate_legacy_s do
-    scope_param
+    param 'Any', :scope
     param 'String', :type_string
     param 'String', :function_name
     param 'Any', :value
-    optional_repeated_param 'Any', :args
+    repeated_param 'Any', :args
+  end
+
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
 
   def validate_legacy_s(scope, type_string, *args)

--- a/lib/puppet/functions/validate_numeric.rb
+++ b/lib/puppet/functions/validate_numeric.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:validate_numeric, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:validate_numeric) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'validate_numeric', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Numeric. There is further documentation for validate_legacy function in the README.")

--- a/lib/puppet/functions/validate_re.rb
+++ b/lib/puppet/functions/validate_re.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:validate_re, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:validate_re) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'validate_re', "This method is deprecated, please use the stdlib validate_legacy function, with Pattern[]. There is further documentation for validate_legacy function in the README.")

--- a/lib/puppet/functions/validate_slength.rb
+++ b/lib/puppet/functions/validate_slength.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:validate_slength, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:validate_slength) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'validate_slength', "This method is deprecated, please use the stdlib validate_legacy function, with String[]. There is further documentation for validate_legacy function in the README.")

--- a/lib/puppet/functions/validate_string.rb
+++ b/lib/puppet/functions/validate_string.rb
@@ -1,7 +1,12 @@
-Puppet::Functions.create_function(:validate_string, Puppet::Functions::InternalFunction) do
+Puppet::Functions.create_function(:validate_string) do
   dispatch :deprecation_gen do
-    scope_param
-    optional_repeated_param 'Any', :args
+    param 'Any', :scope
+    repeated_param 'Any', :args
+  end
+  # Workaround PUP-4438 (fixed: https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08#diff-c937cc584953271bb3d3b3c2cb141790R221) to support puppet < 4.1.0 and puppet < 3.8.1.
+  def call(scope, *args)
+    manipulated_args = [scope] + args
+    self.class.dispatcher.dispatch(self, scope, manipulated_args)
   end
   def deprecation_gen(scope, *args)
     call_function('deprecation', 'validate_string', "This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::String. There is further documentation for validate_legacy function in the README.")


### PR DESCRIPTION
This is a workaround for PUP-4438 (fixed in https://github.com/puppetlabs/puppet/commit/e01c4dc924cd963ff6630008a5200fc6a2023b08, 4.1.0, 3.8.1).

It works by manually passing through the scope, instead of relying on the
InternalFunction class.