### PR TITLE
(MODULES-3829) Use .dup to duplicate classes for modification.

### DIFF
--- a/lib/puppet/parser/functions/ensure_resources.rb
+++ b/lib/puppet/parser/functions/ensure_resources.rb
@@ -36,7 +36,7 @@ ENDOFDOC
   params ||= {}
 
   if title.is_a?(Hash)
-    resource_hash = Hash(title)
+    resource_hash = title.dup
     resources = resource_hash.keys
 
     Puppet::Parser::Functions.function(:ensure_resource)


### PR DESCRIPTION
This function otherwise fails during `puppet preview` on Puppet 3.8.X systems.