### PR TITLE
Update alias spec error message expectation for PUP-7371

### DIFF
--- a/spec/aliases/string_spec.rb
+++ b/spec/aliases/string_spec.rb
@@ -24,7 +24,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
       ].each do |value|
         describe value.inspect do
           let(:params) {{ value: value }}
-          it { is_expected.to compile.and_raise_error(/parameter 'value' expects a String/) }
+          it { is_expected.to compile.and_raise_error(/parameter 'value' expects a (?:value of type Undef or )?String/) }
         end
       end
     end


### PR DESCRIPTION
The fix for PUP-7371 adds the missing `Undef` into the error message
being tested in type aliases specs, fixing the following failure against
Puppet's master branch:

    test::string rejects other values [] should fail to compile and raise an error matching /parameter 'value' expects a String/
    Failure/Error: it { is_expected.to compile.and_raise_error(/parameter 'value' expects a String/) }
      error during compilation: Evaluation Error: Error while evaluating a Resource Statement, Class[Test::String]: parameter 'value' expects a value of type Undef or String, got Array at line 2:1 on node example
    # ./spec/aliases/string_spec.rb:27:in `block (5 levels) in <top (required)>'