### PR TITLE
(MODULES-6051) Add UTF-8 support to capitalize

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
 gem 'facter', *location_for(ENV['FACTER_GEM_VERSION']) if ENV['FACTER_GEM_VERSION']
 gem 'hiera', *location_for(ENV['HIERA_GEM_VERSION']) if ENV['HIERA_GEM_VERSION']
 
+gem 'unicode'
 
 # Evaluate Gemfile.local if it exists
 if File.exists? "#{__FILE__}.local"

--- a/lib/puppet/parser/functions/capitalize.rb
+++ b/lib/puppet/parser/functions/capitalize.rb
@@ -1,3 +1,4 @@
+require 'unicode'
 #
 #  capitalize.rb
 #
@@ -21,9 +22,9 @@ module Puppet::Parser::Functions
 
     if value.is_a?(Array)
       # Numbers in Puppet are often string-encoded which is troublesome ...
-      result = value.collect { |i| i.is_a?(String) ? i.capitalize : i }
+      result = value.collect { |i| i.is_a?(String) ? Unicode::capitalize(i) : i }
     else
-      result = value.capitalize
+      result = Unicode::capitalize(value)
     end
 
     return result

--- a/spec/functions/capitalize_spec.rb
+++ b/spec/functions/capitalize_spec.rb
@@ -7,9 +7,13 @@ describe 'capitalize' do
   it { is_expected.to run.with_params("one").and_return("One") }
   it { is_expected.to run.with_params("one two").and_return("One two") }
   it { is_expected.to run.with_params("ONE TWO").and_return("One two") }
+  it { is_expected.to run.with_params("čǻρίţāŀіşè").and_return("Čǻρίţāŀіşè") }
+  it { is_expected.to run.with_params("čǻρίţāŀіşè ŧĥĩš").and_return("Čǻρίţāŀіşè ŧĥĩš") }
+  it { is_expected.to run.with_params("こねこ").and_return("こねこ") }
 
   it { is_expected.to run.with_params(AlsoString.new("one")).and_return("One") }
   it { is_expected.to run.with_params([]).and_return([]) }
   it { is_expected.to run.with_params(["one", "two"]).and_return(["One", "Two"]) }
+  it { is_expected.to run.with_params(["čǻρίţāŀіşè", "ŧĥĩš"]).and_return(["Čǻρίţāŀіşè", "Ŧĥĩš"]) }
   it { is_expected.to run.with_params(["one", 1, "two"]).and_return(["One", 1, "Two"]) }
 end


### PR DESCRIPTION
Prior to this commit, the capitalize function did not support
UTF-8 characters. Now it has been updated using the Ruby Unicode
library so that it properly parses and capitalizes strings containing
UTF-8 characters.