### PR TITLE
add additional aliasis

### DIFF
--- a/spec/aliases/base32_spec.rb
+++ b/spec/aliases/base32_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'test::base32', type: :class do
+    describe 'valid handling' do
+      %w(
+        ASDASDDASD3453453
+        ASDASDDASD3453453=
+        ASDASDDASD3453453==
+        ASDASDDASD3453453===
+        ASDASDDASD3453453====
+        ASDASDDASD3453453=====
+        ASDASDDASD3453453======
+        asdasddasd3453453
+        asdasddasd3453453=
+        asdasddasd3453453==
+        asdasddasd3453453===
+        asdasddasd3453453====
+        asdasddasd3453453=====
+        asdasddasd3453453======
+      ).each do |value|
+        describe value.inspect do
+          let(:params) { { value: value } }
+          it { is_expected.to compile }
+        end
+      end
+    end
+    describe 'invalid path handling' do
+      context 'garbage inputs' do
+        [
+          [nil],
+          [nil, nil],
+          { 'foo' => 'bar' },
+          {},
+          '',
+          'asdasd!@#$',
+          '=asdasd9879876876+/',
+          'asda=sd9879876876+/',
+          'asdaxsd9879876876+/===',
+          'asdads asdasd',
+          'asdasddasd3453453=======',
+          'asdaSddasd',
+          'asdasddasd1',
+          'asdasddasd9'
+        ].each do |value|
+          describe value.inspect do
+            let(:params) { { value: value } }
+            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::Base32}) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/aliases/base64_spec.rb
+++ b/spec/aliases/base64_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'test::base64', type: :class do
+    describe 'valid handling' do
+      %w(
+        asdasdASDSADA342386832/746+=
+        asdasdASDSADA34238683274/6+
+        asdasdASDSADA3423868327/46+==
+      ).each do |value|
+        describe value.inspect do
+          let(:params) { { value: value } }
+          it { is_expected.to compile }
+        end
+      end
+    end
+
+    describe 'invalid path handling' do
+      context 'garbage inputs' do
+        [
+          [nil],
+          [nil, nil],
+          { 'foo' => 'bar' },
+          {},
+          '',
+          'asdasd!@#$',
+          '=asdasd9879876876+/',
+          'asda=sd9879876876+/',
+          'asdaxsd9879876876+/===',
+          'asdads asdasd'
+        ].each do |value|
+          describe value.inspect do
+            let(:params) { { value: value } }
+            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::Base64}) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/aliases/fqdn_spec.rb
+++ b/spec/aliases/fqdn_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'test::fqdn', type: :class do
+    describe 'valid handling' do
+      %w(
+        example
+        example.com
+        www.example.com
+      ).each do |value|
+        describe value.inspect do
+          let(:params) { { value: value } }
+          it { is_expected.to compile }
+        end
+      end
+    end
+
+    describe 'invalid path handling' do
+      context 'garbage inputs' do
+        [
+          [nil],
+          [nil, nil],
+          { 'foo' => 'bar' },
+          {},
+          '',
+          'www www.example.com'
+        ].each do |value|
+          describe value.inspect do
+            let(:params) { { value: value } }
+            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::Fqdn}) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/aliases/host_spec.rb
+++ b/spec/aliases/host_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'test::host', type: :class do
+    describe 'valid handling' do
+      %w(
+        example
+        example.com
+        www.example.com
+        2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        fa76:8765:34ac:0823:ab76:eee9:0987:1111
+        2001:0db8::1
+        224.0.0.0
+        255.255.255.255
+        0.0.0.0
+        192.88.99.0
+      ).each do |value|
+        describe value.inspect do
+          let(:params) { { value: value } }
+          it { is_expected.to compile }
+        end
+      end
+    end
+
+    describe 'invalid path handling' do
+      context 'garbage inputs' do
+        [
+          [nil],
+          [nil, nil],
+          { 'foo' => 'bar' },
+          {},
+          '',
+          'www www.example.com'
+        ].each do |value|
+          describe value.inspect do
+            let(:params) { { value: value } }
+            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::Host}) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/aliases/puppetcontent.spec
+++ b/spec/aliases/puppetcontent.spec
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'test::puppetcontent', type: :class do
+    describe 'valid handling' do
+      %w{
+        usr2/username/bin
+        var/tmp
+        var///tmp
+        tea/file.erb
+      }.each do |value|
+        describe value.inspect do
+          let(:params) {{ value: value }}
+          it { is_expected.to compile }
+        end
+      end
+    end
+
+    describe 'invalid path handling' do
+      context 'garbage inputs' do
+        [
+          nil,
+          [ nil ],
+          [ nil, nil ],
+          { 'foo' => 'bar' },
+          { },
+          '',
+          "C:/whatever",
+          "\\var\\tmp",
+          "\\Users/hc/wksp/stdlib",
+          "*/Users//nope"
+          "/Users//nope"
+          "/Users/nope"
+        ].each do |value|
+          describe value.inspect do
+            let(:params) {{ value: value }}
+            it { is_expected.to compile.and_raise_error(/parameter 'value' expects a match for Stdlib::Puppetcontent/) }
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/aliases/puppetsource_spec.rb
+++ b/spec/aliases/puppetsource_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'test::puppetsource', type: :class do
+    describe 'valid handling' do
+      %w(
+        https://hello.com
+        https://notcreative.org
+        https://canstillaccepthttps.co.uk
+        http://anhttp.com
+        http://runningoutofideas.gov
+        file:///hello/bla
+        file:///foo/bar.log
+        /usr2/username/bin:/usr/local/bin:/usr/bin:.
+        C:/
+        C:\\
+        C:\\WINDOWS\\System32
+        C:/windows/system32
+        X:/foo/bar
+        X:\\foo\\bar
+        \\\\host\\windows
+        //host/windows
+        /var/tmp
+        /var/opt/../lib/puppet
+      ).each do |value|
+        describe value.inspect do
+          let(:params) { { value: value } }
+          it { is_expected.to compile }
+        end
+      end
+    end
+
+    describe 'invalid path handling' do
+      context 'garbage inputs' do
+        [
+          nil,
+          [nil],
+          [nil, nil],
+          { 'foo' => 'bar' },
+          {},
+          '',
+          '*/Users//nope',
+          '\\Users/hc/wksp/stdlib',
+          'C:noslashes',
+          '\\var\\tmp'
+        ].each do |value|
+          describe value.inspect do
+            let(:params) { { value: value } }
+            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::Puppetsource}) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/aliases/puppeturi_spec.rb
+++ b/spec/aliases/puppeturi_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'test::puppeturi', type: :class do
+    describe 'valid handling' do
+      %w(
+        puppet:///modules/hello/bla
+        puppet:///modules/foo/bar.log
+      ).each do |value|
+        describe value.inspect do
+          let(:params) { { value: value } }
+          it { is_expected.to compile }
+        end
+      end
+    end
+
+    describe 'invalid path handling' do
+      context 'garbage inputs' do
+        [
+          nil,
+          [nil],
+          [nil, nil],
+          { 'foo' => 'bar' },
+          {},
+          '',
+          'puppe:///modules/notquiteright.org',
+          'puppets:///modules/nah',
+          'puppet://modules/nah',
+          'puppet:/modules/nah',
+          'puppet:///hello/bla',
+          '/file/test',
+          'https//notrightbutclose.org'
+        ].each do |value|
+          describe value.inspect do
+            let(:params) { { value: value } }
+            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::Puppeturi}) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/test/manifests/base32.pp
+++ b/spec/fixtures/test/manifests/base32.pp
@@ -1,0 +1,6 @@
+# Class to test the Stdlib::HTTPUrl type alias
+class test::base32 (
+    Stdlib::Base32 $value,
+    ) {
+  notice('Success')
+}

