### PR TITLE
Fix `pick` function docs

### DIFF
--- a/lib/puppet/parser/functions/pick.rb
+++ b/lib/puppet/parser/functions/pick.rb
@@ -4,10 +4,9 @@
 module Puppet::Parser::Functions
   newfunction(:pick, :type => :rvalue, :doc => <<-DOC
     This function is similar to a coalesce function in SQL in that it will return
-    the first value in a list of values that is not undefined or an empty string
-    (two things in Puppet that will return a boolean false value). Typically,
-    this function is used to check for a value in the Puppet Dashboard/Enterprise
-    Console, and failover to a default value like the following:
+    the first value in a list of values that is not undefined or an empty string.
+    Typically, this function is used to check for a value in the Puppet
+    Dashboard/Enterprise Console, and failover to a default value like the following:
 
       $real_jenkins_version = pick($::jenkins_version, '1.449')
 

--- a/lib/puppet/parser/functions/pick_default.rb
+++ b/lib/puppet/parser/functions/pick_default.rb
@@ -5,8 +5,7 @@ module Puppet::Parser::Functions
   newfunction(:pick_default, :type => :rvalue, :doc => <<-DOC
     This function is similar to a coalesce function in SQL in that it will return
     the first value in a list of values that is not undefined or an empty string
-    (two things in Puppet that will return a boolean false value). If no value is
-    found, it will return the last argument.
+    If no value is found, it will return the last argument.
 
     Typically, this function is used to check for a value in the Puppet
     Dashboard/Enterprise Console, and failover to a default value like the


### PR DESCRIPTION
In puppet, (since version 4 or 3 with future parser), the only values
that are falsey are `undef` and `false`.