### PR TITLE
(MODULES-7768) Handle nil in delete_undef_values() function

### DIFF
--- a/lib/puppet/parser/functions/delete_undef_values.rb
+++ b/lib/puppet/parser/functions/delete_undef_values.rb
@@ -30,9 +30,10 @@ module Puppet::Parser::Functions
     end
     result = args[0].dup
     if result.is_a?(Hash)
-      result.delete_if { |_key, val| val.equal? :undef }
+      result.delete_if { |_, val| val.equal?(:undef) || val.nil? }
     elsif result.is_a?(Array)
       result.delete :undef
+      result.delete nil
     end
     result
   end

--- a/spec/functions/delete_undef_values_spec.rb
+++ b/spec/functions/delete_undef_values_spec.rb
@@ -12,7 +12,6 @@ describe 'delete_undef_values' do
       describe "when undef is represented by #{undef_value.inspect}" do
         before(:each) do
           pending("review behaviour when being passed undef as #{undef_value.inspect}") if undef_value == ''
-          pending("review behaviour when being passed undef as #{undef_value.inspect}") if undef_value.nil?
         end
         it { is_expected.to run.with_params([undef_value]).and_return([]) }
         it { is_expected.to run.with_params(['one', undef_value, 'two', 'three']).and_return(['one', 'two', 'three']) }
@@ -35,7 +34,6 @@ describe 'delete_undef_values' do
       describe "when undef is represented by #{undef_value.inspect}" do
         before(:each) do
           pending("review behaviour when being passed undef as #{undef_value.inspect}") if undef_value == ''
-          pending("review behaviour when being passed undef as #{undef_value.inspect}") if undef_value.nil?
         end
         it { is_expected.to run.with_params('key' => undef_value).and_return({}) }
         it {


### PR DESCRIPTION
PUP-9112 changed use of `:undef` inside structured values to instead
using `nil` in Puppet 6.0.0. The `delete_undef_values()` function
was not prepared to handle this and would not delete `nil` from
`Array` or `Hash` values.

This commit fixes this problem.

All 3.x functions in stdlib were reviewed for the same problem, and only `delete_undef_values()` had this problem.