### PR TITLE
Update alias spec error message expectation for PUP-6694

### DIFF
--- a/spec/aliases/absolutepath_spec.rb
+++ b/spec/aliases/absolutepath_spec.rb
@@ -40,7 +40,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         ].each do |value|
           describe value.inspect do
             let(:params) {{ value: value }}
-            it { is_expected.to compile.and_raise_error(/parameter 'value' expects a match for Variant/) }
+            it { is_expected.to compile.and_raise_error(/parameter 'value' expects a match for (?:Stdlib::Absolutepath = )?Variant/) }
           end
         end
       end

--- a/spec/aliases/float_spec.rb
+++ b/spec/aliases/float_spec.rb
@@ -20,7 +20,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
       [ true, 'true', false, 'false', 'iAmAString', '1test', '1 test', 'test 1', 'test 1 test', {}, { 'key' => 'value' }, { 1=> 2 }, '', :undef , 'x', 3, '3', -3, '-3'].each do |value|
         describe value.inspect do
           let(:params) {{ value: value }}
-          it { is_expected.to compile.and_raise_error(/parameter 'value' expects a value of type Float or Pattern(\[.*\]+)?/) }
+          it { is_expected.to compile.and_raise_error(/parameter 'value' expects a (Stdlib::Compat::Float = Variant\[Float, Pattern|value of type Float or Pattern)(\[.*\]+)?/) }
         end
       end
     end

--- a/spec/aliases/integer_spec.rb
+++ b/spec/aliases/integer_spec.rb
@@ -20,7 +20,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
       [ true, 'true', false, 'false', 'iAmAString', '1test', '1 test', 'test 1', 'test 1 test', {}, { 'key' => 'value' }, { 1=> 2 }, '', :undef , 'x', 3.7, '3.7',-3.7, '-342.2315e-12' ].each do |value|
         describe value.inspect do
           let(:params) {{ value: value }}
-          it { is_expected.to compile.and_raise_error(/parameter 'value' expects a value of type Integer, Pattern(\[.*\]+)?, or Array/) }
+          it { is_expected.to compile.and_raise_error(/parameter 'value' expects a (Stdlib::Compat::Integer = Variant\[Integer, Pattern\[.*\]+, Array\[.*\]+\]|value of type Integer, Pattern(\[.*\]+)?, or Array)/) }
         end
       end
     end

--- a/spec/aliases/numeric_spec.rb
+++ b/spec/aliases/numeric_spec.rb
@@ -24,7 +24,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
       [ true, 'true', false, 'false', 'iAmAString', '1test', '1 test', 'test 1', 'test 1 test', {}, { 'key' => 'value' }, { 1=> 2 }, '', :undef , 'x' ].each do |value|
         describe value.inspect do
           let(:params) {{ value: value }}
-          it { is_expected.to compile.and_raise_error(/parameter 'value' expects a value of type Numeric, Pattern(\[.*\]+)?, or Array/) }
+          it { is_expected.to compile.and_raise_error(/parameter 'value' expects a (Stdlib::Compat::Numeric = Variant\[Numeric, Pattern\[.*\]+, Array\[.*\]+\]|value of type Numeric, Pattern(\[.*\]+)?, or Array)/) }
         end
       end
     end

--- a/spec/aliases/string_spec.rb
+++ b/spec/aliases/string_spec.rb
@@ -24,7 +24,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
       ].each do |value|
         describe value.inspect do
           let(:params) {{ value: value }}
-          it { is_expected.to compile.and_raise_error(/parameter 'value' expects a (?:value of type Undef or )?String/) }
+          it { is_expected.to compile.and_raise_error(/parameter 'value' expects a (?:value of type Undef or )?(?:Stdlib::Compat::String = Optional\[String\]|String)/) }
         end
       end
     end


### PR DESCRIPTION
The alias data type name is now included in the error message for data
type mismatches, since puppetlabs/puppet@aef26614. This fixes the
following class of failures against Puppet's master branch:

    1) test::float rejects other values true should fail to compile and raise an error matching /parameter 'value' expects a value of type Float or Pattern(\[.*\]+)?/
       Failure/Error: it { is_expected.to compile.and_raise_error(/parameter 'value' expects a value
         of type Float or Pattern(\[.*\]+)?/) } error during compilation: Evaluation Error: Error while evaluating a Resource Statement,
         Class[Test::Float]: parameter 'value' expects a Stdlib::Compat::Float = Variant[Float, Pattern[/^-?(?:(?:[1-9]\d*)|0)(?:\.\d+)(?:[eE]-?\d+)?$/]] value, got Boolean at line 1:1 on node [..]
       # ./spec/aliases/float_spec.rb:23:in `block (5 levels) in <top (required)>'