### PR TITLE
Added ensure_* functions

### DIFF
--- a/lib/puppet/functions/ensure_directory.rb
+++ b/lib/puppet/functions/ensure_directory.rb
@@ -1,0 +1,37 @@
+# Takes a generic 'ensure' parameter (or its boolean equivalent)
+# and converts it to an appropriate value for use with directory
+# declaration.
+Puppet::Functions.create_function(:ensure_directory) do
+  # @param ensure_param Pass ensure value here
+  # @return [String] 'directory' or 'absent'
+  #
+  # @example Calling the function with 'present'
+  #   ensure_directory('present') # returns 'directory'
+  #
+  # @example Calling the function with boolean parameter
+  #   ensure_directory(true) # returns 'directory'
+  #
+  # @example
+  #   class myservice::config (
+  #     Enum[present, absent] $ensure = present,
+  #   ) {
+  #     file { '/etc/myservice':
+  #       ensure => ensure_directory($ensure),
+  #       mode   => '0755',
+  #     }
+  #   }
+  dispatch :ensure do
+    param 'Variant[String, Boolean]', :ensure_param
+  end
+
+  def ensure(ensure_param)
+    case ensure_param
+    when 'present', true then
+      'directory'
+    when 'absent', false then
+      'absent'
+    else
+      raise(ArgumentError, "ensure_directory(): invalid argument: '#{ensure_param}'.")
+    end
+  end
+end

--- a/lib/puppet/functions/ensure_file.rb
+++ b/lib/puppet/functions/ensure_file.rb
@@ -1,0 +1,37 @@
+# Takes a generic 'ensure' parameter (or its boolean equivalent)
+# and converts it to an appropriate value for use with file
+# declaration.
+Puppet::Functions.create_function(:ensure_file) do
+  # @param ensure_param Pass ensure value here
+  # @return [String] 'file' or 'absent'
+  #
+  # @example Calling the function with 'present'
+  #   ensure_file('present') # returns 'file'
+  #
+  # @example Calling the function with boolean parameter:
+  #   ensure_file(true) # returns 'file'
+  #
+  # @example Usage context:
+  #   class myservice::config (
+  #     Enum[present, absent] $ensure = present,
+  #   ) {
+  #     file { '/etc/myservice':
+  #       ensure => ensure_file($ensure),
+  #       mode   => '0644',
+  #     }
+  #   }
+  dispatch :ensure do
+    param 'Variant[String, Boolean]', :ensure_param
+  end
+
+  def ensure(ensure_param)
+    case ensure_param
+    when 'present', true then
+      'file'
+    when 'absent', false then
+      'absent'
+    else
+      raise(ArgumentError, "ensure_file(): invalid argument: '#{ensure_param}'.")
+    end
+  end
+end

--- a/lib/puppet/functions/ensure_link.rb
+++ b/lib/puppet/functions/ensure_link.rb
@@ -1,0 +1,41 @@
+# Takes a generic 'ensure' parameter (or its boolean equivalent)
+# and converts it to an appropriate value for use with symlink
+# declaration.
+Puppet::Functions.create_function(:ensure_link) do
+  # @param ensure_param Pass ensure value here
+  # @return [String] 'link' or 'absent'
+  #
+  # @example Calling the function with 'present'
+  #   ensure_link('present') # returns 'link'
+  #
+  # @example Calling the function with boolean parameter:
+  #   ensure_link(true) # returns 'link'
+  #
+  # @example Usage context:
+  #   class myservice::config (
+  #     Enum[present, absent] $ensure = present,
+  #   ) {
+  #     file { '/etc/myservice':
+  #       ensure => file,
+  #     }
+  #
+  #     file { '/etc/myservice-link':
+  #       ensure => ensure_link($ensure),
+  #       target => '/etc/myservice'
+  #     }
+  #   }
+  dispatch :ensure do
+    param 'Variant[String, Boolean]', :ensure_param
+  end
+
+  def ensure(ensure_param)
+    case ensure_param
+    when 'present', true then
+      'link'
+    when 'absent', false then
+      'absent'
+    else
+      raise(ArgumentError, "ensure_link(): invalid argument: '#{ensure_param}'.")
+    end
+  end
+end

