### PR TITLE
Update documentation of reject() function to mention filter() function

### DIFF
--- a/lib/puppet/parser/functions/reject.rb
+++ b/lib/puppet/parser/functions/reject.rb
@@ -13,6 +13,11 @@ module Puppet::Parser::Functions
     Would return:
 
         ['bbb','ccc']
+    
+    This function performs the equivalent of using the more general
+    Puppet filter() function as shown in the following example:
+    
+        ['aaa', 'bbb', 'ccc', 'aaaddd'].filter |$x| { $x !~ /aaa/ }
 DOC
 
     if args.size != 2


### PR DESCRIPTION
People finding the reject function may need to perform other types of rejection than using a regexp (which only works on strings).
For that reason it is worth including a small example using filter().