### PR TITLE
(#FM-6068) allow file encoding to be specified

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -118,6 +118,22 @@ In this code example, `match` looks for a line beginning with export
 followed by HTTP_PROXY and delete it.  If multiple lines match, an
 error will be raised unless the `multiple => true` parameter is set.
 
+Encoding example:
+
+    file_line { "XScreenSaver":
+      ensure   => present,
+      path     => '/root/XScreenSaver'
+      line     => "*lock: 10:00:00",
+      match    => '^*lock:',
+      encoding => "iso-8859-1",
+    }
+
+Files with special characters that are not valid UTF-8 will give the 
+error message "invalid byte sequence in UTF-8".  In this case, determine
+the correct file encoding and specify the correct encoding using the
+encoding attribute, the value of which needs to be a valid Ruby character
+encoding.
+
 **Autorequires:** If Puppet is managing the file that contains the line being managed, the `file_line` resource autorequires that file.
 
 ##### Parameters

--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:file_line).provide(:ruby) do
     #  file; for now assuming that this type is only used on
     #  small-ish config files that can fit into memory without
     #  too much trouble.
-    @lines ||= File.readlines(resource[:path])
+    @lines ||= File.readlines(resource[:path], :encoding => resource[:encoding])
   end
 
   def match_regex

--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -48,6 +48,22 @@ Puppet::Type.newtype(:file_line) do
     followed by HTTP_PROXY and delete it.  If multiple lines match, an
     error will be raised unless the `multiple => true` parameter is set.
 
+    Encoding example:
+
+        file_line { "XScreenSaver":
+          ensure   => present,
+          path     => '/root/XScreenSaver'
+          line     => "*lock: 10:00:00",
+          match    => '^*lock:',
+          encoding => "iso-8859-1",
+        }
+
+    Files with special characters that are not valid UTF-8 will give the 
+    error message "invalid byte sequence in UTF-8".  In this case, determine
+    the correct file encoding and specify the correct encoding using the
+    encoding attribute, the value of which needs to be a valid Ruby character
+    encoding.
+
     **Autorequires:** If Puppet is managing the file that will contain the line
     being managed, the file_line resource will autorequire that file.
   EOT
@@ -105,6 +121,11 @@ Puppet::Type.newtype(:file_line) do
     desc 'If true, replace line that matches. If false, do not write line if a match is found'
     newvalues(true, false)
     defaultto true
+  end
+
+  newparam(:encoding) do
+    desc 'For files that are not UTF-8 encoded, specify encoding such as iso-8859-1'
+    defaultto 'UTF-8'
   end
 
   # Autorequire the file resource if it's being managed

--- a/spec/unit/puppet/type/file_line_spec.rb
+++ b/spec/unit/puppet/type/file_line_spec.rb
@@ -69,7 +69,12 @@ describe Puppet::Type.type(:file_line) do
   it 'should default to replace => true' do
     expect(file_line[:replace]).to eq :true
   end
-
+  it 'should default to encoding => UTF-8' do
+    expect(file_line[:encoding]).to eq 'UTF-8'
+  end
+  it 'should accept encoding => iso-8859-1' do
+    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :path => tmp_path, :ensure => :present, :encoding => 'iso-8859-1', :line => 'bar') }.not_to raise_error
+  end
   it "should autorequire the file it manages" do
     catalog = Puppet::Resource::Catalog.new
     file = Puppet::Type.type(:file).new(:name => tmp_path)


### PR DESCRIPTION
Add a new parameter `encoding` to allow non UTF-8 files to specify a file encoding.  This prevents receiving the error message "invalid byte sequence in UTF-8" when special characters that are not UTF-8 encoded appear in the input stream, such as the copyright symbol.