### PR TITLE
(Modules 4377) Causes ensure_packages to accept concurrent declarations with ensure => 'present' and 'installed'

### DIFF
--- a/lib/puppet/parser/functions/ensure_packages.rb
+++ b/lib/puppet/parser/functions/ensure_packages.rb
@@ -20,6 +20,9 @@ third argument to the ensure_resource() function.
     if arguments[0].is_a?(Hash)
       if arguments[1]
         defaults = { 'ensure' => 'present' }.merge(arguments[1])
+        if defaults['ensure'] == 'installed'
+          defaults['ensure'] = 'present'
+        end
       else
         defaults = { 'ensure' => 'present' }
       end
@@ -31,6 +34,9 @@ third argument to the ensure_resource() function.
 
       if arguments[1]
         defaults = { 'ensure' => 'present' }.merge(arguments[1])
+        if defaults['ensure'] == 'installed'
+          defaults['ensure'] = 'present'
+        end
       else
         defaults = { 'ensure' => 'present' }
       end

--- a/spec/functions/ensure_packages_spec.rb
+++ b/spec/functions/ensure_packages_spec.rb
@@ -41,4 +41,16 @@ describe 'ensure_packages' do
     it { expect(lambda { catalogue }).to contain_package('foo').with({'provider' => 'rpm', 'ensure' => 'present'}) }
     it { expect(lambda { catalogue }).to contain_package('bar').with({'provider' => 'gem', 'ensure' => 'present'}) }
   end
+
+  context 'given a catalog with "package { puppet: ensure => present }"' do
+    let(:pre_condition) { 'package { puppet: ensure => present }' }
+
+    describe 'after running ensure_package("puppet", { "ensure" => "installed" })' do
+      before { subject.call(['puppet', { "ensure" => "installed" }]) }
+
+      # this lambda is required due to strangeness within rspec-puppet's expectation handling
+      it { expect(lambda { catalogue }).to contain_package('puppet').with_ensure('present') }
+    end
+  end
+
 end


### PR DESCRIPTION
If user declares ensure_packages(<Package>, { ensure => 'present' }) and ensure_packages(<Package>, { ensure => 'installed' }) concurrently, funcion fails at different 'ensure' values. This change causes function to change 'installed' to 'present', avoiding this error.
Maybe similar treatment is needed when arguments[0] is a hash, but I'm an absolute beginner in Ruby.
