### PR TITLE
Remove rvalue declaration from v3 deprecation() function

### DIFF
--- a/lib/puppet/parser/functions/deprecation.rb
+++ b/lib/puppet/parser/functions/deprecation.rb
@@ -1,5 +1,5 @@
 module Puppet::Parser::Functions
-  newfunction(:deprecation, :type => :rvalue, :doc => <<-EOS
+  newfunction(:deprecation, :doc => <<-EOS
   Function to print deprecation warnings (this is the 3.X version of it), The uniqueness key - can appear once. The msg is the message text including any positional information that is formatted by the user/caller of the method.).
 EOS
   ) do |arguments|
@@ -9,7 +9,7 @@ EOS
 
     key = arguments[0]
     message = arguments[1]
-    
+
     if ENV['STDLIB_LOG_DEPRECATIONS'] == "true"
       warning("deprecation. #{key}. #{message}")
     end


### PR DESCRIPTION
Without this, some uses of this function do not work in puppet3. e.g.

    if $include_src != undef {
      deprecation('apt $include_src', "please use \$include => { 'src' => ${include_src} } instead")
    }

causes

    Function 'deprecation' must be the value of a statement

on puppet 3.8.7.