### PR TITLE
(FM-6054) - Unit tests for low effort functions

### DIFF
--- a/spec/functions/delete_undef_values_spec.rb
+++ b/spec/functions/delete_undef_values_spec.rb
@@ -16,6 +16,7 @@ describe 'delete_undef_values' do
         end
         it { is_expected.to run.with_params([undef_value]).and_return([]) }
         it { is_expected.to run.with_params(['one',undef_value,'two','three']).and_return(['one','two','three']) }
+        it { is_expected.to run.with_params(['ớņέ',undef_value,'ŧשּׁō','ŧħґëə']).and_return(['ớņέ','ŧשּׁō','ŧħґëə']) }
       end
 
       it "should leave the original argument intact" do

--- a/spec/functions/difference_spec.rb
+++ b/spec/functions/difference_spec.rb
@@ -12,8 +12,10 @@ describe 'difference' do
   it { is_expected.to run.with_params([], []).and_return([]) }
   it { is_expected.to run.with_params([], ['one']).and_return([]) }
   it { is_expected.to run.with_params(['one'], ['one']).and_return([]) }
+  it { is_expected.to run.with_params(['ớņέ'], ['']).and_return(['ớņέ']) }
   it { is_expected.to run.with_params(['one'], []).and_return(['one']) }
   it { is_expected.to run.with_params(['one', 'two', 'three'], ['two', 'three']).and_return(['one']) }
+  it { is_expected.to run.with_params(['ớņέ', 'ŧשּׁō', 'ŧħґëə', 2], ['ŧשּׁō', 'ŧħґëə']).and_return(['ớņέ', 2]) }
   it { is_expected.to run.with_params(['one', 'two', 'two', 'three'], ['two', 'three']).and_return(['one']) }
   it { is_expected.to run.with_params(['one', 'two', 'three'], ['two', 'two', 'three']).and_return(['one']) }
   it { is_expected.to run.with_params(['one', 'two', 'three'], ['two', 'three', 'four']).and_return(['one']) }

--- a/spec/functions/flatten_spec.rb
+++ b/spec/functions/flatten_spec.rb
@@ -11,4 +11,5 @@ describe 'flatten' do
   it { is_expected.to run.with_params([['one']]).and_return(['one']) }
   it { is_expected.to run.with_params(["a","b","c","d","e","f","g"]).and_return(["a","b","c","d","e","f","g"]) }
   it { is_expected.to run.with_params([["a","b",["c",["d","e"],"f","g"]]]).and_return(["a","b","c","d","e","f","g"]) }
+  it { is_expected.to run.with_params(["ã","β",["ĉ",["đ","ẽ","ƒ","ġ"]]]).and_return(["ã","β","ĉ","đ","ẽ","ƒ","ġ"]) }
 end

--- a/spec/functions/fqdn_rand_string_spec.rb
+++ b/spec/functions/fqdn_rand_string_spec.rb
@@ -20,6 +20,7 @@ describe 'fqdn_rand_string' do
   it { is_expected.to run.with_params(100, '').and_return(default_charset) }
   it { is_expected.to run.with_params(100, 'a').and_return(/\Aa{100}\z/) }
   it { is_expected.to run.with_params(100, 'ab').and_return(/\A[ab]{100}\z/) }
+  it { is_expected.to run.with_params(100, 'ãβ').and_return(/\A[ãβ]{100}\z/) }
 
   it "provides the same 'random' value on subsequent calls for the same host" do
     expect(fqdn_rand_string(10)).to eql(fqdn_rand_string(10))

--- a/spec/functions/fqdn_rotate_spec.rb
+++ b/spec/functions/fqdn_rotate_spec.rb
@@ -7,6 +7,7 @@ describe 'fqdn_rotate' do
   it { is_expected.to run.with_params({}).and_raise_error(Puppet::ParseError, /Requires either array or string to work with/) }
   it { is_expected.to run.with_params('').and_return('') }
   it { is_expected.to run.with_params('a').and_return('a') }
