### PR TITLE
Updated type alias tests and dropped superfluous wrapper classes

### DIFF
--- a/spec/fixtures/test/manifests/absolute_path.pp
+++ b/spec/fixtures/test/manifests/absolute_path.pp
@@ -1,6 +1,0 @@
-# Class to test the Stdlib::Compat::Absolute_path type alias
-class test::absolute_path(
-  Stdlib::Compat::Absolute_path $value,
-  ) {
-    notice("Success")
-}

--- a/spec/fixtures/test/manifests/absolutepath.pp
+++ b/spec/fixtures/test/manifests/absolutepath.pp
@@ -1,6 +1,0 @@
-# Class to test the Stdlib::Absolutepath type. Not to be confused with Stdlib::Compat::Absolute_path.
-class test::absolutepath(
-    Stdlib::Absolutepath $value,
-    ) {
-  notice("Success")
-}

--- a/spec/fixtures/test/manifests/array.pp
+++ b/spec/fixtures/test/manifests/array.pp
@@ -1,8 +1,0 @@
-# Class to test the Stdlib::Compat::Array type alias
-class test::array(
-  Stdlib::Compat::Array $value,
-  ) {
-
-    notice("Success")
-
-}

--- a/spec/fixtures/test/manifests/bool.pp
+++ b/spec/fixtures/test/manifests/bool.pp
@@ -1,8 +1,0 @@
-# Class to test the Stdlib::Compat::Bool type alias
-class test::bool(
-  Stdlib::Compat::Bool $value,
-  ) {
-
-    notice("Success")
-
-}

--- a/spec/fixtures/test/manifests/filemode.pp
+++ b/spec/fixtures/test/manifests/filemode.pp
@@ -1,6 +1,0 @@
-# Class to test the Stdlib::Filemode type alias
-class test::filemode (
-  Stdlib::Filemode $value,
-) {
-  notice("Success")
-}

--- a/spec/fixtures/test/manifests/float.pp
+++ b/spec/fixtures/test/manifests/float.pp
@@ -1,8 +1,0 @@
-# Class to test the Stdlib::Compat::Float type alias
-class test::float(
-  Stdlib::Compat::Float $value,
-  ) {
-
-    notice("Success")
-
-}

--- a/spec/fixtures/test/manifests/hash.pp
+++ b/spec/fixtures/test/manifests/hash.pp
@@ -1,8 +1,0 @@
-# Class to test the Stdlib::Compat::Hash type alias
-class test::hash(
-    Stdlib::Compat::Hash $value,
-    ) {
-
-  notice("Success")
-
-}

--- a/spec/fixtures/test/manifests/httpsurl.pp
+++ b/spec/fixtures/test/manifests/httpsurl.pp
@@ -1,6 +1,0 @@
-# Class to test the Stdlib::HTTPSUrl type alias
-class test::httpsurl(
-    Stdlib::HTTPSUrl $value,
-    ) {
-  notice("Success")
-}

--- a/spec/fixtures/test/manifests/httpurl.pp
+++ b/spec/fixtures/test/manifests/httpurl.pp
@@ -1,6 +1,0 @@
-# Class to test the Stdlib::HTTPUrl type alias
-class test::httpurl(
-    Stdlib::HTTPUrl $value,
-    ) {
-  notice("Success")
-}

--- a/spec/fixtures/test/manifests/integer.pp
+++ b/spec/fixtures/test/manifests/integer.pp
@@ -1,8 +1,0 @@
-# Class to test the Stdlib::Compat::Integer type alias
-class test::integer(
-  Stdlib::Compat::Integer $value,
-  ) {
-
-    notice("Success")
-
-}

--- a/spec/fixtures/test/manifests/ip_address.pp
+++ b/spec/fixtures/test/manifests/ip_address.pp
@@ -1,6 +1,0 @@
-# Class to test the Stdlib::Compat::Ip_address type alias
-class test::ip_address(
-  Stdlib::Compat::Ip_address $value,
-  ) {
-    notice("Success")
-  }

