### PR TITLE
Revert "Allow pick() to work with strict variables"

### DIFF
--- a/lib/puppet/parser/functions/pick.rb
+++ b/lib/puppet/parser/functions/pick.rb
@@ -15,21 +15,9 @@ module Puppet::Parser::Functions
     called 'jenkins_version' (note that parameters set in the Puppet Dashboard/
     Enterprise Console are brought into Puppet as top-scope variables), and,
     failing that, will use a default value of 1.449.
-
-    If you have `strict_variables` turned on, then wrap your variable in single
-    quotes to prevent interpolation and this function will check to see if that
-    variable exists.
-
-      $real_jenkins_version = pick('$::jenkins_version', '1.449')
-
 DOC
              ) do |args|
-    # look up the values of any strings that look like '$variables' w/o mutating args
-    args = args.map do |item|
-      next item unless item.is_a? String
-      item.start_with?('$') ? call_function('getvar', [item.slice(1..-1)]) : item
-    end
-    args.compact!
+    args = args.compact
     args.delete(:undef)
     args.delete(:undefined)
     args.delete('')

--- a/spec/functions/pick_spec.rb
+++ b/spec/functions/pick_spec.rb
@@ -9,9 +9,6 @@ describe 'pick' do
   it { is_expected.to run.with_params(:undef, 'two').and_return('two') }
   it { is_expected.to run.with_params(:undefined, 'two').and_return('two') }
   it { is_expected.to run.with_params(nil, 'two').and_return('two') }
-  it { is_expected.to run.with_params('$foo', 'two').and_return('two') }
-  it { is_expected.to run.with_params('$puppetversion', 'two').and_return(Puppet.version) }
-  it { is_expected.to run.with_params('$::puppetversion', 'two').and_return(Puppet.version) }
 
   context 'with UTF8 and double byte characters' do
     it { is_expected.to run.with_params(nil, 'このテキスト').and_return('このテキスト') }


### PR DESCRIPTION
This reverts commit 2a493adcd01ece80cb70fab004e2fb8b01261775.

This change was not backwards compatible. If a user was using pick with
a string that include a $, it would be evaluated and could throw an
error.

See https://bugs.launchpad.net/tripleo/+bug/1778201