+  it { is_expected.to run.with_params('ã').and_return('ã') }
 
   it { is_expected.to run.with_params([]).and_return([]) }
   it { is_expected.to run.with_params(['a']).and_return(['a']) }

--- a/spec/functions/grep_spec.rb
+++ b/spec/functions/grep_spec.rb
@@ -16,4 +16,5 @@ describe 'grep' do
   it { is_expected.to run.with_params([], 'two').and_return([]) }
   it { is_expected.to run.with_params(['one', 'two', 'three'], 'two').and_return(['two']) }
   it { is_expected.to run.with_params(['one', 'two', 'three'], 't(wo|hree)').and_return(['two', 'three']) }
+  it { is_expected.to run.with_params(['ờאּê', 'ţשּׂỡ', 'ţһŗəè'], 'ţ(שּׂỡ|һŗəè)').and_return(['ţשּׂỡ', 'ţһŗəè']) }
 end

--- a/spec/functions/hash_spec.rb
+++ b/spec/functions/hash_spec.rb
@@ -10,5 +10,6 @@ describe 'hash' do
   it { is_expected.to run.with_params(['one']).and_raise_error(Puppet::ParseError, /Unable to compute/) }
   it { is_expected.to run.with_params([]).and_return({}) }
   it { is_expected.to run.with_params(['key1', 'value1']).and_return({ 'key1' => 'value1' }) }
+  it { is_expected.to run.with_params(['κ℮ұ1', '√āĺűẻ1']).and_return({ 'κ℮ұ1' => '√āĺűẻ1' }) }
   it { is_expected.to run.with_params(['key1', 'value1', 'key2', 'value2']).and_return({ 'key1' => 'value1', 'key2' => 'value2' }) }
 end

--- a/spec/functions/intersection_spec.rb
+++ b/spec/functions/intersection_spec.rb
@@ -14,6 +14,7 @@ describe 'intersection' do
   it { is_expected.to run.with_params(['one'], []).and_return([]) }
   it { is_expected.to run.with_params(['one'], ['one']).and_return(['one']) }
   it { is_expected.to run.with_params(['one', 'two', 'three'], ['two', 'three']).and_return(['two', 'three']) }
+  it { is_expected.to run.with_params(['ōŋể', 'ŧשợ', 'ţђŕẽё'], ['ŧשợ', 'ţђŕẽё']).and_return(['ŧשợ', 'ţђŕẽё']) }
   it { is_expected.to run.with_params(['one', 'two', 'two', 'three'], ['two', 'three']).and_return(['two', 'three']) }
   it { is_expected.to run.with_params(['one', 'two', 'three'], ['two', 'two', 'three']).and_return(['two', 'three']) }
   it { is_expected.to run.with_params(['one', 'two', 'three'], ['two', 'three', 'four']).and_return(['two', 'three']) }

--- a/spec/functions/join_keys_to_values_spec.rb
+++ b/spec/functions/join_keys_to_values_spec.rb
@@ -11,6 +11,12 @@ describe 'join_keys_to_values' do
   it { is_expected.to run.with_params({}, ':').and_return([]) }
   it { is_expected.to run.with_params({ 'key' => 'value' }, '').and_return(['keyvalue']) }
   it { is_expected.to run.with_params({ 'key' => 'value' }, ':').and_return(['key:value']) }
+
+  context 'should run with UTF8 and double byte characters' do 
+    it { is_expected.to run.with_params({ 'ҝẽγ' => '√ạĺűē' }, ':').and_return(['ҝẽγ:√ạĺűē']) }
+    it  { is_expected.to run.with_params({ 'ҝẽγ' => '√ạĺűē' }, '万').and_return(['ҝẽγ万√ạĺűē']) }
+  end
+
   it { is_expected.to run.with_params({ 'key' => nil }, ':').and_return(['key:']) }
   it 'should run join_keys_to_values(<hash with multiple keys>, ":") and return the proper array' do
     result = subject.call([{ 'key1' => 'value1', 'key2' => 'value2' }, ':'])