--- a/spec/fixtures/test/manifests/base64.pp
+++ b/spec/fixtures/test/manifests/base64.pp
@@ -1,0 +1,6 @@
+# Class to test the Stdlib::HTTPUrl type alias
+class test::base64 (
+    Stdlib::Base64 $value,
+    ) {
+  notice('Success')
+}

--- a/spec/fixtures/test/manifests/fileuri.pp
+++ b/spec/fixtures/test/manifests/fileuri.pp
@@ -1,0 +1,6 @@
+# Class to test the Stdlib::HTTPUrl type alias
+class test::fileuri (
+    Stdlib::Fileuri $value,
+    ) {
+  notice('Success')
+}

--- a/spec/fixtures/test/manifests/fqdn.pp
+++ b/spec/fixtures/test/manifests/fqdn.pp
@@ -1,0 +1,6 @@
+# Class to test the Stdlib::HTTPUrl type alias
+class test::fqdn (
+    Stdlib::Fqdn  $value,
+    ) {
+  notice('Success')
+}

--- a/spec/fixtures/test/manifests/host.pp
+++ b/spec/fixtures/test/manifests/host.pp
@@ -1,0 +1,6 @@
+# Class to test the Stdlib::Host type alias
+class test::host (
+    Stdlib::Host  $value,
+    ) {
+  notice('Success')
+}

--- a/spec/fixtures/test/manifests/puppetcontent.pp
+++ b/spec/fixtures/test/manifests/puppetcontent.pp
@@ -1,0 +1,6 @@
+# Class to test the Stdlib::Puppeturi type alias
+class test::puppetcontent (
+    Stdlib::Puppetcontent $value,
+    ) {
+  notice('Success')
+}

