### PR TITLE
Make any2array return empty array on empty string

### DIFF
--- a/lib/puppet/parser/functions/any2array.rb
+++ b/lib/puppet/parser/functions/any2array.rb
@@ -32,6 +32,7 @@ module Puppet::Parser::Functions
 
     return arguments unless arguments.length == 1
     return arguments[0] if arguments[0].is_a?(Array)
+    return [] if arguments == ['']
     if arguments[0].is_a?(Hash)
       result = []
       arguments[0].each do |key, value|

--- a/spec/functions/any2array_spec.rb
+++ b/spec/functions/any2array_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'any2array' do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_return([]) }
+  it { is_expected.to run.with_params('').and_return([]) }
   it { is_expected.to run.with_params(true).and_return([true]) }
   it { is_expected.to run.with_params('one').and_return(['one']) }
   it { is_expected.to run.with_params('one', 'two').and_return(['one', 'two']) }


### PR DESCRIPTION
any2array currently returns an array containing the empty string, when
given the empty string.

Example:
```
any2array('').each |$e| {
  notice('I\'m not empty!')
}
```

This is counter intuitive, as Puppet considers the empty string as
Strings nil value, for which the equivalent Array is the empty array.

This especially apparent when doing a lookup in a map with a non
existing key.

Example:
```
$config = {}
any2array($config['test']).each |$e| {
  notice('I\'m not empty!')
}
```

Both these cases print the string `I'm not empty`, this PR fixes that.