### PR TITLE
(FACT-932) Add new function, fact()

### DIFF
--- a/lib/puppet/functions/fact.rb
+++ b/lib/puppet/functions/fact.rb
@@ -1,0 +1,58 @@
+# Digs into the facts hash using dot-notation
+#
+# Example usage:
+#
+#     fact('osfamily')
+#     fact('os.architecture')
+#
+# Array indexing:
+#
+#     fact('mountpoints."/dev".options.1')
+#
+# Fact containing a "." in the name:
+#
+#     fact('vmware."VRA.version"')
+#
+Puppet::Functions.create_function(:fact) do
+  dispatch :fact do
+    param 'String', :fact_name
+  end
+
+  def to_dot_syntax(array_path)
+    array_path.map do |string|
+      string.include?('.') ? %Q{"#{string}"} : string
+    end.join('.')
+  end
+
+  def fact(fact_name)
+    facts = closure_scope['facts']
+
+    # Transform the dot-notation string into an array of paths to walk. Make
+    # sure to correctly extract double-quoted values containing dots as single
+    # elements in the path.
+    path = fact_name.scan(/([^."]+)|(?:")([^"]+)(?:")/).map {|x| x.compact.first }
+
+    walked_path = []
+    path.reduce(facts) do |d, k|
+      return nil if d.nil? || k.nil?
+
+      case
+      when d.is_a?(Array)
+        begin
+          result = d[Integer(k)]
+        rescue ArgumentError => e
+          Puppet.warning("fact request for #{fact_name} returning nil: '#{to_dot_syntax(walked_path)}' is an array; cannot index to '#{k}'")
+          result = nil
+        end
+      when d.is_a?(Hash)
+        result = d[k]
+      else
+        Puppet.warning("fact request for #{fact_name} returning nil: '#{to_dot_syntax(walked_path)}' is not a collection; cannot walk to '#{k}'")
+        result = nil
+      end
+
+      walked_path << k
+      result
+    end
+  end
+end

--- a/lib/puppet/functions/fact.rb
+++ b/lib/puppet/functions/fact.rb
@@ -18,27 +18,22 @@ Puppet::Functions.create_function(:fact) do
     param 'String', :fact_name
   end
 
-  dispatch :alternative do
-    param 'Hash',   :fact_hash
-    param 'String', :fact_name
+  def to_dot_syntax(array_path)
+    array_path.map do |string|
+      string.include?('.') ? %Q{"#{string}"} : string
+    end.join('.')
   end
 
   def fact(fact_name)
-    dot_dig(closure_scope['facts'], fact_name)
-  end
+    facts = closure_scope['facts']
 
-  def alternative(alternative_hash, fact_name)
-    dot_dig(alternative_hash, fact_name)
-  end
-
-  def dot_dig(fact_hash, fact_name)
     # Transform the dot-notation string into an array of paths to walk. Make
     # sure to correctly extract double-quoted values containing dots as single
     # elements in the path.
     path = fact_name.scan(/([^."]+)|(?:")([^"]+)(?:")/).map {|x| x.compact.first }
 
     walked_path = []
-    path.reduce(fact_hash) do |d, k|
+    path.reduce(facts) do |d, k|
       return nil if d.nil? || k.nil?
 
       case
@@ -59,11 +54,5 @@ Puppet::Functions.create_function(:fact) do
       walked_path << k
       result
     end
-  end
-
-  def to_dot_syntax(array_path)
-    array_path.map do |string|
-      string.include?('.') ? %Q{"#{string}"} : string
-    end.join('.')
   end
 end


### PR DESCRIPTION
This PR doesn't solve for FACT-932, but is related to it and discussion
there.

The fact() function allows dot-notation reference to facts. It is an
alternative to using $facts directly with array-indexing. Array-indexing
is often onerous to use since it doesn't align with how structured facts
are accessed elsewhere in the ecosystem and if any element in a
multi-step path doesn't exist, array indexing can cause a compilation
failure.

Example usage:

    fact('os.family')