### PR TITLE
Indicate that the type function is preferred

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1190,6 +1190,8 @@ Returns a string description of the type when passed a value. Type can be a stri
 
 #### `type_of`
 
+This function is provided for backwards compatibility but is generally not preferred over the built-in [type() function](https://docs.puppet.com/puppet/latest/reference/function.html#type) provided by Puppet.
+
 Returns the literal type when passed a value. Requires the new parser. Useful for comparison of types with `<=` such as in `if type_of($some_value) <= Array[String] { ... }` (which is equivalent to `if $some_value =~ Array[String] { ... }`) *Type*: rvalue.
 
 #### `union`

--- a/lib/puppet/functions/type_of.rb
+++ b/lib/puppet/functions/type_of.rb
@@ -10,6 +10,8 @@
 # See the documentation for "The Puppet Type System" for more information about types.
 # See the `assert_type()` function for flexible ways to assert the type of a value.
 #
+# The built-in type() function in puppet is generally preferred over this function 
+# this function is provided for backwards compatibility.
 Puppet::Functions.create_function(:type_of) do
   def type_of(value)
     Puppet::Pops::Types::TypeCalculator.infer_set(value)


### PR DESCRIPTION
Prior to this commit, users coming to the type_of function would not realize that the type function in puppet does the same thing and is preferred over type_of. 

After this commit, we have a comment indicating the above.