### PR TITLE
(MODULES-3829) Add tests for ensure_resources

### DIFF
--- a/lib/puppet/parser/functions/ensure_packages.rb
+++ b/lib/puppet/parser/functions/ensure_packages.rb
@@ -25,7 +25,7 @@ third argument to the ensure_resource() function.
       end
 
       Puppet::Parser::Functions.function(:ensure_resources)
-      function_ensure_resources(['package', Hash(arguments[0]), defaults ])
+      function_ensure_resources(['package', arguments[0].dup, defaults ])
     else
       packages = Array(arguments[0])
 

--- a/spec/fixtures/test/manifests/ensure_resources.pp
+++ b/spec/fixtures/test/manifests/ensure_resources.pp
@@ -1,0 +1,4 @@
+# A helper class to test the ensure_resources function
+class test::ensure_resources($resource_type, $title_hash, $attributes_hash) {
+  ensure_resources($resource_type, $title_hash, $attributes_hash)
+}

--- a/spec/functions/ensure_packages_spec.rb
+++ b/spec/functions/ensure_packages_spec.rb
@@ -33,4 +33,12 @@ describe 'ensure_packages' do
       it { expect(lambda { catalogue }).to contain_package('facter').with_ensure('present').with_provider("gem") }
     end
   end
+
+  context 'given hash of packages' do
+    before { subject.call([{"foo" => { "provider" => "rpm" }, "bar" => { "provider" => "gem" }}, { "ensure" => "present"}]) }
+
+    # this lambda is required due to strangeness within rspec-puppet's expectation handling
+    it { expect(lambda { catalogue }).to contain_package('foo').with({'provider' => 'rpm', 'ensure' => 'present'}) }
+    it { expect(lambda { catalogue }).to contain_package('bar').with({'provider' => 'gem', 'ensure' => 'present'}) }
+  end
 end

--- a/spec/unit/ensure_resources_spec.rb
+++ b/spec/unit/ensure_resources_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'test::ensure_resources', type: :class do
+  let(:params) {{ resource_type: 'user', title_hash: title_param, attributes_hash: {'ensure' => 'present'} }}
+
+  describe 'given a title hash of multiple resources' do
+
+    let(:title_param) { {'dan' => { 'gid' => 'mygroup', 'uid' => '600' }, 'alex' => { 'gid' => 'mygroup', 'uid' => '700'}} }
+
+    it { is_expected.to compile }
+    it { is_expected.to contain_user('dan').with({ 'gid' => 'mygroup', 'uid' => '600', 'ensure' => 'present'}) }
+    it { is_expected.to contain_user('alex').with({ 'gid' => 'mygroup', 'uid' => '700', 'ensure' => 'present'}) }
+  end
+
+  describe 'given a title hash of a single resource' do
+
+    let(:title_param) { {'dan' => { 'gid' => 'mygroup', 'uid' => '600' }} }
+
+    it { is_expected.to compile }
+    it { is_expected.to contain_user('dan').with({ 'gid' => 'mygroup', 'uid' => '600', 'ensure' => 'present'}) }
+  end
+end


### PR DESCRIPTION
Prior to this commit, we didn't have tests for the ensure_resources
function (only for the ensure_resource function). This meant that
we weren't catching a bug in the ensure_resources function. In order
to prevent this in the future, add some tests which test the
specific functionality of ensure_resources.