--- a/spec/fixtures/test/manifests/ipv4.pp
+++ b/spec/fixtures/test/manifests/ipv4.pp
@@ -1,6 +1,0 @@
-# Class to test the Stdlib::Compat::Ipv4 type alias
-class test::ipv4(
-  Stdlib::Compat::Ipv4 $value,
-  ) {
-    notice("Success")
-  }

--- a/spec/fixtures/test/manifests/ipv6.pp
+++ b/spec/fixtures/test/manifests/ipv6.pp
@@ -1,6 +1,0 @@
-# Class to test the Stdlib::Compat::Ipv6 type alias
-class test::ipv6(
-  Stdlib::Compat::Ipv6 $value,
-  ) {
-  notice("Success")
-}

--- a/spec/fixtures/test/manifests/numeric.pp
+++ b/spec/fixtures/test/manifests/numeric.pp
@@ -1,8 +1,0 @@
-# Class to test the Stdlib::Compat::Numeric type alias
-class test::numeric(
-  Stdlib::Compat::Numeric $value,
-  ) {
-
-    notice("Success")
-
-}

--- a/spec/fixtures/test/manifests/string.pp
+++ b/spec/fixtures/test/manifests/string.pp
@@ -1,8 +1,0 @@
-# Class to test the Stdlib::Compat::String type alias
-class test::string(
-  Stdlib::Compat::String $value,
-  ) {
-
-    notice("Success")
-
-}

--- a/spec/fixtures/test/manifests/unixpath.pp
+++ b/spec/fixtures/test/manifests/unixpath.pp
@@ -1,6 +1,0 @@
-# Class to test the Stdlib::Unixpath type alias
-class test::unixpath(
-    Stdlib::Unixpath $value,
-    ) {
-  notice("Success")
-}

--- a/spec/fixtures/test/manifests/windowspath.pp
+++ b/spec/fixtures/test/manifests/windowspath.pp
@@ -1,6 +1,0 @@
-# Class to test the Stdlib::Windowspath type alias
-class test::windowspath(
-    Stdlib::Windowspath $value,
-    ) {
-  notice("Success")
-}

--- a/spec/type_aliases/absolute_path_spec.rb
+++ b/spec/type_aliases/absolute_path_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::absolute_path', type: :class do
+  describe 'Stdlib::Compat::Absolute_path' do
     describe 'valid paths handling' do
       %w[
         C:/
@@ -20,9 +20,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         /var/ネット
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -38,9 +36,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
           '',
         ].each do |value|
           describe value.inspect do
-            let(:params) { { value: value } }
-
-            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::Compat::Absolute_path}) }
+            it { is_expected.not_to allow_value(value) }
           end
         end
       end
@@ -59,9 +55,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
           \var\ネット
         ].each do |value|
           describe value.inspect do
-            let(:params) { { value: value } }
-
-            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::Compat::Absolute_path}) }
+            it { is_expected.not_to allow_value(value) }
           end
         end
       end

--- a/spec/type_aliases/array_spec.rb
+++ b/spec/type_aliases/array_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::array', type: :class do
+  describe 'Stdlib::Compat::Array' do
     describe 'accepts arrays' do
       [
         [],
@@ -11,9 +11,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         [[]],
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -26,9 +24,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         {},
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a Stdlib::Compat::Array}) }
+          it { is_expected.not_to allow_value(value) }
         end
       end
     end

--- a/spec/type_aliases/bool_spec.rb
+++ b/spec/type_aliases/bool_spec.rb
@@ -1,16 +1,14 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::bool', type: :class do
+  describe 'Stdlib::Compat::Bool' do
     describe 'accepts booleans' do
       [
         true,
         false,
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -24,9 +22,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         'false',
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a Stdlib::Compat::Bool}) }
+          it { is_expected.not_to allow_value(value) }
         end
       end
     end

--- a/spec/type_aliases/filemode_spec.rb
+++ b/spec/type_aliases/filemode_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::filemode', type: :class do
+  describe 'Stdlib::Filemode' do
     describe 'valid modes' do
       %w[
         0644
@@ -12,9 +12,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         0777
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -39,9 +37,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
           '0649',
         ].each do |value|
           describe value.inspect do
