### PR TITLE
(MODULES-5095) Workaround for PUP-7650

### DIFF
--- a/lib/puppet/parser/functions/defined_with_params.rb
+++ b/lib/puppet/parser/functions/defined_with_params.rb
@@ -29,7 +29,7 @@ ENDOFDOC
     # Workaround for PE-20308
     if reference.is_a?(String)
       type_name, title = Puppet::Resource.type_and_title(reference, nil)
-      type = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type_or_class(find_global_scope, type_name)
+      type = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type_or_class(find_global_scope, type_name.downcase)
     elsif reference.is_a?(Puppet::Resource)
       type = reference.resource_type
       title = reference.title


### PR DESCRIPTION
This commit adds a simple workaround for the problem described in
PUP-7650. The workaround is harmless and can remain in place regardless
of if the fix for PUP-7650 is in place or not.