### PR TITLE
Added to_json, to_json_pretty, and to_yaml functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1754,6 +1754,30 @@ Arguments: A single string.
 
 *Type*: rvalue.
 
+#### `to_json`
+
+Converts input into a JSON String.
+
+For example, `{ "key" => "value" }` becomes `{"key":"value"}`.
+
+*Type*: rvalue.
+
+#### `to_json_pretty`
+
+Converts input into a pretty JSON String.
+
+For example, `{ "key" => "value" }` becomes `{\n  \"key\": \"value\"\n}`.
+
+*Type*: rvalue.
+
+#### `to_yaml`
+
+Converts input into a YAML String.
+
+For example, `{ "key" => "value" }` becomes `"---\nkey: value\n"`.
+
+*Type*: rvalue.
+
 #### `try_get_value`
 
 **DEPRECATED:** replaced by `dig()`.

--- a/lib/puppet/functions/to_json.rb
+++ b/lib/puppet/functions/to_json.rb
@@ -1,0 +1,21 @@
+# Take a data structure and output it as JSON
+#
+# @example how to output JSON
+#   # output json to a file
+#     file { '/tmp/my.json':
+#       ensure  => file,
+#       content => to_json($myhash),
+#     }
+#
+#
+require 'json'
+
+Puppet::Functions.create_function(:to_json) do
+  dispatch :to_json do
+    param 'Any', :data
+  end
+
+  def to_json(data)
+    data.to_json
+  end
+end

--- a/lib/puppet/functions/to_json_pretty.rb
+++ b/lib/puppet/functions/to_json_pretty.rb
@@ -1,0 +1,21 @@
+# Take a data structure and output it as pretty JSON
+#
+# @example how to output pretty JSON
+#   # output pretty json to a file
+#     file { '/tmp/my.json':
+#       ensure  => file,
+#       content => to_json_pretty($myhash),
+#     }
+#
+#
+require 'json'
+
+Puppet::Functions.create_function(:to_json_pretty) do
+  dispatch :to_json_pretty do
+    param 'Variant[Hash, Array]', :data
+  end
+
+  def to_json_pretty(data)
+    JSON.pretty_generate(data)
+  end
+end

--- a/lib/puppet/functions/to_yaml.rb
+++ b/lib/puppet/functions/to_yaml.rb
@@ -1,0 +1,21 @@
+# Take a data structure and output it as YAML
+#
+# @example how to output YAML
+#   # output yaml to a file
+#     file { '/tmp/my.yaml':
+#       ensure  => file,
+#       content => to_yaml($myhash),
+#     }
+#
+#
+require 'yaml'
+
+Puppet::Functions.create_function(:to_yaml) do
+  dispatch :to_yaml do
+    param 'Any', :data
+  end
+
+  def to_yaml(data)
+    data.to_yaml
+  end
+end

--- a/spec/functions/to_json_pretty_spec.rb
+++ b/spec/functions/to_json_pretty_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'to_json_pretty' do
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params([]).and_return("[\n\n]") }
+  it { is_expected.to run.with_params(['one']).and_return("[\n  \"one\"\n]") }
+  it { is_expected.to run.with_params(['one', 'two']).and_return("[\n  \"one\",\n  \"two\"\n]") }
+  it { is_expected.to run.with_params({}).and_return("{\n}") }
+  it { is_expected.to run.with_params({ 'key' => 'value' }).and_return("{\n  \"key\": \"value\"\n}") }
+  it { is_expected.to run.with_params({"one" => {"oneA" => "A","oneB" => {"oneB1" => "1","oneB2" => "2"}},"two" => ["twoA","twoB"]}).and_return("{\n  \"one\": {\n    \"oneA\": \"A\",\n    \"oneB\": {\n      \"oneB1\": \"1\",\n      \"oneB2\": \"2\"\n    }\n  },\n  \"two\": [\n    \"twoA\",\n    \"twoB\"\n  ]\n}") }
+end

--- a/spec/functions/to_json_spec.rb
+++ b/spec/functions/to_json_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'to_json' do
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params('').and_return("\"\"") }
+  it { is_expected.to run.with_params(true).and_return("true") }
+  it { is_expected.to run.with_params('one').and_return("\"one\"") }
+  it { is_expected.to run.with_params([]).and_return("[]") }
+  it { is_expected.to run.with_params(['one']).and_return("[\"one\"]") }
+  it { is_expected.to run.with_params(['one', 'two']).and_return("[\"one\",\"two\"]") }
+  it { is_expected.to run.with_params({}).and_return("{}") }
+  it { is_expected.to run.with_params({ 'key' => 'value' }).and_return("{\"key\":\"value\"}") }
+  it { is_expected.to run.with_params({"one" => {"oneA" => "A","oneB" => {"oneB1" => "1","oneB2" => "2"}},"two" => ["twoA","twoB"]}).and_return("{\"one\":{\"oneA\":\"A\",\"oneB\":{\"oneB1\":\"1\",\"oneB2\":\"2\"}},\"two\":[\"twoA\",\"twoB\"]}") }
+
+  it { is_expected.to run.with_params('‰').and_return('"‰"') }
+  it { is_expected.to run.with_params('竹').and_return('"竹"') }
+  it { is_expected.to run.with_params('Ü').and_return('"Ü"') }
+  it { is_expected.to run.with_params('∇').and_return('"∇"') }
+end

--- a/spec/functions/to_yaml_spec.rb
+++ b/spec/functions/to_yaml_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'to_yaml' do
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params('').and_return("--- ''\n") }
+  it { is_expected.to run.with_params(true).and_return("--- true\n...\n") }
+  it { is_expected.to run.with_params('one').and_return("--- one\n...\n") }
+  it { is_expected.to run.with_params([]).and_return("--- []\n") }
+  it { is_expected.to run.with_params(['one']).and_return("---\n- one\n") }
+  it { is_expected.to run.with_params(['one', 'two']).and_return("---\n- one\n- two\n") }
+  it { is_expected.to run.with_params({}).and_return("--- {}\n") }
+  it { is_expected.to run.with_params({ 'key' => 'value' }).and_return("---\nkey: value\n") }
+  it { is_expected.to run.with_params({"one" => {"oneA" => "A","oneB" => {"oneB1" => "1","oneB2" => "2"}},"two" => ["twoA","twoB"]}).and_return("---\none:\n  oneA: A\n  oneB:\n    oneB1: '1'\n    oneB2: '2'\ntwo:\n- twoA\n- twoB\n") }
+
+  it { is_expected.to run.with_params('‰').and_return("--- \"‰\"\n") }
+  it { is_expected.to run.with_params('∇').and_return("--- \"∇\"\n") }
+end


### PR DESCRIPTION
In ERB, it was easy to do:

```ruby
<%= @hash.to_json %>
```

...but now with EPP, we cannot call on ruby.  We need to access this through Puppet functions.

https://tickets.puppetlabs.com/browse/MODULES-5386