@@ -21,3 +27,4 @@ describe 'join_keys_to_values' do
     expect(result.sort).to eq(['key1 value1', 'key2 value2', 'key2 value3'].sort)
   end
 end
+

--- a/spec/functions/join_spec.rb
+++ b/spec/functions/join_spec.rb
@@ -16,4 +16,5 @@ describe 'join' do
   it { is_expected.to run.with_params(['one'], ':').and_return('one') }
   it { is_expected.to run.with_params(['one', 'two', 'three']).and_return('onetwothree') }
   it { is_expected.to run.with_params(['one', 'two', 'three'], ':').and_return('one:two:three') }
+  it { is_expected.to run.with_params(['ōŋể', 'ŧשợ', 'ţђŕẽё'], ':').and_return('ōŋể:ŧשợ:ţђŕẽё') }
 end

--- a/spec/functions/lstrip_spec.rb
+++ b/spec/functions/lstrip_spec.rb
@@ -22,6 +22,7 @@ describe 'lstrip' do
   it { is_expected.to run.with_params('one ').and_return('one ') }
   it { is_expected.to run.with_params(' one ').and_return('one ') }
   it { is_expected.to run.with_params('     one ').and_return('one ') }
+  it { is_expected.to run.with_params('     ǿňè ').and_return('ǿňè ') }
   it { is_expected.to run.with_params("\tone ").and_return('one ') }
   it { is_expected.to run.with_params("\t one ").and_return('one ') }
   it { is_expected.to run.with_params("one \t").and_return("one \t") }

--- a/spec/functions/member_spec.rb
+++ b/spec/functions/member_spec.rb
@@ -17,5 +17,7 @@ describe 'member' do
   it { is_expected.to run.with_params(['one'], 'one').and_return(true) }
   it { is_expected.to run.with_params(['one'], ['one']).and_return(true) }
   it { is_expected.to run.with_params(['one', 'two', 'three', 'four'], ['four', 'two']).and_return(true) }
+  it { is_expected.to run.with_params(['ọאּẹ', 'ŧẅồ', 'ţҺŗęē', 'ƒơџŕ'], ['ƒơџŕ', 'ŧẅồ']).and_return(true) }
   it { is_expected.to run.with_params(['one', 'two', 'three', 'four'], ['four', 'five']).and_return(false) }
+  it { is_expected.to run.with_params(['ọאּẹ', 'ŧẅồ', 'ţҺŗęē', 'ƒơџŕ'], ['ƒơџŕ', 'ƒί√ə']).and_return(false) }
 end

--- a/spec/functions/pick_default_spec.rb
+++ b/spec/functions/pick_default_spec.rb
@@ -5,6 +5,7 @@ describe 'pick_default' do
   it { is_expected.to run.with_params().and_raise_error(Puppet::Error, /Must receive at least one argument/) }
 
   it { is_expected.to run.with_params('one', 'two').and_return('one') }
+  it { is_expected.to run.with_params('ớņệ', 'ťωơ').and_return('ớņệ') }
   it { is_expected.to run.with_params('', 'two').and_return('two') }
   it { is_expected.to run.with_params(:undef, 'two').and_return('two') }
   it { is_expected.to run.with_params(:undefined, 'two').and_return('two') }
@@ -13,6 +14,7 @@ describe 'pick_default' do
   [ '', :undef, :undefined, nil, {}, [], 1, 'default' ].each do |value|
     describe "when providing #{value.inspect} as default" do
       it { is_expected.to run.with_params('one', value).and_return('one') }
+      it { is_expected.to run.with_params('ớņệ', value).and_return('ớņệ') }
       it { is_expected.to run.with_params([], value).and_return([]) }
       it { is_expected.to run.with_params({}, value).and_return({}) }
       it { is_expected.to run.with_params(value, value).and_return(value) }