--- a/spec/fixtures/test/manifests/puppetsource.pp
+++ b/spec/fixtures/test/manifests/puppetsource.pp
@@ -1,0 +1,6 @@
+# Class to test the Stdlib::Puppeturi type alias
+class test::puppetsource (
+    Stdlib::Puppetsource $value,
+    ) {
+  notice('Success')
+}

--- a/spec/fixtures/test/manifests/puppeturi.pp
+++ b/spec/fixtures/test/manifests/puppeturi.pp
@@ -1,0 +1,6 @@
+# Class to test the Stdlib::Puppeturi type alias
+class test::puppeturi (
+    Stdlib::Puppeturi $value,
+    ) {
+  notice('Success')
+}

--- a/types/base32.pp
+++ b/types/base32.pp
@@ -1,0 +1,2 @@
+# Type to match base32 String
+type Stdlib::Base32 = Pattern[/^[a-z2-7]+={,6}$/, /^[A-Z2-7]+={,6}$/]

--- a/types/base64.pp
+++ b/types/base64.pp
@@ -1,0 +1,2 @@
+# Type to match base64 String
+type Stdlib::Base64 = Pattern[/^[a-zA-Z0-9\/\+]+={,2}$/]

--- a/types/fileuri.pp
+++ b/types/fileuri.pp
@@ -1,0 +1,2 @@
+#Type to match URIs
+type Stdlib::Fileuri = Pattern[/^file:\/\/\/([^\/\0]+(\/)?)+/]

--- a/types/fqdn.pp
+++ b/types/fqdn.pp
@@ -1,0 +1,1 @@
+type Stdlib::Fqdn = Pattern[/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/]

--- a/types/host.pp
+++ b/types/host.pp
@@ -1,0 +1,1 @@
+type Stdlib::Host = Variant[Stdlib::Fqdn, Stdlib::Compat::Ip_address]

--- a/types/port.pp
+++ b/types/port.pp
@@ -1,0 +1,1 @@
+type Stdlib::Port = Integer[0, 65535]

--- a/types/privilegedport.pp
+++ b/types/privilegedport.pp
@@ -1,0 +1,1 @@
+type Stdlib::Privilegedport = Integer[1, 1023]

--- a/types/puppetcontent.pp
+++ b/types/puppetcontent.pp
@@ -1,0 +1,2 @@
+# this regex rejects any path component that is a / or a NUL
+type Stdlib::Puppetcontent = Pattern[/^([^\/\0]+(\/)?)+$/]

--- a/types/puppetsource.pp
+++ b/types/puppetsource.pp
@@ -1,0 +1,2 @@
+# Validate the source parameter on file opjects
+type Stdlib::Puppetsource = Variant[Stdlib::Absolutepath, Stdlib::HTTPUrl, Stdlib::Fileuri, Stdlib::Puppeturi]

--- a/types/puppeturi.pp
+++ b/types/puppeturi.pp
@@ -1,0 +1,2 @@
+#Type to match URIs
+type Stdlib::Puppeturi = Pattern[/^puppet:\/\/\/modules\/([^\/\0]+(\/)?)+/]

--- a/types/unprivilegedport.pp
+++ b/types/unprivilegedport.pp
@@ -1,0 +1,1 @@
+type Stdlib::Unprivilegedport = Integer[1024, 65535]


### PR DESCRIPTION
Add additional types to standard lib for 

* `Stdlib::Port`: all valid TCP/UDP ports
* `Stdlib::Privilegedport`:  ports which need root power to bind
* `Stdlib::Unprivilegedport`:  ports which do not need root power
* `Stdlib::Fileuri`: match file:///path/to/file
* `Stdlib::Puppeturi`: match puppet:///modules/path/to/file
* `Stdlib::Puppetsource`: matches values that can be used for a file type source parameter
* `Stdlib::Puppetcontent`: matches values that can be used for a file type content parameter
* `Stdlib::Base64`: matches base64 strings
* `Stdlib::Base32`: matches base64 strings
* `Stdlib::Fqdn`: loose check for a fully qualified domain name 
* `Stdlib::Host`: fqdn or ip address

i think the port types originally came from voxpupuli/puppet-tea so can remove them if desired.  it seems i [icann-dns/puppet-tea] and voxpupuli/puppet-tea have also implemented some syslog types would you be intrested in adding them or a variation their of?  

I would also be keen to move the IP and other compat functions to the Stdlib level.  i.e. `Stdlib::Ip_address` instead of `Stdlib::Compat::Ip_address` .  just simply because the latter is getting on the large side.  would be happy to to the work just wondered if there is philosophical objections to doing something like

```puppet
type Stdlib::Ip_address = Stdlib::Compat::Ip_address
```