### PR TITLE
Ability to skip undef values in to_json_pretty()

### DIFF
--- a/lib/puppet/functions/to_json_pretty.rb
+++ b/lib/puppet/functions/to_json_pretty.rb
@@ -7,15 +7,32 @@
 #       content => to_json_pretty($myhash),
 #     }
 #
+# @example how to output pretty JSON skipping over keys with undef values
+#   # output pretty JSON to a file skipping over undef values
+#     file { '/tmp/my.json':
+#       ensure  => file,
+#       content => to_json_pretty({
+#         param_one => 'value',
+#         param_two => undef,
+#       }),
+#     }
 #
 require 'json'
 
 Puppet::Functions.create_function(:to_json_pretty) do
   dispatch :to_json_pretty do
     param 'Variant[Hash, Array]', :data
+    optional_param 'Boolean', :skip_undef
   end
 
-  def to_json_pretty(data)
-    JSON.pretty_generate(data)
+  def to_json_pretty(data, skip_undef = false)
+    if skip_undef
+      if data.is_a? Array
+        data = data.reject { |value| value.nil? }
+      elsif data.is_a? Hash
+        data = data.reject { |_, value| value.nil? }
+      end
+    end
+    JSON.pretty_generate(data) << "\n"
   end
 end

--- a/spec/functions/to_json_pretty_spec.rb
+++ b/spec/functions/to_json_pretty_spec.rb
@@ -2,13 +2,15 @@ require 'spec_helper'
 
 describe 'to_json_pretty' do
   it { is_expected.not_to eq(nil) }
-  it { is_expected.to run.with_params([]).and_return("[\n\n]") }
-  it { is_expected.to run.with_params(['one']).and_return("[\n  \"one\"\n]") }
-  it { is_expected.to run.with_params(%w[one two]).and_return("[\n  \"one\",\n  \"two\"\n]") }
-  it { is_expected.to run.with_params({}).and_return("{\n}") }
-  it { is_expected.to run.with_params('key' => 'value').and_return("{\n  \"key\": \"value\"\n}") }
+  it { is_expected.to run.with_params([]).and_return("[\n\n]\n") }
+  it { is_expected.to run.with_params(['one']).and_return("[\n  \"one\"\n]\n") }
+  it { is_expected.to run.with_params(%w[one two]).and_return("[\n  \"one\",\n  \"two\"\n]\n") }
+  it { is_expected.to run.with_params({}).and_return("{\n}\n") }
+  it { is_expected.to run.with_params('key' => 'value').and_return("{\n  \"key\": \"value\"\n}\n") }
   it {
     is_expected.to run.with_params('one' => { 'oneA' => 'A', 'oneB' => { 'oneB1' => '1', 'oneB2' => '2' } }, 'two' => %w[twoA twoB])
-                      .and_return("{\n  \"one\": {\n    \"oneA\": \"A\",\n    \"oneB\": {\n      \"oneB1\": \"1\",\n      \"oneB2\": \"2\"\n    }\n  },\n  \"two\": [\n    \"twoA\",\n    \"twoB\"\n  ]\n}") # rubocop:disable Metrics/LineLength : Unable to reduce line to required length
+                      .and_return("{\n  \"one\": {\n    \"oneA\": \"A\",\n    \"oneB\": {\n      \"oneB1\": \"1\",\n      \"oneB2\": \"2\"\n    }\n  },\n  \"two\": [\n    \"twoA\",\n    \"twoB\"\n  ]\n}\n") # rubocop:disable Metrics/LineLength : Unable to reduce line to required length
   }
+  it { is_expected.to run.with_params({'one' => '1', 'two' => nil}, true).and_return("{\n  \"one\": \"1\"\n}\n") }
+  it { is_expected.to run.with_params(['one', 'two', nil, 'three'], true).and_return("[\n  \"one\",\n  \"two\",\n  \"three\"\n]\n") }
 end

--- a/spec/functions/to_json_pretty_spec.rb
+++ b/spec/functions/to_json_pretty_spec.rb
@@ -11,6 +11,6 @@ describe 'to_json_pretty' do
     is_expected.to run.with_params('one' => { 'oneA' => 'A', 'oneB' => { 'oneB1' => '1', 'oneB2' => '2' } }, 'two' => %w[twoA twoB])
                       .and_return("{\n  \"one\": {\n    \"oneA\": \"A\",\n    \"oneB\": {\n      \"oneB1\": \"1\",\n      \"oneB2\": \"2\"\n    }\n  },\n  \"two\": [\n    \"twoA\",\n    \"twoB\"\n  ]\n}\n") # rubocop:disable Metrics/LineLength : Unable to reduce line to required length
   }
-  it { is_expected.to run.with_params({'one' => '1', 'two' => nil}, true).and_return("{\n  \"one\": \"1\"\n}\n") }
+  it { is_expected.to run.with_params({ 'one' => '1', 'two' => nil }, true).and_return("{\n  \"one\": \"1\"\n}\n") }
   it { is_expected.to run.with_params(['one', 'two', nil, 'three'], true).and_return("[\n  \"one\",\n  \"two\",\n  \"three\"\n]\n") }
 end


### PR DESCRIPTION
Note that I also added a trailing newline at the end of `to_json_pretty()` output. Seems like a desirable change since usually we output to a file.