### PR TITLE
MODULES-4380 Tests for ensure_resource

### DIFF
--- a/spec/functions/ensure_resource_spec.rb
+++ b/spec/functions/ensure_resource_spec.rb
@@ -38,7 +38,31 @@ describe 'ensure_resource' do
       it { expect(lambda { catalogue }).to contain_user('username1').with_ensure('present') }
       it { expect(lambda { catalogue }).to contain_user('username1').without_gid }
     end
+  end
 
+  context 'given a catalog with UTF8 chars' do
+    describe 'after running ensure_resource("user", "Şắოрŀễ Ţë×ť", {})' do
+      before { subject.call(['User', 'Şắოрŀễ Ţë×ť', {}]) }
+
+      # this lambda is required due to strangeness within rspec-puppet's expectation handling
+      it { expect(lambda { catalogue }).to contain_user('Şắოрŀễ Ţë×ť').without_ensure }
+    end
+
+    describe 'after running ensure_resource("user", "Şắოрŀễ Ţë×ť", { gid => undef })' do
+      before { subject.call(['User', 'Şắოрŀễ Ţë×ť', { 'gid' => :undef }]) }
+
+      # this lambda is required due to strangeness within rspec-puppet's expectation handling
+      it { expect(lambda { catalogue }).to contain_user('Şắოрŀễ Ţë×ť').without_ensure }
+      it { expect(lambda { catalogue }).to contain_user('Şắოрŀễ Ţë×ť').without_gid }
+    end
+
+    describe 'after running ensure_resource("user", "Şắოрŀễ Ţë×ť", { ensure => present, gid => undef })' do
+      before { subject.call(['User', 'Şắოрŀễ Ţë×ť', { 'ensure' => 'present', 'gid' => :undef }]) }
+
+      # this lambda is required due to strangeness within rspec-puppet's expectation handling
+      it { expect(lambda { catalogue }).to contain_user('Şắოрŀễ Ţë×ť').with_ensure('present') }
+      it { expect(lambda { catalogue }).to contain_user('Şắოрŀễ Ţë×ť').without_gid }
+    end
   end
 
   context 'given a catalog with "user { username1: ensure => present }"' do


### PR DESCRIPTION
This is adding tests to ensure that the ensure_resource function can process UFT8 strings. 
Tests will be added for each function as a separate PR to maintain traceability. 