### PR TITLE
(MODULES-4528) Use versioncmp to check Puppet version for 4.10.x compat

### DIFF
--- a/spec/aliases/absolute_path_spec.rb
+++ b/spec/aliases/absolute_path_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::absolute_path', type: :class do
     describe 'valid paths handling' do
       %w{

--- a/spec/aliases/absolutepath_spec.rb
+++ b/spec/aliases/absolutepath_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::absolutepath', type: :class do
     describe 'valid handling' do
       %w{

--- a/spec/aliases/array_spec.rb
+++ b/spec/aliases/array_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::array', type: :class do
     describe 'accepts arrays' do
       [

--- a/spec/aliases/bool_spec.rb
+++ b/spec/aliases/bool_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::bool', type: :class do
     describe 'accepts booleans' do
       [

--- a/spec/aliases/float_spec.rb
+++ b/spec/aliases/float_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::float', type: :class do
     describe 'accepts floats' do
       [

--- a/spec/aliases/hash_spec.rb
+++ b/spec/aliases/hash_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::hash', type: :class do
     describe 'accepts hashes' do
       [

--- a/spec/aliases/httpsurl_spec.rb
+++ b/spec/aliases/httpsurl_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::httpsurl', type: :class do
     describe 'valid handling' do
       %w{

--- a/spec/aliases/httpurl_spec.rb
+++ b/spec/aliases/httpurl_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::httpurl', type: :class do
     describe 'valid handling' do
       %w{

--- a/spec/aliases/integer_spec.rb
+++ b/spec/aliases/integer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::integer', type: :class do
     describe 'accepts integers' do
       [

--- a/spec/aliases/ip_address.rb
+++ b/spec/aliases/ip_address.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::ip_address', type: :class do
     describe 'accepts ipv4 and ipv6 addresses' do
       [

--- a/spec/aliases/ipv4_spec.rb
+++ b/spec/aliases/ipv4_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::ipv4', type: :class do
     describe 'accepts ipv4 addresses' do
       SharedData::IPV4_PATTERNS.each do |value|

--- a/spec/aliases/ipv6_spec.rb
+++ b/spec/aliases/ipv6_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::ipv6', type: :class do
     describe 'accepts ipv6 addresses' do
       [

--- a/spec/aliases/numeric_spec.rb
+++ b/spec/aliases/numeric_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::numeric', type: :class do
     describe 'accepts numerics' do
       [

--- a/spec/aliases/string_spec.rb
+++ b/spec/aliases/string_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::string', type: :class do
     describe 'accepts strings' do
       [

--- a/spec/aliases/unixpath_spec.rb
+++ b/spec/aliases/unixpath_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::unixpath', type: :class do
     describe 'valid handling' do
       %w{

--- a/spec/aliases/windowspath_spec.rb
+++ b/spec/aliases/windowspath_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::windowspath', type: :class do
     describe 'valid handling' do
       %w{

--- a/spec/functions/deprecation_spec.rb
+++ b/spec/functions/deprecation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'deprecation' do
     before(:each) {
       # this is to reset the strict variable to default

--- a/spec/functions/ensure_resource_spec.rb
+++ b/spec/functions/ensure_resource_spec.rb
@@ -4,7 +4,7 @@ describe 'ensure_resource' do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params().and_raise_error(ArgumentError, /Must specify a type/) }
   it { is_expected.to run.with_params('type').and_raise_error(ArgumentError, /Must specify a title/) }
-  if Puppet.version.to_f >= 4.6
+  if Puppet::Util::Package.versioncmp(Puppet.version, '4.6.0') >= 0
     it { is_expected.to run.with_params('type', 'title', {}, 'extras').and_raise_error(ArgumentError) }
   else
     it { is_expected.to run.with_params('type', 'title', {}, 'extras').and_raise_error(Puppet::ParseError) }

--- a/spec/functions/validate_legacy_spec.rb
+++ b/spec/functions/validate_legacy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.4
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0
   describe 'validate_legacy' do
     it { is_expected.not_to eq(nil) }
     it { is_expected.to run.with_params.and_raise_error(ArgumentError) }


### PR DESCRIPTION
`Puppet.version.to_f` on Puppet 4.10.0 will evaluate to `4.1`, causing
test and behavioural changes when conditionals check that the version is
equal or greater than versions such as `4.3`.

Version comparisons that are vulnerable to this have been changed to use
Puppet's versioncmp implementation, while most others only check for
for major version boundaries which is safe.