### PR TITLE
Fix unsupported data type error with rspec-puppet master

### DIFF
--- a/spec/functions/has_ip_network_spec.rb
+++ b/spec/functions/has_ip_network_spec.rb
@@ -9,7 +9,6 @@ describe 'has_ip_network' do
     let(:facts) do
       {
         :interfaces => 'eth0,lo',
-        :network => :undefined,
         :network_lo => '127.0.0.0',
         :network_eth0 => '10.0.0.0',
       }


### PR DESCRIPTION
The symbol used in the value of the facts hash is not a valid type of
value for facts, and results in the following error since
rspec-puppet@d50acf0e.

    Puppet::Error:
      Unsupported data type: 'Symbol'
    # puppet/lib/puppet/parser/scope.rb:788:in `deep_freeze'
    # puppet/lib/puppet/parser/scope.rb:781:in `block in deep_freeze'
    # puppet/lib/puppet/parser/scope.rb:781:in `each'
    # puppet/lib/puppet/parser/scope.rb:781:in `deep_freeze'
    # puppet/lib/puppet/parser/scope.rb:764:in `set_facts'
    # puppet/lib/puppet/parser/compiler.rb:850:in `set_node_parameters'
    # puppet/lib/puppet/parser/compiler.rb:166:in `block (2 levels) in compile'
    # puppet/lib/puppet/util/profiler/around_profiler.rb:58:in `profile'
    # puppet/lib/puppet/util/profiler.rb:51:in `profile'
    # puppet/lib/puppet/parser/compiler.rb:166:in `block in compile'
    # puppet/lib/puppet/context.rb:65:in `override'
    # puppet/lib/puppet.rb:293:in `override'
    # puppet/lib/puppet/parser/compiler.rb:162:in `compile'
    # rspec-puppet/lib/rspec-puppet/example/function_example_group.rb:161:in `build_compiler'

The fact's presence doesn't change the behaviour, so remove it.