### PR TITLE
Handle join_keys_to_values() with undef values.

### DIFF
--- a/lib/puppet/parser/functions/join_keys_to_values.rb
+++ b/lib/puppet/parser/functions/join_keys_to_values.rb
@@ -41,6 +41,8 @@ module Puppet::Parser::Functions
     hash.map { |k, v|
       if v.is_a?(Array)
         v.map { |va| String(k) + separator + String(va) }
+      elsif String(v) == 'undef'
+        String(k)
       else
         String(k) + separator + String(v)
       end


### PR DESCRIPTION
support flags
```
gitlab_ci_runners_defaults:
  tag-list: 'custom'
  run-untagged:
  executor: 'shell'
```
(gitlab module joins on space)
would become:
`--tag-list custom --run-untagged --executor shell`

the `--run-untagged` does not accept values.

Because puppet and hieradata returns string values i had to use `String(v) == "undef"`.  
I couldn't get it to work with `not defined?(v)` or `v.nil?`.