### PR TITLE
(MODULES-7024) Add 20-octet MAC addresses

### DIFF
--- a/lib/puppet/parser/functions/is_mac_address.rb
+++ b/lib/puppet/parser/functions/is_mac_address.rb
@@ -14,6 +14,7 @@ module Puppet::Parser::Functions
     mac = arguments[0]
 
     return true if %r{^[a-f0-9]{1,2}(:[a-f0-9]{1,2}){5}$}i =~ mac
+    return true if %r{^[a-f0-9]{1,2}(:[a-f0-9]{1,2}){19}$}i =~ mac
     return false
   end
 end

--- a/spec/acceptance/is_mac_address_spec.rb
+++ b/spec/acceptance/is_mac_address_spec.rb
@@ -29,6 +29,20 @@ describe 'is_mac_address function' do
         expect(r.stdout).to match(%r{Notice: output correct})
       end
     end
+
+    pp3 = <<-DOC
+      $a = '80:00:02:09:fe:80:00:00:00:00:00:00:00:24:65:ff:ff:91:a3:12'
+      $b = true
+      $o = is_mac_address($a)
+      if $o == $b {
+        notify { 'output correct': }
+      }
+    DOC
+    it 'is_mac_addresss a 20-octet mac' do
+      apply_manifest(pp3, :catch_failures => true) do |r|
+        expect(r.stdout).to match(%r{Notice: output correct})
+      end
+    end
   end
   describe 'failure' do
     it 'handles improper argument counts'

--- a/spec/functions/is_mac_address_spec.rb
+++ b/spec/functions/is_mac_address_spec.rb
@@ -6,6 +6,7 @@ describe 'is_mac_address' do
   it { is_expected.to run.with_params([], []).and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   it { is_expected.to run.with_params('00:a0:1f:12:7f:a0').and_return(true) }
   it { is_expected.to run.with_params('00:A0:1F:12:7F:A0').and_return(true) }
+  it { is_expected.to run.with_params('80:00:02:09:fe:80:00:00:00:00:00:00:00:24:65:ff:ff:91:a3:12').and_return(true) }
   it { is_expected.to run.with_params('00:00:00:00:00:0g').and_return(false) }
   it { is_expected.to run.with_params('').and_return(false) }
   it { is_expected.to run.with_params('one').and_return(false) }

--- a/types/mac.pp
+++ b/types/mac.pp
@@ -1,2 +1,5 @@
 # A type for a MAC address
-type Stdlib::MAC = Pattern[/^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$/]
+type Stdlib::MAC = Pattern[
+  /^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$/,
+  /^([0-9A-Fa-f]{2}[:-]){19}([0-9A-Fa-f]{2})$/
+]


### PR DESCRIPTION
Not quite sure if the best thing is to extend the MAC matcher, but since the 20-octet hardware address is the exact same format it feels like a good start.