### PR TITLE
Add merge_resource_hash function

### DIFF
--- a/lib/puppet/parser/functions/merge_resource_hash.rb
+++ b/lib/puppet/parser/functions/merge_resource_hash.rb
@@ -1,0 +1,63 @@
+#
+# merge_resource_hash.rb
+#
+
+module Puppet::Parser::Functions
+  newfunction(:merge_resource_hash, :type => :rvalue, :doc => <<-EOS
+    Takes any number of hashes of hashes (in the format fit for create_resources()).
+    For each key as hash, merges all subkey values (i.e. resource parameters) into arrays.
+
+    E.g. given these three hashes:
+
+       $h1 = {
+         k1 => { p1 => 'v1' },
+         k2 => { p1 => ['v211', 'v212'] }
+       }
+
+       $h2 = {
+         k2 => {
+           p1 => 'v213',
+           p2 => 'v221'
+         }
+       }
+
+       $h3 = {
+         k2 => {
+           p1 => ['v214', 'v215'],
+           p3 => 'v231'
+         },
+       }
+
+    it will produce:
+
+       {
+         k1 => {p1 => v1},
+         k2 => {
+           p1 => [v211, v212, v213, v214, v215],
+           p2 => v221,
+           p3 => v231
+         }
+       }
+  EOS
+  ) do |args|
+      raise(Puppet::ParseError, "merge_resource_hash(): Wrong number of arguments given (#{args.size})") if args.size < 1
+
+      args.each do |a|
+          raise Puppet::ParseError, 'merge_resource_hash(): arguments should be hashes' unless a.is_a?(Hash)
+
+          a.each do |k, v|
+              raise Puppet::ParseError, 'merge_resource_hash(): arguments should be hashes of hashes' unless v.is_a?(Hash)
+          end
+      end
+
+      h = args.shift
+
+      while new_h = args.shift
+          h.merge!(new_h) do |k, v1, v2|
+              v1.merge(v2) { |kk, vv1, vv2| [vv1, vv2].flatten }
+          end
+      end
+
+      h
+  end
+end

--- a/spec/functions/merge_resource_hash_spec.rb
+++ b/spec/functions/merge_resource_hash_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'merge_resource_hash' do
+  let(:h1) { {
+      'foo' => { 'p1' => ['v1', 'v2'] },
+      'bar' => { 'p' => 'v' }
+  } }
+
+  let(:h2) { {
+      'foo' => {
+          'p1' => 'v3',
+          'p2' => ['v1', 'v2'],
+      },
+  } }
+
+  let(:h3) { {
+      'foo' => {
+          'p2' => ['v3'],
+      },
+      'baz' => {
+          'p' => 'v',
+      },
+  } }
+
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /Wrong number of arguments/) }
+  it { is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError, /arguments should be hashes/) }
+  it { is_expected.to run.with_params('a').and_raise_error(Puppet::ParseError, /arguments should be hashes/) }
+  it { is_expected.to run.with_params(true).and_raise_error(Puppet::ParseError, /arguments should be hashes/) }
+  it { is_expected.to run.with_params({'a' => 'b'}).and_raise_error(Puppet::ParseError, /arguments should be hashes of hashes/i) }
+
+  it { is_expected.to run.with_params(h1).and_return(h1) }
+  it { is_expected.to run.with_params(h1, h2).and_return({
+      'foo' => {
+          'p1' => ['v1', 'v2', 'v3'],
+          'p2' => ['v1', 'v2'],
+      },
+      'bar' => { 'p' => 'v' },
+  }) }
+  it { is_expected.to run.with_params(h1, h2, h3).and_return({
+      'foo' => {
+          'p1' => ['v1', 'v2', 'v3'],
+          'p2' => ['v1', 'v2', 'v3'],
+      },
+      'bar' => { 'p' => 'v' },
+      'baz' => { 'p' => 'v' },
+  }) }
+end


### PR DESCRIPTION
Takes any number of hashes of hashes (in the format fit for create_resources()).
For each key as hash, merges all subkey values (i.e. resource parameters) into arrays.

E.g. given these three hashes:

```puppet
   $h1 = {
     k1 => { p1 => 'v1' },
     k2 => { p1 => ['v211', 'v212'] }
   }

   $h2 = {
     k2 => {
       p1 => 'v213',
       p2 => 'v221'
     }
   }

   $h3 = {
     k2 => {
       p1 => ['v214', 'v215'],
       p3 => 'v231'
     },
   }
```

it will produce:

```puppet
   {
     k1 => {p1 => 'v1'},
     k2 => {
       p1 => ['v211', 'v212', 'v213', 'v214', 'v215'],
       p2 => 'v221',
       p3 => 'v231'
     }
   }
```