### PR TITLE
(FM-6058) - Unit tests for med effort functions

### DIFF
--- a/spec/functions/basename_spec.rb
+++ b/spec/functions/basename_spec.rb
@@ -11,4 +11,9 @@ describe 'basename' do
   it { is_expected.to run.with_params('/path/to/a/file.ext', '.ext').and_return('file') }
   it { is_expected.to run.with_params('relative_path/to/a/file.ext', '.ext').and_return('file') }
   it { is_expected.to run.with_params('scheme:///path/to/a/file.ext').and_return('file.ext') }
+
+  context 'should run with UTF8 and double byte characters' do
+    it { is_expected.to run.with_params('scheme:///√ạĺűē/竹.ext').and_return('竹.ext') }
+    it { is_expected.to run.with_params('ҝẽγ:/√ạĺűē/竹.ㄘ', '.ㄘ').and_return('竹') }
+  end
 end

--- a/spec/functions/chomp_spec.rb
+++ b/spec/functions/chomp_spec.rb
@@ -17,4 +17,9 @@ describe 'chomp' do
   it { is_expected.to run.with_params(AlsoString.new("one\n")).and_return("one") }
   it { is_expected.to run.with_params(AlsoString.new("one\n\n")).and_return("one\n") }
   it { is_expected.to run.with_params([AlsoString.new("one\n"), AlsoString.new("two"), "three\n"]).and_return(["one", "two", "three"]) }
+
+  context 'should run with UTF8 and double byte characters' do
+    it { is_expected.to run.with_params("ůťƒ8\n\n").and_return("ůťƒ8\n") }
+    it { is_expected.to run.with_params("ネット\n\n").and_return("ネット\n") }
+  end
 end

--- a/spec/functions/chop_spec.rb
+++ b/spec/functions/chop_spec.rb
@@ -17,4 +17,9 @@ describe 'chop' do
   it { is_expected.to run.with_params(AlsoString.new("one\n")).and_return("one") }
   it { is_expected.to run.with_params(AlsoString.new("one\n\n")).and_return("one\n") }
   it { is_expected.to run.with_params([AlsoString.new("one\n"), AlsoString.new("two"), "three\n"]).and_return(["one", "tw", "three"]) }
+
+  context 'should run with UTF8 and double byte characters' do
+    it { is_expected.to run.with_params("ůťƒ8\n\n").and_return("ůťƒ8\n") }
+    it { is_expected.to run.with_params("ネット\n\n").and_return("ネット\n") }
+  end
 end

--- a/spec/functions/deep_merge_spec.rb
+++ b/spec/functions/deep_merge_spec.rb
@@ -52,4 +52,8 @@ describe 'deep_merge' do
     expect(argument1).to eq(original1)
     expect(argument2).to eq(original2)
   end
+
+  context 'should run with UTF8 and double byte characters' do
+    it { is_expected.to run.with_params({'ĸέỹ1' => 'ϋǻļủë1'}, {'この文字列' => '万' }).and_return({'ĸέỹ1' => 'ϋǻļủë1', 'この文字列' => '万'}) }
+  end
 end

--- a/spec/functions/dirname_spec.rb
+++ b/spec/functions/dirname_spec.rb
@@ -10,4 +10,9 @@ describe 'dirname' do
   it { is_expected.to run.with_params('/path/to/a/file.ext', []).and_raise_error(Puppet::ParseError) }
   it { is_expected.to run.with_params('/path/to/a/file.ext').and_return('/path/to/a') }
   it { is_expected.to run.with_params('relative_path/to/a/file.ext').and_return('relative_path/to/a') }
+
+  context 'should run with UTF8 and double byte characters' do
+    it { is_expected.to run.with_params('scheme:///√ạĺűē/竹.ext').and_return('scheme:///√ạĺűē') }
+    it { is_expected.to run.with_params('ҝẽγ:/√ạĺűē/竹.ㄘ').and_return('ҝẽγ:/√ạĺűē') }
+  end
 end

