### PR TITLE
Allow test module metadata.json to be read

### DIFF
--- a/spec/functions/load_module_metadata_spec.rb
+++ b/spec/functions/load_module_metadata_spec.rb
@@ -7,8 +7,8 @@ describe 'load_module_metadata' do
 
   describe "when calling with valid arguments" do
     before :each do
-      allow(File).to receive(:read).with(/\/stdlib\/metadata.json/, {:encoding=>"utf-8"}).and_return('{"name": "puppetlabs-stdlib"}')
-      allow(File).to receive(:read).with(/\/stdlib\/metadata.json/).and_return('{"name": "puppetlabs-stdlib"}')
+      allow(File).to receive(:read).with(/\/(stdlib|test)\/metadata.json/, {:encoding=>"utf-8"}).and_return('{"name": "puppetlabs-stdlib"}')
+      allow(File).to receive(:read).with(/\/(stdlib|test)\/metadata.json/).and_return('{"name": "puppetlabs-stdlib"}')
     end
     it "should json parse the file" do
       if Puppet::Util::Platform.windows?

--- a/spec/functions/loadjson_spec.rb
+++ b/spec/functions/loadjson_spec.rb
@@ -6,8 +6,8 @@ describe 'loadjson' do
 
   describe "when calling with valid arguments" do
     before :each do
-      allow(File).to receive(:read).with(/\/stdlib\/metadata.json/, {:encoding=>"utf-8"}).and_return('{"name": "puppetlabs-stdlib"}')
-      allow(File).to receive(:read).with(/\/stdlib\/metadata.json/).and_return('{"name": "puppetlabs-stdlib"}')
+      allow(File).to receive(:read).with(/\/(stdlib|test)\/metadata.json/, {:encoding=>"utf-8"}).and_return('{"name": "puppetlabs-stdlib"}')
+      allow(File).to receive(:read).with(/\/(stdlib|test)\/metadata.json/).and_return('{"name": "puppetlabs-stdlib"}')
     end
 
     context 'when a non-existing file is specified' do


### PR DESCRIPTION
Since puppetlabs/puppet@f2e8e66, the test module's metadata.json is also
read causing expectation failures. Like 5c51463, permit it to be read by
Puppet.