-            let(:params) { { value: value } }
-
-            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::Filemode}) }
+            it { is_expected.not_to allow_value(value) }
           end
         end
       end

--- a/spec/type_aliases/float_spec.rb
+++ b/spec/type_aliases/float_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::float', type: :class do
+  describe 'Stdlib::Compat::Float' do
     describe 'accepts floats' do
       [
         3.7,
@@ -10,9 +10,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         '-342.2315e-12',
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -20,9 +18,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
     describe 'rejects other values' do
       [true, 'true', false, 'false', 'iAmAString', '1test', '1 test', 'test 1', 'test 1 test', {}, { 'key' => 'value' }, { 1 => 2 }, '', :undef, 'x', 3, '3', -3, '-3'].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects.*Float.*Pattern}) }
+          it { is_expected.not_to allow_value(value) }
         end
       end
     end

--- a/spec/type_aliases/hash_spec.rb
+++ b/spec/type_aliases/hash_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::hash', type: :class do
+  describe 'Stdlib::Compat::Hash' do
     describe 'accepts hashes' do
       [
         {},
@@ -10,9 +10,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         { '001' => 'helly' },
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -24,9 +22,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         [],
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a Stdlib::Compat::Hash}) }
+          it { is_expected.not_to allow_value(value) }
         end
       end
     end

--- a/spec/type_aliases/httpsurl_spec.rb
+++ b/spec/type_aliases/httpsurl_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::httpsurl', type: :class do
+  describe 'Stdlib::HTTPSUrl' do
     describe 'valid handling' do
       %w[
         https://hello.com
@@ -11,9 +11,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         https://graphemica.com/緩
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -34,9 +32,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
           'http://graphemica.com/緩',
         ].each do |value|
           describe value.inspect do
-            let(:params) { { value: value } }
-
-            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::HTTPSUrl}) }
+            it { is_expected.not_to allow_value(value) }
           end
         end
       end

--- a/spec/type_aliases/httpurl_spec.rb
+++ b/spec/type_aliases/httpurl_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::httpurl', type: :class do
+  describe 'Stdlib::HTTPUrl' do
     describe 'valid handling' do
       %w[
         https://hello.com
@@ -14,9 +14,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         http://graphemica.com/緩
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -37,9 +35,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
           'https:graphemica.com/緩',
         ].each do |value|
           describe value.inspect do
-            let(:params) { { value: value } }
-
-            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::HTTPUrl}) }
+            it { is_expected.not_to allow_value(value) }
           end
         end
       end

--- a/spec/type_aliases/integer_spec.rb
+++ b/spec/type_aliases/integer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::integer', type: :class do
+  describe 'Stdlib::Compat::Integer' do
     describe 'accepts integers' do
       [
         3,
@@ -12,9 +12,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         "foo\n123",
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -23,13 +21,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
       ["foo\nbar", true, 'true', false, 'false', 'iAmAString', '1test', '1 test', 'test 1', 'test 1 test',
        {}, { 'key' => 'value' }, { 1 => 2 }, '', :undef, 'x', 3.7, '3.7', -3.7, '-342.2315e-12'].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          if Puppet::Util::Package.versioncmp(Puppet.version, '5.0.0') >= 0
-            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a Stdlib::Compat::Integer = Variant\[Integer, Pattern\[.*\], Array\[.*\]\] value}) }
-          else
-            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a value of type Integer, Pattern(\[.*\]+)?, or Array}) }
-          end
+          it { is_expected.not_to allow_value(value) }
         end
       end
     end

--- a/spec/type_aliases/ip_address.rb
+++ b/spec/type_aliases/ip_address.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::ip_address', type: :class do
+  describe 'Stdlib::Compat::Ip_address' do
     describe 'accepts ipv4 and ipv6 addresses' do
       [
         '224.0.0.0',
@@ -12,9 +12,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         'fa76:8765:34ac:0823:ab76:eee9:0987:1111',
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -26,9 +24,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         '2001:0db8:85a3:000000:0000:8a2e:0370:7334',
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for}) }
+          it { is_expected.not_to allow_value(value) }
         end
       end
     end

