### PR TITLE
Allow pick() to work with strict variables

### DIFF
--- a/lib/puppet/parser/functions/pick.rb
+++ b/lib/puppet/parser/functions/pick.rb
@@ -24,13 +24,12 @@ module Puppet::Parser::Functions
 
 DOC
              ) do |args|
-    args = args.compact
-               
-    # look up the values of any strings that look like '$variables'
-    args.map! do |item|
-      next unless item.is_a? String
+    # look up the values of any strings that look like '$variables' w/o mutating args
+    args = args.map do |item|
+      next item unless item.is_a? String
       item.start_with?('$') ? call_function('getvar', [item.slice(1..-1)]) : item
     end
+    args.compact!
     args.delete(:undef)
     args.delete(:undefined)
     args.delete('')

--- a/lib/puppet/parser/functions/pick.rb
+++ b/lib/puppet/parser/functions/pick.rb
@@ -15,9 +15,22 @@ module Puppet::Parser::Functions
     called 'jenkins_version' (note that parameters set in the Puppet Dashboard/
     Enterprise Console are brought into Puppet as top-scope variables), and,
     failing that, will use a default value of 1.449.
+
+    If you have `strict_variables` turned on, then wrap your variable in single
+    quotes to prevent interpolation and this function will check to see if that
+    variable exists.
+
+      $real_jenkins_version = pick('$::jenkins_version', '1.449')
+
 DOC
              ) do |args|
-    args = args.compact
+
+    # look up the values of any strings that look like '$variables'
+    args.map! do |item|
+      next unless item.is_a? String
+      item.start_with?('$') ? function_getvar([item.slice(1..-1)]) : item
+    end
+    args.compact!
     args.delete(:undef)
     args.delete(:undefined)
     args.delete('')

--- a/lib/puppet/parser/functions/pick.rb
+++ b/lib/puppet/parser/functions/pick.rb
@@ -24,13 +24,13 @@ module Puppet::Parser::Functions
 
 DOC
              ) do |args|
-
+    args = args.compact
+               
     # look up the values of any strings that look like '$variables'
     args.map! do |item|
       next unless item.is_a? String
       item.start_with?('$') ? call_function('getvar', [item.slice(1..-1)]) : item
     end
-    args.compact!
     args.delete(:undef)
     args.delete(:undefined)
     args.delete('')

--- a/lib/puppet/parser/functions/pick.rb
+++ b/lib/puppet/parser/functions/pick.rb
@@ -28,7 +28,7 @@ DOC
     # look up the values of any strings that look like '$variables'
     args.map! do |item|
       next unless item.is_a? String
-      item.start_with?('$') ? function_getvar([item.slice(1..-1)]) : item
+      item.start_with?('$') ? call_function('getvar', [item.slice(1..-1)]) : item
     end
     args.compact!
     args.delete(:undef)

--- a/spec/functions/pick_spec.rb
+++ b/spec/functions/pick_spec.rb
@@ -9,6 +9,9 @@ describe 'pick' do
   it { is_expected.to run.with_params(:undef, 'two').and_return('two') }
   it { is_expected.to run.with_params(:undefined, 'two').and_return('two') }
   it { is_expected.to run.with_params(nil, 'two').and_return('two') }
+  it { is_expected.to run.with_params('$foo', 'two').and_return('two') }
+  it { is_expected.to run.with_params('$puppetversion', 'two').and_return(Puppet.version) }
+  it { is_expected.to run.with_params('$::puppetversion', 'two').and_return(Puppet.version) }
 
   context 'with UTF8 and double byte characters' do
     it { is_expected.to run.with_params(nil, 'このテキスト').and_return('このテキスト') }


### PR DESCRIPTION
If `strict_variables` is enabled, then the standard usage of `pick()`
will fail. This simply adds the calling convention that strings that
look like variables will be resolved if they exist and ignored if they
don't.