--- a/spec/functions/prefix_spec.rb
+++ b/spec/functions/prefix_spec.rb
@@ -11,6 +11,7 @@ describe 'prefix' do
   it { is_expected.to run.with_params([], 2).and_raise_error(Puppet::ParseError, /expected second argument to be a String/) }
   it { is_expected.to run.with_params([]).and_return([]) }
   it { is_expected.to run.with_params(['one', 2]).and_return(['one', '2']) }
+  it { is_expected.to run.with_params(['ớņệ', 2]).and_return(['ớņệ', '2']) }
   it { is_expected.to run.with_params([], '').and_return([]) }
   it { is_expected.to run.with_params([''], '').and_return(['']) }
   it { is_expected.to run.with_params(['one'], 'pre').and_return(['preone']) }

--- a/spec/functions/reject_spec.rb
+++ b/spec/functions/reject_spec.rb
@@ -16,4 +16,5 @@ describe 'reject' do
   it { is_expected.to run.with_params([], 'two').and_return([]) }
   it { is_expected.to run.with_params(['one', 'two', 'three'], 'two').and_return(['one', 'three']) }
   it { is_expected.to run.with_params(['one', 'two', 'three'], 't(wo|hree)').and_return(['one']) }
+  it { is_expected.to run.with_params(['όŉệ', 'ţщồ', 'ţңяέέ'], 'ţ(щồ|ңяέέ)').and_return(['όŉệ']) }
 end

--- a/spec/functions/reverse_spec.rb
+++ b/spec/functions/reverse_spec.rb
@@ -15,11 +15,13 @@ describe 'reverse' do
   it { is_expected.to run.with_params(['one']).and_return(['one']) }
   it { is_expected.to run.with_params(['one', 'two', 'three']).and_return(['three', 'two', 'one']) }
   it { is_expected.to run.with_params(['one', 'two', 'three', 'four']).and_return(['four', 'three', 'two', 'one']) }
+  it { is_expected.to run.with_params(['ổňë', 'ťŵọ', 'ŧңяəė', 'ƒŏůŗ']).and_return(['ƒŏůŗ', 'ŧңяəė', 'ťŵọ', 'ổňë']) }
 
   it { is_expected.to run.with_params('').and_return('') }
   it { is_expected.to run.with_params('a').and_return('a') }
   it { is_expected.to run.with_params('abc').and_return('cba') }
   it { is_expected.to run.with_params('abcd').and_return('dcba') }
+  it { is_expected.to run.with_params('āβćđ').and_return('đćβā') }
 
   context 'when using a class extending String' do
     it 'should call its reverse method' do

--- a/spec/functions/rstrip_spec.rb
+++ b/spec/functions/rstrip_spec.rb
@@ -22,6 +22,7 @@ describe 'rstrip' do
   it { is_expected.to run.with_params('one ').and_return('one') }
   it { is_expected.to run.with_params(' one ').and_return(' one') }
   it { is_expected.to run.with_params('     one ').and_return('     one') }
+  it { is_expected.to run.with_params(' ǿňè    ').and_return(' ǿňè') }
   it { is_expected.to run.with_params("\tone ").and_return("\tone") }
   it { is_expected.to run.with_params("\t one ").and_return("\t one") }
   it { is_expected.to run.with_params("one\t").and_return('one') }

--- a/spec/functions/size_spec.rb
+++ b/spec/functions/size_spec.rb
@@ -19,11 +19,14 @@ describe 'size' do
   it { is_expected.to run.with_params({}).and_return(0) }
   it { is_expected.to run.with_params({'1' => '2'}).and_return(1) }
   it { is_expected.to run.with_params({'1' => '2', '4' => '4'}).and_return(2) }
+  it { is_expected.to run.with_params({'€' => '@', '竹' => 'ǿňè'}).and_return(2) }
 
   it { is_expected.to run.with_params('').and_return(0) }
   it { is_expected.to run.with_params('a').and_return(1) }
   it { is_expected.to run.with_params('abc').and_return(3) }
   it { is_expected.to run.with_params('abcd').and_return(4) }