--- a/spec/type_aliases/ipv4_spec.rb
+++ b/spec/type_aliases/ipv4_spec.rb
@@ -1,22 +1,18 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::ipv4', type: :class do
+  describe 'Stdlib::Compat::Ipv4' do
     describe 'accepts ipv4 addresses' do
       SharedData::IPV4_PATTERNS.each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
     describe 'rejects other values' do
       SharedData::IPV4_NEGATIVE_PATTERNS.each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::Compat::Ipv4}) }
+          it { is_expected.not_to allow_value(value) }
         end
       end
     end

--- a/spec/type_aliases/ipv6_spec.rb
+++ b/spec/type_aliases/ipv6_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::ipv6', type: :class do
+  describe 'Stdlib::Compat::Ipv6' do
     describe 'accepts ipv6 addresses' do
       [
         '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
@@ -15,9 +15,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         '2001::',
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -32,9 +30,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         '::ffff:12345678901234567890.1.26',
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::Compat::Ipv6}) }
+          it { is_expected.not_to allow_value(value) }
         end
       end
     end

--- a/spec/type_aliases/numeric_spec.rb
+++ b/spec/type_aliases/numeric_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::numeric', type: :class do
+  describe 'Stdlib::Compat::Numeric' do
     describe 'accepts numerics' do
       [
         3,
@@ -14,9 +14,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         '-342.2315e-12',
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -24,9 +22,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
     describe 'rejects other values' do
       [true, 'true', false, 'false', 'iAmAString', '1test', '1 test', 'test 1', 'test 1 test', {}, { 'key' => 'value' }, { 1 => 2 }, '', :undef, 'x'].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects.*Numeric.*Pattern.*Array}) }
+          it { is_expected.not_to allow_value(value) }
         end
       end
     end

--- a/spec/type_aliases/string_spec.rb
+++ b/spec/type_aliases/string_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::string', type: :class do
+  describe 'Stdlib::Compat::String' do
     describe 'accepts strings' do
       [
         '',
@@ -9,9 +9,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         nil,
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -24,9 +22,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         true,
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a (?:value of type Undef or )?.*String}) }
+          it { is_expected.not_to allow_value(value) }
         end
       end
     end

--- a/spec/type_aliases/unixpath_spec.rb
+++ b/spec/type_aliases/unixpath_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::unixpath', type: :class do
+  describe 'Stdlib::Unixpath' do
     describe 'valid handling' do
       %w[
         /usr2/username/bin:/usr/local/bin:/usr/bin:.
@@ -13,9 +13,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         /var/../tmp
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -37,9 +35,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
           "var\ネット",
         ].each do |value|
           describe value.inspect do
-            let(:params) { { value: value } }
-
-            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::Unixpath}) }
+            it { is_expected.not_to allow_value(value) }
           end
         end
       end

--- a/spec/type_aliases/windowspath_spec.rb
+++ b/spec/type_aliases/windowspath_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
-  describe 'test::windowspath', type: :class do
+  describe 'Stdlib::Windowspath' do
     describe 'valid handling' do
       %w[
         C:\\
@@ -14,9 +14,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
         X:/var/ネット
       ].each do |value|
         describe value.inspect do
-          let(:params) { { value: value } }
-
-          it { is_expected.to compile }
+          it { is_expected.to allow_value(value) }
         end
       end
     end
@@ -38,9 +36,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
           'C:ůťƒ8',
         ].each do |value|
           describe value.inspect do
-            let(:params) { { value: value } }
-
-            it { is_expected.to compile.and_raise_error(%r{parameter 'value' expects a match for Stdlib::Windowspath}) }
+            it { is_expected.not_to allow_value(value) }
           end
         end
       end


### PR DESCRIPTION
Since newer versions of rspec-puppet support testing type aliases directly, let's drop superfluous wrapper classes and start testing properly.