### PR TITLE
(WIP) (MAINT) Test Travis bundler fail theory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache: bundler
 script: "bundle exec rake release_checks"
 #Inserting below due to the following issue: https://github.com/travis-ci/travis-ci/issues/3531#issuecomment-88311203
 before_install:
-  - gem update bundler
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
As discussed in MODULES-6339, there are some ongoing problems
with Travis, bundler, and ruby versions. This commit is
an experiment to see what versions of bundler come with
which images and to determine whether or not we can remove
the update line or if we should pin to a particular version.