### PR TITLE
(MODULES-5651) append_on_no_match method fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ The `stdlib` class has no parameters.
 
 * `stdlib::stages`: Manages a standard set of run stages for Puppet.
 
-### Defined types
+### Custom types
 
 #### `file_line`
 
-Ensures that a given line is contained within a file. The implementation matches the full line, including whitespace at the beginning and end. If the line is not contained in the given file, Puppet appends the line to the end of the file to ensure the desired state. Multiple resources can be declared to manage multiple lines in the same file.
+Ensures that a given line is contained within a file. The implementation matches the full line, including whitespace at the beginning and end. If the line is not contained in the given file, Puppet will append the line (`append` defaults to `true`) to the end of the file to ensure the desired state. Multiple resources can be declared to manage multiple lines in the same file.
 
 Example:
 
@@ -122,10 +122,10 @@ Match Example:
       path               => '/etc/bashrc',
       line               => 'export HTTP_PROXY=http://squid.puppetlabs.vm:3128',
       match              => '^export\ HTTP_PROXY\=',
-      append_on_no_match => false,
+      append             => false
     }
 
-In this code example, `match` looks for a line beginning with export followed by HTTP_PROXY and replaces it with the value in line. If a match is not found, then no changes are made to the file.
+In the example above, `match` looks for a line beginning with export followed by HTTP_PROXY and replaces it with the value in line. If a match is not found, then nothing happens.
 
 Match Example with `ensure => absent`:
 
@@ -238,6 +238,16 @@ Value: String specifying an absolute path to the file.
 Specifies whether the resource overwrites an existing line that matches the `match` parameter. If set to `false` and a line is found matching the `match` parameter, the line is not placed in the file.
 
 Boolean.
+
+Default value: `true`.
+
+##### `append`
+
+Specifies whether or not the line is appended to the end of the file when no match is found.
+
+Boolean.
+
+Values: `true`, `false`
 
 Default value: `true`.
 

--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:file_line).provide(:ruby) do
       found = lines_count > 0
     else
       match_count = count_matches(new_match_regex)
-      if resource[:append_on_no_match].to_s == 'false'
+      if resource[:append].to_s == 'false' && match_count == 0
         found = true
       elsif resource[:replace].to_s == 'true'
         found = lines_count > 0 && lines_count == match_count

--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -136,7 +136,7 @@ Puppet::Type.newtype(:file_line) do
     defaultto 'UTF-8'
   end
 
-  newparam(:append_on_no_match) do
+  newparam(:append) do
     desc 'If true, append line if match is not found. If false, do not append line if a match is not found'
     newvalues(true, false)
     defaultto true

--- a/spec/unit/puppet/provider/file_line/ruby_spec.rb
+++ b/spec/unit/puppet/provider/file_line/ruby_spec.rb
@@ -202,7 +202,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
             :path               => @tmpfile,
             :line               => 'inserted = line',
             :match              => '^foo3$',
-            :append_on_no_match => false,
+            :append             => false,
           }
         )
         @provider = provider_class.new(@resource)


### PR DESCRIPTION
This renames append_on_no_match to simply append to relieve lots of double negatives and adds a fix to the method. Previously, if the param was set to false then it always returns true before the replace param is evaluated, so nothing happens. This being the case, I added an additional condition , so that it only acts when there's no match.