### PR TITLE
Fix issue where the following causes obscure catalog compilation errors:

### DIFF
--- a/lib/puppet/parser/functions/ensure_packages.rb
+++ b/lib/puppet/parser/functions/ensure_packages.rb
@@ -36,6 +36,7 @@ third argument to the ensure_resource() function.
 
       Puppet::Parser::Functions.function(:ensure_resource)
       packages.each { |package_name|
+      raise(Puppet::ParseError, 'ensure_packages(): Empty String provided for package name') if package_name.length == 0
       if !findresource("Package[#{package_name}]")
         function_ensure_resource(['package', package_name, defaults ])
       end


### PR DESCRIPTION
```
file { '/tmp/somefile':
  ensure => 'file',
}

File['/tmp/somefile'] -> Package <| |>

ensure_packages($somearray)
```

If $somearray is undefined or one of the elements contains an empty
string, an error like the following is thrown:

Could not find resource 'Package[]' for relationship from
'File[/tmp/somefile]' on node $::fqdn