### PR TITLE
Fix acceptance test failure "Hiera is not a class"

### DIFF
--- a/spec/acceptance/zip_spec.rb
+++ b/spec/acceptance/zip_spec.rb
@@ -1,6 +1,5 @@
 #! /usr/bin/env ruby -S rspec
 require 'spec_helper_acceptance'
-require 'puppet'
 
 describe 'zip function', :unless => UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem')) do
   describe 'success' do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby -S rspec
+require 'puppet'
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'


### PR DESCRIPTION
Due to [BKR-969](https://tickets.puppetlabs.com/browse/BKR-969) the global `Hiera` symbol is corrupted. Loading puppet before beaker fixes that.