### PR TITLE
Release prep for 4.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Supported Release 4.13.2
+## Supported Release 4.14.0
 ### Summary
 
 Adds several new features and updates, especially around refining the deprecation and validate_legacy functions. Also includes a Gemfile update around an issue with parallel_tests dependancy for different versions of Ruby.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-stdlib",
-  "version": "4.13.2",
+  "version": "4.14.0",
   "author": "puppetlabs",
   "summary": "Standard library of resources for Puppet modules.",
   "license": "Apache-2.0",


### PR DESCRIPTION
The previous release prep accidentally had 4.13.2 instead of 4.14.0 as is appropriate with releases with features. This is a PR to rectify that. No 4.13.2 release or tag will be made. The 4.14.0 release will go ahead instead.