### PR TITLE
(MODULES-3432) Adds getvar_emptystring function

### DIFF
--- a/lib/puppet/parser/functions/getvar_emptystring.rb
+++ b/lib/puppet/parser/functions/getvar_emptystring.rb
@@ -1,0 +1,35 @@
+module Puppet::Parser::Functions
+
+  newfunction(:getvar_emptystring, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
+    Lookup a variable in a remote namespace.
+    Return an empty string rather than undef/nil if it could not be found
+
+    For example:
+
+        $foo = getvar('site::data::foo')
+        # Equivalent to $foo = $site::data::foo
+
+    This is useful if the namespace itself is stored in a string:
+
+        $datalocation = 'site::data'
+        $bar = getvar("${datalocation}::bar")
+        # Equivalent to $bar = $site::data::bar
+    ENDHEREDOC
+
+    unless args.length == 1
+      raise Puppet::ParseError, ("getvar_emptystring(): wrong number of arguments (#{args.length}; must be 1)")
+    end
+
+    begin
+      result = self.lookupvar("#{args[0]}")
+
+      result = '' if result.nil?
+
+      result
+    rescue Puppet::ParseError # Eat the exception if strict_variables = true is set and return an empty string
+      return ''
+    end
+
+  end
+
+end

--- a/spec/acceptance/getvar_emtpystring_spec.rb
+++ b/spec/acceptance/getvar_emtpystring_spec.rb
@@ -1,0 +1,31 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper_acceptance'
+
+describe 'getvar_emptystring function' do
+  describe 'success' do
+    it 'getvars from classes' do
+      pp = <<-EOS
+      class a::data { $foo = 'aoeu' }
+      include a::data
+      $b = 'aoeu'
+      $o = getvar_emptystring("a::data::foo")
+      if $o == $b {
+        notify { 'output correct': }
+      }
+      $z = getvar_emptystring("a::data::bar")
+      if $z == '' {
+        notify { 'empty string when not found': }
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true) do |r|
+        expect(r.stdout).to match(/Notice: output correct/)
+        expect(r.stdout).to match(/Notice: empty string when not found/)
+      end
+    end
+  end
+  describe 'failure' do
+    it 'handles improper argument counts'
+    it 'handles non-numbers'
+  end
+end

--- a/spec/functions/getvar_emptystring_spec.rb
+++ b/spec/functions/getvar_emptystring_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'getvar_emptystring' do
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }
+  it { is_expected.to run.with_params('one', 'two').and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }
+  it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }
+
+  it { is_expected.to run.with_params('$::foo').and_return('') }
+
+  context 'given variables in namespaces' do
+    let(:pre_condition) {
+      <<-'ENDofPUPPETcode'
+      class site::data { $foo = 'baz' }
+      include site::data
+      ENDofPUPPETcode
+    }
+
+    it { is_expected.to run.with_params('site::data::foo').and_return('baz') }
+    it { is_expected.to run.with_params('::site::data::foo').and_return('baz') }
+    it { is_expected.to run.with_params('::site::data::bar').and_return('') }
+  end
+
+  context 'given variables in namespaces' do
+    let(:pre_condition) {
+      <<-'ENDofPUPPETcode'
+      class site::info { $lock = 'ŧҺîš íš ắ śţřĭŋĝ' }
+      class site::new { $item = '万Ü€‰' }
+      include site::info
+      include site::new
+      ENDofPUPPETcode
+    }
+
+    it { is_expected.to run.with_params('site::info::lock').and_return('ŧҺîš íš ắ śţřĭŋĝ') }
+    it { is_expected.to run.with_params('::site::new::item').and_return('万Ü€‰') }
+  end
+end
+


### PR DESCRIPTION
* To be combined with pick
* Allows a degree of backwards compatibility with
pick() and getvar()
* For example:
`$redis_version_real = pick(getvar_emptystring('$::redis_server_version'), $minimum_version)`

This will work with:
* Puppet 3
* Puppet 4
* Puppet 3 with strict_variables
* Puppet 4 with strict_variables