--- a/spec/functions/fqdn_uuid_spec.rb
+++ b/spec/functions/fqdn_uuid_spec.rb
@@ -10,5 +10,4 @@ describe 'fqdn_uuid' do
     it { should run.with_params('puppetlabs.com').and_return('9c70320f-6815-5fc5-ab0f-debe68bf764c') }
     it { should run.with_params('google.com').and_return('64ee70a4-8cc1-5d25-abf2-dea6c79a09c8') }
   end
-
 end

--- a/spec/functions/getvar_spec.rb
+++ b/spec/functions/getvar_spec.rb
@@ -20,4 +20,19 @@ describe 'getvar' do
     it { is_expected.to run.with_params('::site::data::foo').and_return('baz') }
     it { is_expected.to run.with_params('::site::data::bar').and_return(nil) }
   end
+
+  context 'given variables in namespaces' do
+    let(:pre_condition) {
+      <<-'ENDofPUPPETcode'
+      class site::info { $lock = 'ŧҺîš íš ắ śţřĭŋĝ' }
+      class site::new { $item = '万Ü€‰' }
+      include site::info
+      include site::new
+      ENDofPUPPETcode
+    }
+
+    it { is_expected.to run.with_params('site::info::lock').and_return('ŧҺîš íš ắ śţřĭŋĝ') }
+    it { is_expected.to run.with_params('::site::new::item').and_return('万Ü€‰') }
+  end
 end
+

--- a/spec/functions/has_key_spec.rb
+++ b/spec/functions/has_key_spec.rb
@@ -12,4 +12,9 @@ describe 'has_key' do
   it { is_expected.to run.with_params({ 'key' => 'value' }, "key").and_return(true) }
   it { is_expected.to run.with_params({}, "key").and_return(false) }
   it { is_expected.to run.with_params({ 'key' => 'value'}, "not a key").and_return(false) }
+
+  context 'should run with UTF8 and double byte characters' do
+    it { is_expected.to run.with_params({ 'κéỳ ' => '٧ậļųể' }, "κéỳ ").and_return(true) }
+    it { is_expected.to run.with_params({ 'キー' => '٧ậļųể' }, "キー").and_return(true) }
+  end
 end

--- a/spec/functions/is_a_spec.rb
+++ b/spec/functions/is_a_spec.rb
@@ -21,5 +21,10 @@ if Puppet.version.to_f >= 4.0
     it 'fails when comparing an integer and a string' do
       is_expected.to run.with_params(5, String).and_return(false)
     end
+
+    it 'suceeds when comparing an UTF8 and double byte characters' do
+      is_expected.to run.with_params('このテキスト', String).and_return(true)
+      is_expected.to run.with_params('ŧћịś ŧêχŧ', String).and_return(true)
+    end
   end
 end

--- a/spec/functions/pick_spec.rb
+++ b/spec/functions/pick_spec.rb
@@ -9,4 +9,9 @@ describe 'pick' do
   it { is_expected.to run.with_params(:undef, 'two').and_return('two') }
   it { is_expected.to run.with_params(:undefined, 'two').and_return('two') }
   it { is_expected.to run.with_params(nil, 'two').and_return('two') }
+
+  context 'should run with UTF8 and double byte characters' do
+  it { is_expected.to run.with_params(nil, 'このテキスト').and_return('このテキスト') }
+  it { is_expected.to run.with_params('', 'ŝẳмрłề џţƒ8 ţẽ×ť', 'このテキスト').and_return('ŝẳмрłề џţƒ8 ţẽ×ť') }
+  end
 end

--- a/spec/functions/regexpescape_spec.rb
+++ b/spec/functions/regexpescape_spec.rb
@@ -32,5 +32,10 @@ describe 'regexpescape' do
     it { is_expected.to run.with_params([]).and_return([]) }
     it { is_expected.to run.with_params(['one*', "two"]).and_return(['one\*', "two"]) }
     it { is_expected.to run.with_params(['one*', 1, true, {}, "two"]).and_return(['one\*', 1, true, {}, "two"]) }
