### PR TITLE
correct test cases to properly check result

### DIFF
--- a/spec/unit/puppet/provider/file_line/ruby_spec.rb
+++ b/spec/unit/puppet/provider/file_line/ruby_spec.rb
@@ -663,9 +663,11 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
           :match_for_absence => true,
         }
       )
+      @provider = provider_class.new(@resource)
       File.open(tmpfile, 'w') do |fh|
         fh.write("foo1\nfoo\nfoo2")
       end
+      expect(@provider.exists?).to eql (true)
       @provider.destroy
       expect(File.read(tmpfile)).to eql("foo1\nfoo2")
     end
@@ -680,9 +682,11 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
           :match_for_absence => true,
         }
       )
+      @provider = provider_class.new(@resource)
       File.open(tmpfile, 'w') do |fh|
         fh.write("foo1\nfoo\nfoo2")
       end
+      expect(@provider.exists?).to eql (true)
       @provider.destroy
       expect(File.read(tmpfile)).to eql("foo1\nfoo2")
     end
@@ -710,6 +714,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
       File.open(tmpfile, 'w') do |fh|
         fh.write("foo1\nfoo\nfoo2\nfoo\nfoo")
       end
+      expect(@provider.exists?).to eql (true)
       @provider.destroy
       expect(File.read(tmpfile)).to eql("foo1\nfoo2\n")
     end
@@ -728,6 +733,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
       File.open(tmpfile, 'w') do |fh|
         fh.write("foo1\nfoo\nfoo2")
       end
+      expect(@provider.exists?).to eql (true)
       @provider.destroy
       expect(File.read(tmpfile)).to eql("foo1\nfoo\n")
     end
@@ -747,6 +753,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
       File.open(tmpfile, 'w') do |fh|
         fh.write("foo1\nfoo\nfoo2")
       end
+      expect(@provider.exists?).to eql (true)
       @provider.destroy
       expect(File.read(tmpfile)).to eql("foo1\nfoo\n")
     end
@@ -766,6 +773,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
       File.open(tmpfile, 'w') do |fh|
         fh.write("foo1\nfoo2\nexport HTTP_PROXY=foo\nfoo4\n")
       end
+      expect(@provider.exists?).to eql (true)
       @provider.destroy
       expect(File.read(tmpfile)).to eql("foo1\nfoo2\nfoo4\n")
     end
@@ -784,6 +792,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
       File.open(tmpfile, 'w') do |fh|
         fh.write("foo1\nfoo2\nexport HTTP_PROXY=foo\nfoo4\n")
       end
+      expect(@provider.exists?).to eql (true)
       @provider.destroy
       expect(File.read(tmpfile)).to eql("foo1\nfoo2\nfoo4\n")
     end


### PR DESCRIPTION
When working with "file_line" and "ensure=>absent", I noticed that my existing manifests that were perfectly fine in 4.18.0, stopped working in 4.19.0. Digging deeper into the issue, I was able to identify commit 81d7d35fd789 that caused the problem. In order to provide a minimal working example to describe the issue, I stumbled over the example from the "README.md":
```
file_line { 'bashrc_proxy':
  ensure             => present,
  path               => '/etc/bashrc',
  line               => 'export HTTP_PROXY=http://squid.puppetlabs.vm:3128',
  match              => '^export\ HTTP_PROXY\=',
  append_on_no_match => false,
}
```
I found out, that this example only works when the line to remove is exactly "export HTTP_PROXY=http://squid.puppetlabs.vm:3128" and does not do anything for a line like "export HTTP_PROXY=a".

I checked and saw that these test cases are exactly the ones run by "spec/unit/puppet/provider/file_line/ruby_spec.rb" which surprised me and I wondered how theses testcases could pass.

So after more debugging I saw that the problematic test cases don't even create the provider. When I corrected that, I noticed that the testcases were sill passing. I realized that the test cases don't check the "exists?" method, which is used when applying manifests with such resources. So I added that assertion as well.

Note that the corrected test cases will not pass, as the code from commit 81d7d35fd789 causes such file_line resources to be handled incorrectly, which I did not attempt to correct.