### PR TITLE
(maint) revert puppet version requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -101,7 +101,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">=2.7.20 < 6.0.0"
     }
   ],
   "description": "Standard Library for Puppet Modules",


### PR DESCRIPTION
puppet version requirement lower bound was accidentally moved to 4.7.0 without a major bump. this returns the lower bound to 2.7 but also pushes the upper bound to include puppet 5.