### PR TITLE
Add support for symbolic file modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,14 +299,14 @@ Unacceptable input example:
 
 Matches acceptable ensure values for service resources.
 
-Acceptable input examples:    
+Acceptable input examples:
 
 ```shell
 stopped
 running
 ```
 
-Unacceptable input example:   
+Unacceptable input example:
 
 ```shell
 true
@@ -371,7 +371,7 @@ C:/whatever
 
 #### `Stdlib::Filemode`
 
-Matches valid four digit modes in octal format.
+Matches octal file modes consisting of 1 to 4 numbers and symbolic file modes.
 
 Acceptable input examples:
 
@@ -383,10 +383,14 @@ Acceptable input examples:
 1777
 ```
 
+```shell
+a=Xr,g=w
+```
+
 Unacceptable input examples:
 
 ```shell
-644
+x=r,a=wx
 ```
 
 ```shell

--- a/spec/type_aliases/filemode_spec.rb
+++ b/spec/type_aliases/filemode_spec.rb
@@ -1,9 +1,28 @@
+# coding: utf-8
+
 require 'spec_helper'
 
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'Stdlib::Filemode' do
     describe 'valid modes' do
-      ['0644', '1644', '2644', '4644', '0123', '0777'].each do |value|
+      [
+        '7',
+        '12',
+        '666',
+
+        '0000',
+        '0644',
+        '1644',
+        '2644',
+        '4644',
+        '0123',
+        '0777',
+
+        'a=,o-r,u+X,g=w',
+        'a=Xr,+0',
+        'u=rwx,g+rX',
+        'u+s,g-s',
+      ].each do |value|
         describe value.inspect do
           it { is_expected.to allow_value(value) }
         end
@@ -13,6 +32,9 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
     describe 'invalid modes' do
       context 'with garbage inputs' do
         [
+          true,
+          false,
+          :keyword,
           nil,
           [nil],
           [nil, nil],
@@ -20,14 +42,12 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
           {},
           '',
           'ネット',
-          '644',
-          '7777',
-          '1',
-          '22',
-          '333',
           '55555',
           '0x123',
           '0649',
+
+          '=8,X',
+          'x=r,a=wx',
         ].each do |value|
           describe value.inspect do
             it { is_expected.not_to allow_value(value) }

--- a/types/filemode.pp
+++ b/types/filemode.pp
@@ -1,1 +1,2 @@
-type Stdlib::Filemode = Pattern[/^[0124]{1}[0-7]{3}$/]
+# See `man chmod.1` for the regular expression for symbolic mode
+type Stdlib::Filemode = Pattern[/^(([0-7]{1,4})|(([ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=][0-7]+)(,([ugoa]*([-+=]([rwxXst]*|[ugo]))+|[-+=][0-7]+))*))$/]


### PR DESCRIPTION
Also add tests for symbolic file modes, and fix an error in the previous
regex (the first digit was limited to values `[0124]`).