### PR TITLE
(maint) Add deprecation call to `sprintf_hash`

### DIFF
--- a/lib/puppet/functions/sprintf_hash.rb
+++ b/lib/puppet/functions/sprintf_hash.rb
@@ -27,6 +27,8 @@ Puppet::Functions.create_function(:sprintf_hash) do
   end
 
   def sprintf_hash(format, arguments)
+    call_function('deprecation', 'sprintf_hash', 'This method is deprecated. From Puppet 4.10.10/5.3.4 please use the built-in sprintf instead')
+
     Kernel.sprintf(format, Hash[arguments.map { |(k, v)| [k.to_sym, v] }])
   end
 end


### PR DESCRIPTION
The functions was already documented as being deprecated but an actual
call was missing. This commit adds a call.

Note that the sprintf_hash function is a 4.x function and therefore uses
call_function (all other functions use the deprecated `function_<name>`
convention. They also send Ruby Symbol as the name of the function.