### PR TITLE
Allow root as valid UNIX path

### DIFF
--- a/types/unixpath.pp
+++ b/types/unixpath.pp
@@ -1,2 +1,2 @@
 # this regex rejects any path component that is a / or a NUL
-type Stdlib::Unixpath = Pattern[/^\/([^\/\0]+\/*)+$/]
+type Stdlib::Unixpath = Pattern[/^\/([^\/\0]+\/*)*$/]


### PR DESCRIPTION
Since the purpose of this validation type is to check if the given parameter is a valid UNIX path it should also cover the root path "slash" since it might be possible that it is specified as a target directory.