--- a/lib/puppet/functions/ensure_present.rb
+++ b/lib/puppet/functions/ensure_present.rb
@@ -1,0 +1,20 @@
+# Converts a boolean to a generic 'ensure' value.
+Puppet::Functions.create_function(:ensure_present) do
+  # @param ensure_param Pass a boolean here
+  # @return [String] 'present' or 'absent'
+  #
+  # @example Calling the function
+  #   ensure_present(true) # returns 'present'
+  #   ensure_present(false) # returns 'absent'
+  dispatch :ensure do
+    param 'Boolean', :ensure_param
+  end
+
+  def ensure(ensure_param)
+    if ensure_param
+      'present'
+    else
+      'absent'
+    end
+  end
+end

--- a/spec/functions/ensure_directory_spec.rb
+++ b/spec/functions/ensure_directory_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'ensure_directory' do
+  context 'return :directory or :absent with correct parameter' do
+    it { is_expected.to run.with_params(true).and_return('directory') }
+    it { is_expected.to run.with_params('present').and_return('directory') }
+    it { is_expected.to run.with_params(false).and_return('absent') }
+    it { is_expected.to run.with_params('absent').and_return('absent') }
+  end
+
+  context 'raise an argument error with incorrect parameter' do
+    [
+      '',
+      ' ',
+      'someweirdstuff',
+      'true',
+      'false',
+      {},
+      [],
+      [''],
+      [' '],
+    ].each do |ensure_param|
+      it { is_expected.to run.with_params(ensure_param).and_raise_error(ArgumentError) }
+    end
+  end
+end

--- a/spec/functions/ensure_file_spec.rb
+++ b/spec/functions/ensure_file_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'ensure_file' do
+  context 'return :file or :absent with correct parameter' do
+    it { is_expected.to run.with_params(true).and_return('file') }
+    it { is_expected.to run.with_params('present').and_return('file') }
+    it { is_expected.to run.with_params(false).and_return('absent') }
+    it { is_expected.to run.with_params('absent').and_return('absent') }
+  end
+
+  context 'raise an argument error with incorrect parameter' do
+    [
+      '',
+      ' ',
+      'someweirdstuff',
+      'true',
+      'false',
+      {},
+      [],
+      [''],
+      [' '],
+    ].each do |ensure_param|
+      it { is_expected.to run.with_params(ensure_param).and_raise_error(ArgumentError) }
+    end
+  end
+end

--- a/spec/functions/ensure_link_spec.rb
+++ b/spec/functions/ensure_link_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'ensure_link' do
+  context 'return :link or :absent with correct parameter' do
+    it { is_expected.to run.with_params(true).and_return('link') }
+    it { is_expected.to run.with_params('present').and_return('link') }
+    it { is_expected.to run.with_params(false).and_return('absent') }
+    it { is_expected.to run.with_params('absent').and_return('absent') }
+  end
+
+  context 'raise an argument error with incorrect parameter' do
+    [
+      '',
+      ' ',
+      'someweirdstuff',
+      'true',
+      'false',
+      {},
+      [],
+      [''],
+      [' '],
+    ].each do |ensure_param|
+      it { is_expected.to run.with_params(ensure_param).and_raise_error(ArgumentError) }
+    end
+  end
+end

--- a/spec/functions/ensure_present_spec.rb
+++ b/spec/functions/ensure_present_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'ensure_present' do
+  context 'return :present or :absent when passed a Boolean' do
+    it { is_expected.to run.with_params(true).and_return('present') }
+    it { is_expected.to run.with_params(false).and_return('absent') }
+  end
+
+  context 'raise an argument error with incorrect parameter' do
+    [
+      :present,
+      :absent,
+      '',
+      ' ',
+      'someweirdstuff',
+      'true',
+      'false',
+      {},
+      [],
+      [''],
+      [' '],
+    ].each do |ensure_param|
+      it { is_expected.to run.with_params(ensure_param).and_raise_error(ArgumentError) }
+    end
+  end
+end


### PR DESCRIPTION
After seeing lots of these

```puppet
if $ensure == present {
  $ensure_directory = directory
} else {
  $ensure_directory = absent
}

file { '/somedir':
  ensure => $ensure_directory,
}
```

I decided to implement helper functions and abstract this logic away.

Usage is as follows:

```puppet
file { '/somedir':
  ensure => ensure_directory($ensure),
}

file { '/somedir/somelink':
  ensure => ensure_link($ensure),
}
```