+
+    context 'should run with UTF8 and double byte characters' do
+      it { is_expected.to run.with_params(['ŏŉε*']).and_return(['ŏŉε\*']) }
+      it { is_expected.to run.with_params(['インターネット*']).and_return(['インターネット\*']) }
+    end
   end
 end

--- a/spec/functions/shell_escape_spec.rb
+++ b/spec/functions/shell_escape_spec.rb
@@ -19,4 +19,9 @@ describe 'shell_escape' do
     it { is_expected.to run.with_params('~`!@#$%^&*()_+-=[]\{}|;\':",./<>?')
            .and_return('\~\`\!@\#\$\%\^\&\*\(\)_\+-\=\[\]\\\\\{\}\|\;\\\':\",./\<\>\?') }
   end
+
+  context 'should run with UTF8 and double byte characters' do
+      it { is_expected.to run.with_params('スペー スを含むテ  キスト').and_return('\\ス\\ペ\\ー\\ \\ス\\を\\含\\む\\テ\\ \\ \\キ\\ス\\ト') }
+      it { is_expected.to run.with_params('μťƒ 8  ŧĕχť').and_return('\\μ\\ť\\ƒ\\ 8\\ \\ \\ŧ\\ĕ\\χ\\ť') }
+  end
 end

--- a/spec/functions/shell_join_spec.rb
+++ b/spec/functions/shell_join_spec.rb
@@ -15,6 +15,11 @@ describe 'shell_join' do
     it { is_expected.to run.with_params(['foo', 'bar baz']).and_return('foo bar\ baz') }
     it { is_expected.to run.with_params(['~`!@#$', '%^&*()_+-=', '[]\{}|;\':"', ',./<>?'])
                             .and_return('\~\`\!@\#\$ \%\^\&\*\(\)_\+-\= \[\]\\\\\{\}\|\;\\\':\" ,./\<\>\?') }
+
+  context 'should run with UTF8 and double byte characters' do
+      it { is_expected.to run.with_params(['μťƒ', '8',  'ŧĕχť']).and_return('\\μ\\ť\\ƒ 8 \\ŧ\\ĕ\\χ\\ť') }
+      it { is_expected.to run.with_params(['スペー', 'スを含むテ', ' キスト']).and_return('\\ス\\ペ\\ー \\ス\\を\\含\\む\\テ \\ \\キ\\ス\\ト') }
+    end
   end
 
   describe 'stringification' do

--- a/spec/functions/shell_split_spec.rb
+++ b/spec/functions/shell_split_spec.rb
@@ -20,5 +20,10 @@ describe 'shell_split' do
          .and_return(['~`!@#$%^&*()_+-=[]\{}|;\':",./<>?']) }
     it { is_expected.to run.with_params('\~\`\!@\#\$ \%\^\&\*\(\)_\+-\= \[\]\\\\\{\}\|\;\\\':\" ,./\<\>\?')
          .and_return(['~`!@#$', '%^&*()_+-=', '[]\{}|;\':"', ',./<>?']) }
+
+     context 'should run with UTF8 and double byte characters' do
+        it { is_expected.to run.with_params('\\μ\\ť\\ƒ 8 \\ŧ\\ĕ\\χ\\ť').and_return(['μťƒ', '8',  'ŧĕχť']) }
+        it { is_expected.to run.with_params('\\ス\\ペ\\ー \\ス\\を\\含\\む\\テ \\ \\キ\\ス\\ト').and_return(['スペー', 'スを含むテ', ' キスト']) }
+    end
   end
 end

