### PR TITLE
(MODULES-6881) - Removing duplication in .sync.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,68 +1,42 @@
 ---
-sudo: false
-dist: trusty
-language: ruby
-cache: bundler
-before_install:
-  - bundle -v
-  - rm Gemfile.lock || true
-  - gem update --system
-  - gem update bundler
-  - gem --version
-  - bundle -v
-script:
-  - 'bundle exec rake $CHECK'
-bundler_args: --without system_tests
-rvm:
-  - 2.4.1
-env:
-  - PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
-matrix:
-  fast_finish: true
-  include:
-    -
-      bundler_args: 
-      dist: trusty
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7
-      rvm: 2.4.1
-      script: bundle exec rake beaker
-      services: docker
-      sudo: required
-    -
-      bundler_args: 
-      dist: trusty
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04
-      rvm: 2.4.1
-      script: bundle exec rake beaker
-      services: docker
-      sudo: required
-    -
-      env: CHECK=rubocop
-    -
-      env: CHECK="syntax lint"
-    -
-      env: CHECK=metadata_lint
-    -
-      env: CHECK=spec
-    -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
-      rvm: 2.1.9
-    -
-      env: CHECK=release_checks
-      rvm: 2.1.9
-branches:
-  only:
-    - master
-    - /^v\d/
+.travis.yml:
+  docker_sets:
+    - set: docker/centos-7
+    - set: docker/ubuntu-14.04
+  docker_defaults:
+    bundler_args: ""
+  secure: ""
+  branches:
     - release
-notifications:
-  email: false
-deploy:
-  provider: puppetforge
-  user: puppet
-  password:
-    secure: ""
-  on:
-    tags: true
-    all_branches: true
-    condition: "$DEPLOY_TO_FORGE = yes"
+extras:
+  - env: CHECK=release_checks
+    rvm: 2.1.9
+
+Gemfile:
+  required:
+    ':system_tests':
+      - gem: 'puppet-module-posix-system-r#{minor_version}'
+        platforms: ruby
+      - gem: 'puppet-module-win-system-r#{minor_version}'
+        platforms:
+          - mswin
+          - mingw
+          - x64_mingw
+      - gem: beaker
+        version: '~> 3.13'
+        from_env: BEAKER_VERSION
+      - gem: beaker-abs
+        from_env: BEAKER_ABS_VERSION
+        version: '~> 0.1'
+      - gem: beaker-pe
+      - gem: beaker-hostgenerator
+        from_env: BEAKER_HOSTGENERATOR_VERSION
+      - gem: beaker-rspec
+        from_env: BEAKER_RSPEC_VERSION
+Rakefile:
+  requires:
+    - puppet-lint/tasks/puppet-lint
+
+.rubocop.yml:
+  default_configs:
+    inherit_from: .rubocop_todo.yml


### PR DESCRIPTION
```extras:
  - env: CHECK=release_checks
    rvm: 2.1.9
```

release_checks is included in the pdk template however it runs against ruby 2.4.1 instead of ruby 2.1.9. With this config, release_checks runs against ruby 2.1.9.