### PR TITLE
(PUP-8605) - Update acceptance tests and README for size function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1969,6 +1969,8 @@ Randomizes the order of a string or array elements.
 
 #### `size`
 
+**Deprecated:** This function will be replaced with a built-in `size` function as of Puppet 6.0.0.
+
 Returns the number of elements in a string, an array or a hash. This function will be deprecated in a future release. For Puppet 4, use the `length` function.
 
 *Type*: rvalue.

--- a/spec/acceptance/size_spec.rb
+++ b/spec/acceptance/size_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'size function' do
+describe 'size function', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   describe 'success' do
     pp1 = <<-DOC
       $a = 'discombobulate'


### PR DESCRIPTION
This fix is required as the size function has been put into puppet from puppet 6.0.0. The function in puppet 6 and greater will take precendence over the one in stdlib therefore our tests are no longer relevant for versions of puppet 6 and above.

I have tested this function locally to ensure that the tests continue to run on versions less than puppet 6.0.0 and no longer run on versions 6.0.0.

I can confirms tests continue to run on puppet versions less than puppet 6.0.0 and no longer run on puppet version 6.0.0.

```
=>  5: describe 'size function', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
     6:   describe 'success' do
     7:     pp1 = <<-DOC
     8:       $a = 'discombobulate'
     9:       $o = size($a)
    10:       notice(inline_template('size is <%= @o.inspect %>'))

[1] pry(main)> Puppet::Util::Package
=> Puppet::Util::Package
[2] pry(main)> Puppet.version
=> "5.5.1"
[3] pry(main)> Puppet.version = '6.0.0'
=> "6.0.0"
[4] pry(main)> exit
No examples found.
Destroying vagrant boxes
```