### PR TITLE
(MODULES-5546) add check for pw_hash

### DIFF
--- a/lib/puppet/parser/functions/pw_hash.rb
+++ b/lib/puppet/parser/functions/pw_hash.rb
@@ -28,7 +28,7 @@ Puppet::Parser::Functions::newfunction(
   are compatible before using this function.") do |args|
     raise ArgumentError, "pw_hash(): wrong number of arguments (#{args.size} for 3)" if args.size != 3
     args.map! do |arg|
-      if arg.is_a? Puppet::Pops::Types::PSensitiveType::Sensitive
+      if (defined? Puppet::Pops::Types::PSensitiveType::Sensitive) && (arg.is_a? Puppet::Pops::Types::PSensitiveType::Sensitive)
         arg.unwrap
       else
         arg


### PR DESCRIPTION
Older versions of Puppet end up choking on the sensitive data type check in the pw_hash function added in 42d4ea7. this adds a check for the Sensitive class and then the type of the arg, so that if the class has not been declared, it will just move on.