### PR TITLE
(MODULES-6216) - Fix type3x function in stdlib

### DIFF
--- a/lib/puppet/parser/functions/type.rb
+++ b/lib/puppet/parser/functions/type.rb
@@ -11,7 +11,7 @@ module Puppet::Parser::Functions
     unless Puppet::Parser::Functions.autoloader.loaded?(:type3x)
       Puppet::Parser::Functions.autoloader.load(:type3x)
     end
-    function_type3x(args + [false])
+    function_type3x(args)
   end
 end
 

--- a/lib/puppet/parser/functions/type3x.rb
+++ b/lib/puppet/parser/functions/type3x.rb
@@ -15,13 +15,13 @@ module Puppet::Parser::Functions
     * boolean
   DOC
              ) do |args|
-    raise(Puppet::ParseError, "type3x(): Wrong number of arguments given (#{args.size} for 1)") if args.empty?
+    raise(Puppet::ParseError, "type3x(): Wrong number of arguments given (#{args.size} for 1)") unless args.size == 1
 
     value = args[0]
 
     klass = value.class
 
-    unless [TrueClass, FalseClass, Array, Integer, Integer, Float, Hash, String].include?(klass)
+    unless [TrueClass, FalseClass, Array, Bignum, Fixnum, Float, Hash, String].include?(klass) # rubocop:disable Lint/UnifiedInteger
       raise(Puppet::ParseError, 'type3x(): Unknown type')
     end
 

--- a/spec/acceptance/type3x_spec.rb
+++ b/spec/acceptance/type3x_spec.rb
@@ -1,0 +1,28 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper_acceptance'
+
+describe 'type3x function' do
+  describe 'success' do
+    {
+      %{type3x({ 'a' => 'hash' })} => 'Hash',
+      %{type3x(['array'])}         => 'Array',
+      %{type3x(false)}             => 'Boolean',
+      %{type3x('asdf')}            => 'String',
+      %{type3x(242)}               => 'Integer',
+      %{type3x(3.14)}              => 'Float',
+    }.each do |pp, type|
+      it "with type #{type}" do
+        apply_manifest(pp, :catch_failures => true)
+      end
+    end
+  end
+
+  describe 'failure' do
+    pp_fail = <<-EOS
+      type3x('one','two')
+    EOS
+    it 'handles improper number of arguments' do
+      expect(apply_manifest(pp_fail, :expect_failures => true).stderr).to match(%r{Wrong number of arguments})
+    end
+  end
+end

--- a/spec/acceptance/type3x_spec.rb
+++ b/spec/acceptance/type3x_spec.rb
@@ -18,9 +18,9 @@ describe 'type3x function' do
   end
 
   describe 'failure' do
-    pp_fail = <<-EOS
+    pp_fail = <<-MANIFEST
       type3x('one','two')
-    EOS
+    MANIFEST
     it 'handles improper number of arguments' do
       expect(apply_manifest(pp_fail, :expect_failures => true).stderr).to match(%r{Wrong number of arguments})
     end


### PR DESCRIPTION
This has been introduced with implementing Rubocop: https://github.com/puppetlabs/puppetlabs-stdlib/pull/838