### PR TITLE
(maint) - Revert "get rid of fixnum|bignum deprecation warning"

### DIFF
--- a/lib/puppet/parser/functions/type3x.rb
+++ b/lib/puppet/parser/functions/type3x.rb
@@ -21,7 +21,7 @@ module Puppet::Parser::Functions
 
     klass = value.class
 
-    unless %w[TrueClass FalseClass Array Bignum Fixnum Float Hash String].include?(klass.to_s)
+    unless [TrueClass, FalseClass, Array, Bignum, Fixnum, Float, Hash, String].include?(klass) # rubocop:disable Lint/UnifiedInteger
       raise(Puppet::ParseError, 'type3x(): Unknown type')
     end
 


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-stdlib#875

@tuxmea I would just like to thank you for taking the time to make this change. However as an oversight from our end we are only testing on Puppet4 and this change breaks tests on Puppet5. This is something that we are currently looking into rectifying. Apologies for the revert, but again thank you for taking the time to contribute it is really appreciated. 

The Modules Team.