### PR TITLE
Fix placement of chaining arrow for style guide/linting

### DIFF
--- a/examples/file_line.pp
+++ b/examples/file_line.pp
@@ -2,8 +2,8 @@
 # of the file_line resource type.
 file { '/tmp/dansfile':
   ensure => file,
-} ->
-file_line { 'dans_line':
+}
+-> file_line { 'dans_line':
   line => 'dan is awesome',
   path => '/tmp/dansfile',
 }


### PR DESCRIPTION
Corrects lint warning under puppet-lint 2.2.0:

    WARNING: arrow should be on the right operand's line on line 5