### PR TITLE
(FM-6051) Adds comments to warn for UTF8 incompatibility

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -209,6 +209,8 @@ Converts a string to and from base64 encoding. Requires an `action` ('encode', '
 
 For backward compatibility, `method` will be set as `default` if not specified.
 
+*Please note:* This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
+
 *Examples:*
 ~~~
 base64('encode', 'hello')
@@ -263,9 +265,17 @@ bool2str(false, 't', 'f')         => 'f'
 
 Requires a single boolean as input. *Type*: rvalue.
 
+#### `camelcase`
+
+Converts the case of a string or all strings in an array to camel case. *Type*: rvalue.
+
+*Please note:* This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
+
 #### `capitalize`
 
 Capitalizes the first character of a string or array of strings and lowercases the remaining characters of each string. Requires either a single string or an array as an input. *Type*: rvalue.
+
+*Please note:* This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 
 #### `ceiling`
 
@@ -348,6 +358,8 @@ Deletes a determined indexed value from an array. For example, `delete_at(['a','
 #### `delete_regex`
 
 Deletes all instances of a given element from an array or hash that match a provided regular expression. A string will be treated as a one-item array.
+
+*Please note:* This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 
 For example, `delete_regex(['a','b','c','b'], 'b')` returns ['a','c']; `delete_regex({'a' => 1,'b' => 2,'c' => 3},['b','c'])` returns {'a'=> 1}, `delete_regex(['abf', 'ab', 'ac'], '^ab.*')` returns ['ac']. `delete_regex(['ab', 'b'], 'b')` returns ['ab'].
 
@@ -476,6 +488,8 @@ See also [unix2dos](#unix2dos).
 #### `downcase`
 
 Converts the case of a string or of all strings in an array to lowercase. *Type*: rvalue.
+
+*Please note:* This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 
 #### `empty`
 
@@ -1014,6 +1028,8 @@ The third argument to this function is the salt to use.
 
 *Type*: rvalue.
 
+**Please note:** This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
+
 **Note:** this uses the Puppet master's implementation of crypt(3). If your environment contains several different operating systems, ensure that they are compatible before using this function.
 
 #### `range`
@@ -1093,6 +1109,8 @@ Returns the number of elements in a string, an array or a hash. May get confused
 
 Sorts strings and arrays lexically. *Type*: rvalue.
 
+*Please note:* This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
+
 #### `squeeze`
 
 Returns a new string where runs of the same character that occur in this set are replaced by a single character. *Type*: rvalue.
@@ -1106,9 +1124,13 @@ Converts certain strings to a boolean. This attempts to convert strings that con
 Converts a string to a salted-SHA512 password hash, used for OS X versions >= 10.7. Given any string, this function returns a hex version of a salted-SHA512 password hash, which can be inserted into your Puppet
 manifests as a valid password attribute. *Type*: rvalue.
 
+*Please note:* This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
+
 #### `strftime`
 
 Returns formatted time. For example, `strftime("%s")` returns the time since Unix epoch, and `strftime("%Y-%m-%d")` returns the date. *Type*: rvalue.
+
+*Please note:* This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 
   *Format:*
 
@@ -1174,6 +1196,8 @@ For example:
 #### `swapcase`
 
 Swaps the existing case of a string. For example, `swapcase("aBcD")` results in "AbCd". *Type*: rvalue.
+
+*Please note:* This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 
 #### `time`
 
@@ -1262,9 +1286,13 @@ See also [dos2unix](#dos2unix).
 
 Converts an object, array or hash of objects that respond to upcase to uppercase. For example, `upcase('abcd')` returns 'ABCD'. *Type*: rvalue.
 
+*Please note:* This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
+
 #### `uriescape`
 
 URLEncodes a string or array of strings. Requires either a single string or an array as an input. *Type*: rvalue.
+
+*Please note:* This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 
 #### `validate_absolute_path`
 

--- a/lib/puppet/parser/functions/base64.rb
+++ b/lib/puppet/parser/functions/base64.rb
@@ -1,3 +1,6 @@
+
+#  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
+
 module Puppet::Parser::Functions
 
   newfunction(:base64, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|

--- a/lib/puppet/parser/functions/camelcase.rb
+++ b/lib/puppet/parser/functions/camelcase.rb
@@ -1,5 +1,6 @@
 #
 #  camelcase.rb
+#  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 
 module Puppet::Parser::Functions

--- a/lib/puppet/parser/functions/capitalize.rb
+++ b/lib/puppet/parser/functions/capitalize.rb
@@ -1,5 +1,6 @@
 #
 #  capitalize.rb
+#  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 
 module Puppet::Parser::Functions
@@ -27,5 +28,3 @@ module Puppet::Parser::Functions
     return result
   end
 end
-
-# vim: set ts=2 sw=2 et :

--- a/lib/puppet/parser/functions/delete_regex.rb
+++ b/lib/puppet/parser/functions/delete_regex.rb
@@ -1,5 +1,6 @@
 #
-# delete_regex.rb
+#  delete_regex.rb
+#  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 
 module Puppet::Parser::Functions

--- a/lib/puppet/parser/functions/downcase.rb
+++ b/lib/puppet/parser/functions/downcase.rb
@@ -1,5 +1,6 @@
 #
 #  downcase.rb
+#  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 
 module Puppet::Parser::Functions

--- a/lib/puppet/parser/functions/pw_hash.rb
+++ b/lib/puppet/parser/functions/pw_hash.rb
@@ -1,3 +1,6 @@
+
+#  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
+
 Puppet::Parser::Functions::newfunction(
   :pw_hash,
   :type => :rvalue,

--- a/lib/puppet/parser/functions/sort.rb
+++ b/lib/puppet/parser/functions/sort.rb
@@ -1,5 +1,6 @@
 #
-# sort.rb
+#  sort.rb
+#  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 
 module Puppet::Parser::Functions

--- a/lib/puppet/parser/functions/str2saltedsha512.rb
+++ b/lib/puppet/parser/functions/str2saltedsha512.rb
@@ -1,5 +1,6 @@
 #
-# str2saltedsha512.rb
+#  str2saltedsha512.rb
+#  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 
 module Puppet::Parser::Functions

--- a/lib/puppet/parser/functions/strftime.rb
+++ b/lib/puppet/parser/functions/strftime.rb
@@ -1,5 +1,6 @@
 #
-# strftime.rb
+#  strftime.rb
+#  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 
 module Puppet::Parser::Functions

--- a/lib/puppet/parser/functions/swapcase.rb
+++ b/lib/puppet/parser/functions/swapcase.rb
@@ -1,5 +1,6 @@
 #
 #  swapcase.rb
+#  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 
 module Puppet::Parser::Functions

--- a/lib/puppet/parser/functions/upcase.rb
+++ b/lib/puppet/parser/functions/upcase.rb
@@ -1,5 +1,6 @@
 #
-# upcase.rb
+#  upcase.rb
+#  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 
 module Puppet::Parser::Functions

--- a/lib/puppet/parser/functions/uriescape.rb
+++ b/lib/puppet/parser/functions/uriescape.rb
@@ -1,5 +1,6 @@
 #
 #  uriescape.rb
+#  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 require 'uri'
 


### PR DESCRIPTION
Add comments detailing which functions may not be fully UTF8 compatible. Also adds the camelcase readme entry. 