### PR TITLE
get rid of fixnum|bignum deprecation warning

### DIFF
--- a/lib/puppet/parser/functions/type3x.rb
+++ b/lib/puppet/parser/functions/type3x.rb
@@ -21,7 +21,7 @@ module Puppet::Parser::Functions
 
     klass = value.class
 
-    unless [TrueClass, FalseClass, Array, Bignum, Fixnum, Float, Hash, String].include?(klass) # rubocop:disable Lint/UnifiedInteger
+    unless %w[TrueClass FalseClass Array Bignum Fixnum Float Hash String].include?(klass.to_s)
       raise(Puppet::ParseError, 'type3x(): Unknown type')
     end
 


### PR DESCRIPTION
stdlib/lib/puppet/parser/functions/type3x.rb:25: warning: constant ::Fixnum is deprecated
stdlib/lib/puppet/parser/functions/type3x.rb:25: warning: constant ::Bignum is deprecated