### PR TITLE
Should only try to apply the resource if it not defined

### DIFF
--- a/lib/puppet/parser/functions/ensure_packages.rb
+++ b/lib/puppet/parser/functions/ensure_packages.rb
@@ -37,7 +37,9 @@ third argument to the ensure_resource() function.
 
       Puppet::Parser::Functions.function(:ensure_resource)
       packages.each { |package_name|
+      if !findresource("Package[#{package_name}]")
         function_ensure_resource(['package', package_name, defaults ])
+      end
     }
     end
   end


### PR DESCRIPTION
As there is a number of modules that use ensure_package without wrapping a defined around them many modules have conflicts. This will help work around them by default, Puppet will not let you define a resource twice so it should be done here as well