### PR TITLE
loosen the regex for tuple checking

### DIFF
--- a/spec/acceptance/type_spec.rb
+++ b/spec/acceptance/type_spec.rb
@@ -12,7 +12,7 @@ describe 'type function' do
       EOS
 
       apply_manifest(pp, :catch_failures => true) do |r|
-        expect(r.stdout).to match(/type is Tuple\[String, String, String, String\]/)
+        expect(r.stdout).to match(/type is Tuple\[String.*, String.*, String.*, String.*\]/)
       end
     end
     it 'types strings' do


### PR DESCRIPTION
now handles type is Tuple[String[3, 3], String[6, 6], String[3, 3], String[9, 9]] and Tuple[String, String, String, String]