+  it { is_expected.to run.with_params('万').and_return(1) }
+  it { is_expected.to run.with_params('āβćđ').and_return(4) }
 
   context 'when using a class extending String' do
     it 'should call its size method' do

--- a/spec/functions/strip_spec.rb
+++ b/spec/functions/strip_spec.rb
@@ -30,5 +30,6 @@ describe 'strip' do
   it { is_expected.to run.with_params("\tone \t").and_return('one') }
   it { is_expected.to run.with_params("\t one \t").and_return('one') }
   it { is_expected.to run.with_params(' o n e ').and_return('o n e') }
+  it { is_expected.to run.with_params('      ỏŋέ  ').and_return('ỏŋέ') }
   it { is_expected.to run.with_params(AlsoString.new(' one ')).and_return('one') }
 end

--- a/spec/functions/suffix_spec.rb
+++ b/spec/functions/suffix_spec.rb
@@ -15,6 +15,8 @@ describe 'suffix' do
   it { is_expected.to run.with_params([''], '').and_return(['']) }
   it { is_expected.to run.with_params(['one'], 'post').and_return(['onepost']) }
   it { is_expected.to run.with_params(['one', 'two', 'three'], 'post').and_return(['onepost', 'twopost', 'threepost']) }
+  it { is_expected.to run.with_params(['ỗńέ', 'ťשׂǿ', 'ŧҺř℮ə'], 'рổŝţ').and_return(['ỗńέрổŝţ', 'ťשׂǿрổŝţ', 'ŧҺř℮əрổŝţ']) }
+
   it {
     is_expected.to run.with_params({}).and_return({})
   }

--- a/spec/functions/union_spec.rb
+++ b/spec/functions/union_spec.rb
@@ -20,5 +20,6 @@ describe 'union' do
   it { is_expected.to run.with_params(['one', 'two', 'three'], ['two', 'two', 'three']).and_return(['one', 'two', 'three']) }
   it { is_expected.to run.with_params(['one', 'two'], ['two', 'three'], ['one', 'three']).and_return(['one', 'two', 'three']) }
   it { is_expected.to run.with_params(['one', 'two'], ['three', 'four'], ['one', 'two', 'three'], ['four']).and_return(['one', 'two', 'three', 'four']) }
+  it { is_expected.to run.with_params(['ốńə', 'ţשׂợ'], ['ŧĥяếệ', 'ƒởųŗ'], ['ốńə', 'ţשׂợ', 'ŧĥяếệ'], ['ƒởųŗ']).and_return(['ốńə', 'ţשׂợ', 'ŧĥяếệ', 'ƒởųŗ']) }
   it 'should not confuse types' do is_expected.to run.with_params(['1', '2', '3'], [1, 2]).and_return(['1', '2', '3', 1, 2]) end
 end

--- a/spec/functions/unique_spec.rb
+++ b/spec/functions/unique_spec.rb
@@ -17,11 +17,13 @@ describe 'unique' do
     it { is_expected.to run.with_params([]).and_return([]) }
     it { is_expected.to run.with_params(['a']).and_return(['a']) }
     it { is_expected.to run.with_params(['a', 'b', 'a']).and_return(['a', 'b']) }
+    it { is_expected.to run.with_params(['ã', 'ъ', 'ã']).and_return(['ã', 'ъ']) }
   end
 
   context 'when called with a string' do
     it { is_expected.to run.with_params('').and_return('') }
     it { is_expected.to run.with_params('a').and_return('a') }
     it { is_expected.to run.with_params('aaba').and_return('ab') }
+    it { is_expected.to run.with_params('ããъã').and_return('ãъ') }
   end
 end


### PR DESCRIPTION
This is unit tests for the low effort function tests for i18n compatibility. 

This includes tests for the following functions:
delete_undef_values
difference
flatten
fqdn_rand_string
fqdn_rotate
grep
hash
intersection
join
join_keys_to_values
lstrip
member
merge
pick_default
prefix
reject
reverse
rstrip
strip
suffix
union
unique