### PR TITLE
(PE-20308) Pass a literal type and not a string to findresource

### DIFF
--- a/lib/puppet/parser/functions/defined_with_params.rb
+++ b/lib/puppet/parser/functions/defined_with_params.rb
@@ -24,7 +24,25 @@ ENDOFDOC
     params = {}
   end
   ret = false
-  if resource = findresource(reference.to_s)
+
+  if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
+    # Workaround for PE-20308
+    if reference.is_a?(String)
+      type_name, title = Puppet::Resource.type_and_title(reference, nil)
+      type = Puppet::Type.type(type_name)
+    elsif reference.is_a?(Puppet::Resource)
+      type = reference.resource_type
+      title = reference.title
+    else
+      raise(ArgumentError, "Reference is not understood: '#{reference.class}'")
+    end
+    #end workaround
+  else
+    type = reference.to_s
+    title = nil
+  end
+
+  if resource = findresource(type, title)
     matches = params.collect do |key, value|
       # eql? avoids bugs caused by monkeypatching in puppet
       resource_is_undef = resource[key].eql?(:undef) || resource[key].nil?

--- a/spec/functions/defined_with_params_spec.rb
+++ b/spec/functions/defined_with_params_spec.rb
@@ -37,4 +37,22 @@ describe 'defined_with_params' do
     it { is_expected.to run.with_params('File[/tmp/a]', {}).and_return(true) }
     it { is_expected.to run.with_params('File[/tmp/a]', { 'ensure' => 'present', 'owner' => :undef }).and_return(true) }
   end
+
+  describe 'when the reference is a' do
+    let :pre_condition do
+      'user { "dan": }'
+    end
+    context 'reference' do
+      it { is_expected.to run.with_params(Puppet::Resource.new('User[dan]'), {}).and_return(true) }
+    end
+    if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
+      context 'array' do
+        it 'fails' do
+          expect {
+            subject.call([['User[dan]'], {}])
+          }.to raise_error ArgumentError, /not understood: 'Array'/
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
- `defined_with_params` calls `findresource(reference.to_s)`
- `findresource` is
  https://github.com/puppetlabs/puppet/blob/4.8.1/lib/puppet/parser/compiler.rb#L407
  and points to
  https://github.com/puppetlabs/puppet/blob/4.8.1/lib/puppet/resource/catalog.rb#L352
- This calls `Puppet::Resource.new` with the type
  https://github.com/puppetlabs/puppet/blob/4.8.1/lib/puppet/resource/catalog.rb#L366
- This ends up calling `resource_type` via
  https://github.com/puppetlabs/puppet/blob/4.8.1/lib/puppet/resource.rb#L317-L319
  and that ends up declaring the type via the autoloader api at
  https://github.com/puppetlabs/puppet/blob/4.8.1/lib/puppet/resource.rb#L390
- But why does the autoloader API fail to find it in the current
  environment?
- Okay, so when the autoloader is trying to find the type, it uses the
  typeloader to look it up in the current environment
  https://github.com/puppetlabs/puppet/blob/4.8.1/lib/puppet/metatype/manager.rb#L171
- this calls `get_file` and `mark_loaded`
  https://github.com/puppetlabs/puppet/blob/4.8.1/lib/puppet/util/autoload.rb#L64-L67

Suggested workaround is to pass a literal type instead of a string to
`findresource` to fix in stdlib, and also to fix loading/requiring of
type in core puppet.