### PR TITLE
Add new file_line option append_on_no_match

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ file_line { 'bashrc_proxy':
 
 In the example above, `match` looks for a line beginning with 'export' followed by 'HTTP_PROXY' and replaces it with the value in line.
 
+Match Example:
+
+    file_line { 'bashrc_proxy':
+      ensure             => present,
+      path               => '/etc/bashrc',
+      line               => 'export HTTP_PROXY=http://squid.puppetlabs.vm:3128',
+      match              => '^export\ HTTP_PROXY\=',
+      append_on_no_match => false,
+    }
+
+In this code example, `match` looks for a line beginning with export followed by HTTP_PROXY and replaces it with the value in line. If a match is not found, then no changes are made to the file.
+
 Match Example with `ensure => absent`:
 
 ```puppet

--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -12,7 +12,9 @@ Puppet::Type.type(:file_line).provide(:ruby) do
       found = lines_count > 0
     else
       match_count = count_matches(new_match_regex)
-      if resource[:replace].to_s == 'true'
+      if resource[:append_on_no_match].to_s == 'false'
+        found = true
+      elsif resource[:replace].to_s == 'true'
         found = lines_count > 0 && lines_count == match_count
       else
         found = match_count > 0

--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -58,7 +58,7 @@ Puppet::Type.newtype(:file_line) do
           encoding => "iso-8859-1",
         }
 
-    Files with special characters that are not valid UTF-8 will give the 
+    Files with special characters that are not valid UTF-8 will give the
     error message "invalid byte sequence in UTF-8".  In this case, determine
     the correct file encoding and specify the correct encoding using the
     encoding attribute, the value of which needs to be a valid Ruby character
@@ -134,6 +134,12 @@ Puppet::Type.newtype(:file_line) do
   newparam(:encoding) do
     desc 'For files that are not UTF-8 encoded, specify encoding such as iso-8859-1'
     defaultto 'UTF-8'
+  end
+
+  newparam(:append_on_no_match) do
+    desc 'If true, append line if match is not found. If false, do not append line if a match is not found'
+    newvalues(true, false)
+    defaultto true
   end
 
   # Autorequire the file resource if it's being managed

--- a/spec/unit/puppet/provider/file_line/ruby_spec.rb
+++ b/spec/unit/puppet/provider/file_line/ruby_spec.rb
@@ -194,6 +194,24 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
         @provider.create
         expect(File.read(@tmpfile).chomp).to eql("foo1\nfoo = bar\nfoo2")
       end
+
+      it 'should not add line after no matches found' do
+        @resource = Puppet::Type::File_line.new(
+          {
+            :name               => 'foo',
+            :path               => @tmpfile,
+            :line               => 'inserted = line',
+            :match              => '^foo3$',
+            :append_on_no_match => false,
+          }
+        )
+        @provider = provider_class.new(@resource)
+        File.open(@tmpfile, 'w') do |fh|
+          fh.write("foo1\nfoo = blah\nfoo2\nfoo = baz")
+        end
+        expect(@provider.exists?).to be true
+        expect(File.read(@tmpfile).chomp).to eql("foo1\nfoo = blah\nfoo2\nfoo = baz")
+      end
     end
 
     describe 'using after' do


### PR DESCRIPTION
Currently, there doesn't exist a way to leave a file untouched if no regex matches are found. 

I have a use case where I'm searching for a specific regex in multiple files and I only want to update the files that contain the regex pattern.