### PR TITLE
use single quotes in validate_legacy example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2214,7 +2214,7 @@ Arguments:
 Example:
 
 ```puppet
-validate_legacy("Optional[String]", "validate_re", "Value to be validated", ["."])
+validate_legacy('Optional[String]', 'validate_re', 'Value to be validated', ["."])
 ```
 
 This function supports updating modules from Puppet 3-style argument validation (using the stdlib `validate_*` functions) to Puppet 4 data types, without breaking functionality for those depending on Puppet 3-style validation.


### PR DESCRIPTION
I used the example code from this README file with our puppet code but i got downvotes from CI / jenkins / puppet-lint because it doesn't conform to Puppet style guides to use double quotes here.

It produces "double quoted string containing no variables" warnings from puppet-lint.

I wanted to fix the example locally but it was pointed out to me we should fix it upstream stdlib instead, so here it is. Just use single quotes here.