### PR TITLE
(maint) - Skip sort when puppet agent is version 6 or greater

### DIFF
--- a/spec/acceptance/size_spec.rb
+++ b/spec/acceptance/size_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'size function', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'size function', :if => Puppet::Util::Package.versioncmp(return_puppet_version, '6.0.0') < 0 do
   describe 'success' do
     pp1 = <<-DOC
       $a = 'discombobulate'


### PR DESCRIPTION
This function will be present in core puppet from version 6.0.0 and later.