### PR TITLE
MODULES-6106: Fix broken `.sync.yml`

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -12,11 +12,11 @@ spec/spec_helper.rb:
 
 .travis.yml:
   extras:
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION="~> 4.6.0"
-      bundler_args: --without system_tests
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION="~> 4.7.0"
-      bundler_args: --without system_tests
-  - rvm: 2.1.9
-    script: bundle exec rake rubocop
+    - rvm: 2.1.9
+      env: PUPPET_GEM_VERSION="~> 4.6.0"
+      bundler_args: --without system_tests
+    - rvm: 2.1.9
+      env: PUPPET_GEM_VERSION="~> 4.7.0"
+      bundler_args: --without system_tests
+    - rvm: 2.1.9
+      script: bundle exec rake rubocop


### PR DESCRIPTION
Fix the indentation of the `rubocop` test in the `.travis.yml` `extras`
section.  Also replace unicode `EN SPACE` characters with ASCII spaces.