--- a/spec/functions/shuffle_spec.rb
+++ b/spec/functions/shuffle_spec.rb
@@ -26,6 +26,11 @@ describe 'shuffle' do
     it { is_expected.to run.with_params('abc').and_return('bac') }
     it { is_expected.to run.with_params('abcd').and_return('dcba') }
 
+    context 'should run with UTF8 and double byte characters' do
+      it { is_expected.to run.with_params('ůţƒ8 ŧέχŧ şŧґíńģ').and_return('ģńş ůχţέƒŧí8ґŧŧ ') }
+      it { is_expected.to run.with_params('日本語の文字列').and_return('字本日語文列の') }
+    end
+
     context 'when using a class extending String' do
       it { is_expected.to run.with_params(AlsoString.new('asdfghjkl')).and_return('lkhdsfajg') }
     end

--- a/spec/functions/values_at_spec.rb
+++ b/spec/functions/values_at_spec.rb
@@ -30,6 +30,11 @@ describe 'values_at' do
     it { is_expected.to run.with_params([0, 1, 2], 3).and_raise_error(Puppet::ParseError, /index exceeds array size/) }
   end
 
+  context 'when requesting a single item using UTF8 and double byte characters' do
+    it { is_expected.to run.with_params(['ẩ', 'β', 'с', 'ď'], 0).and_return(['ẩ']) }
+    it { is_expected.to run.with_params(['文', '字', 'の', '値'], 2).and_return(['の']) }
+  end
+
   context 'when requesting multiple items' do
     it { is_expected.to run.with_params([0, 1, 2], [1, -1]).and_raise_error(Puppet::ParseError, /Unknown format of given index/) }
     it { is_expected.to run.with_params([0, 1, 2], [0, 2]).and_return([0, 2]) }

--- a/spec/functions/values_spec.rb
+++ b/spec/functions/values_spec.rb
@@ -16,4 +16,9 @@ describe 'values' do
     result = subject.call([{ 'key1' => 'value1', 'key2' => 'value2', 'duplicate_value_key' => 'value2' }])
     expect(result).to match_array(['value1', 'value2', 'value2'])
   end
+
+  it 'should run with UTF8 and double byte characters' do
+    result = subject.call([{ 'かぎ' => '使用', 'ҝĕұ' => '√ẩŀứệ', 'ҝĕұďŭрļǐçằťè' => '√ẩŀứệ' }])
+    expect(result).to match_array(['使用', '√ẩŀứệ', '√ẩŀứệ'])
+  end
 end

--- a/spec/functions/zip_spec.rb
+++ b/spec/functions/zip_spec.rb
@@ -12,4 +12,10 @@ describe 'zip' do
   it { is_expected.to run.with_params([1,2,3], [4,5,6]).and_return([[1,4], [2,5], [3,6]]) }
   it { is_expected.to run.with_params([1,2,3], [4,5,6], false).and_return([[1,4], [2,5], [3,6]]) }
   it { is_expected.to run.with_params([1,2,3], [4,5,6], true).and_return([1, 4, 2, 5, 3, 6]) }
+
+  context 'should run with UTF8 and double byte characters' do
+   it { is_expected.to run.with_params(['ầ', 'ь', 'ć'], ['đ', 'ề', 'ƒ']).and_return([['ầ','đ'], ['ь','ề'], ['ć', 'ƒ']]) }
+   it { is_expected.to run.with_params(['ペ', '含', '値'], ['ッ', '文', 'イ']).and_return([['ペ','ッ'], ['含','文'], ['値', 'イ']]) }
+  end
 end
+


### PR DESCRIPTION
This contains unit tests for to check for UTF8 and double byte character compatibility for the medium effort functions.

Tests for the following functions are included:

1. - basename
2. - chop
3. - chomp
4. - deep_merge
5. - dirname
6. - getvar
7. - has_key
8. - is_a
9. - pick
10. - assert_private
11. - shell_escape
12. - shell_join
13. - shell_split
14. - shuffle
15. - values
16. - values_at
17. - zip