### PR TITLE
(FM-7388) Fix failing tests on Puppet 6

### DIFF
--- a/spec/functions/abs_spec.rb
+++ b/spec/functions/abs_spec.rb
@@ -12,6 +12,10 @@ describe 'abs', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0')
   end
 
   describe 'signature validation in puppet4', :if => RSpec.configuration.puppet_future do
+    before(:each) do
+      pending('does not raise error on versions before Puppet 6.0.0') if Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0
+    end
+
     it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
     it { is_expected.to run.with_params(1, 2).and_raise_error(ArgumentError) }
     it { is_expected.to run.with_params([]).and_raise_error(ArgumentError) }

--- a/spec/functions/abs_spec.rb
+++ b/spec/functions/abs_spec.rb
@@ -12,26 +12,11 @@ describe 'abs', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0')
   end
 
   describe 'signature validation in puppet4', :if => RSpec.configuration.puppet_future do
-    it {
-      pending 'the puppet 4 implementation'
-      is_expected.to run.with_params.and_raise_error(ArgumentError)
-    }
-    it {
-      pending 'the puppet 4 implementation'
-      is_expected.to run.with_params(1, 2).and_raise_error(ArgumentError)
-    }
-    it {
-      pending 'the puppet 4 implementation'
-      is_expected.to run.with_params([]).and_raise_error(ArgumentError)
-    }
-    it {
-      pending 'the puppet 4 implementation'
-      is_expected.to run.with_params({}).and_raise_error(ArgumentError)
-    }
-    it {
-      pending 'the puppet 4 implementation'
-      is_expected.to run.with_params(true).and_raise_error(ArgumentError)
-    }
+    it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
+    it { is_expected.to run.with_params(1, 2).and_raise_error(ArgumentError) }
+    it { is_expected.to run.with_params([]).and_raise_error(ArgumentError) }
+    it { is_expected.to run.with_params({}).and_raise_error(ArgumentError) }
+    it { is_expected.to run.with_params(true).and_raise_error(ArgumentError) }
   end
 
   it { is_expected.to run.with_params(-34).and_return(34) }

--- a/spec/functions/concat_spec.rb
+++ b/spec/functions/concat_spec.rb
@@ -20,7 +20,7 @@ describe 'concat' do
   arguments = [['1', '2', '3'], ['4', '5', '6']]
   originals = [arguments[0].dup, arguments[1].dup]
   it 'leaves the original array intact' do
-    _result = subject.call([arguments[0], arguments[1]])
+    _result = subject.execute(arguments[0], arguments[1])
     arguments.each_with_index do |argument, index|
       expect(argument).to eq(originals[index])
     end

--- a/spec/functions/deep_merge_spec.rb
+++ b/spec/functions/deep_merge_spec.rb
@@ -46,7 +46,7 @@ describe 'deep_merge' do
   arguments = { 'key1' => 'value1' }, { 'key2' => 'value2' }
   originals = [arguments[0].dup, arguments[1].dup]
   it 'does not change the original hashes' do
-    subject.call([arguments[0], arguments[1]])
+    subject.execute(arguments[0], arguments[1])
     arguments.each_with_index do |argument, index|
       expect(argument).to eq(originals[index])
     end

--- a/spec/functions/defined_with_params_spec.rb
+++ b/spec/functions/defined_with_params_spec.rb
@@ -35,9 +35,11 @@ describe 'defined_with_params' do
     let :pre_condition do
       'file { "/tmp/a": ensure => present }'
     end
+    let(:is_puppet_6_or_greater) { Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') >= 0 }
+    let(:undef_value) { is_puppet_6_or_greater ? nil : :undef } # even if :undef would work on 6.0.1, :undef should not be used
 
     it { is_expected.to run.with_params('File[/tmp/a]', {}).and_return(true) }
-    it { is_expected.to run.with_params('File[/tmp/a]', 'ensure' => 'present', 'owner' => :undef).and_return(true) }
+    it { is_expected.to run.with_params('File[/tmp/a]', 'ensure' => 'present', 'owner' => undef_value).and_return(true) }
   end
 
   describe 'when the reference is a' do
@@ -53,7 +55,7 @@ describe 'defined_with_params' do
         it 'fails' do
           expect {
             subject.execute(['User[dan]'], {})
-          }.to raise_error ArgumentError, %r{not understood: 'Array'}
+          }.to raise_error(ArgumentError, %r{not understood: 'Array'})
         end
       end
     end
@@ -61,7 +63,7 @@ describe 'defined_with_params' do
 
   describe 'when passed a defined type' do
     let :pre_condition do
-      'test::deftype { "foo": }'
+      'define test::deftype() { } test::deftype { "foo": }'
     end
 
     it { is_expected.to run.with_params('Test::Deftype[foo]', {}).and_return(true) }

--- a/spec/functions/defined_with_params_spec.rb
+++ b/spec/functions/defined_with_params_spec.rb
@@ -52,7 +52,7 @@ describe 'defined_with_params' do
       context 'with array' do
         it 'fails' do
           expect {
-            subject.call([['User[dan]'], {}])
+            subject.execute(['User[dan]'], {})
           }.to raise_error ArgumentError, %r{not understood: 'Array'}
         end
       end

--- a/spec/functions/delete_at_spec.rb
+++ b/spec/functions/delete_at_spec.rb
@@ -23,7 +23,7 @@ describe 'delete_at' do
   it 'leaves the original array intact' do
     argument = [1, 2, 3]
     original = argument.dup
-    _result = subject.call([argument, 2])
+    _result = subject.execute(argument, 2)
     expect(argument).to eq(original)
   end
 end

--- a/spec/functions/delete_regex_spec.rb
+++ b/spec/functions/delete_regex_spec.rb
@@ -44,13 +44,13 @@ describe 'delete_regex' do
   it 'leaves the original array intact' do
     argument1 = ['one', 'two', 'three']
     original1 = argument1.dup
-    subject.call([argument1, 'two'])
+    subject.execute(argument1, 'two')
     expect(argument1).to eq(original1)
   end
   it 'leaves the original hash intact' do
     argument1 = { 'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3' }
     original1 = argument1.dup
-    subject.call([argument1, 'key2'])
+    subject.execute(argument1, 'key2')
     expect(argument1).to eq(original1)
   end
 end

--- a/spec/functions/delete_spec.rb
+++ b/spec/functions/delete_spec.rb
@@ -61,19 +61,19 @@ describe 'delete' do
   it 'leaves the original array intact' do
     argument1 = ['one', 'two', 'three']
     original1 = argument1.dup
-    _result = subject.call([argument1, 'two'])
+    _result = subject.execute(argument1, 'two')
     expect(argument1).to eq(original1)
   end
   it 'leaves the original string intact' do
     argument1 = 'onetwothree'
     original1 = argument1.dup
-    _result = subject.call([argument1, 'two'])
+    _result = subject.execute(argument1, 'two')
     expect(argument1).to eq(original1)
   end
   it 'leaves the original hash intact' do
     argument1 = { 'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3' }
     original1 = argument1.dup
-    _result = subject.call([argument1, 'key2'])
+    _result = subject.execute(argument1, 'key2')
     expect(argument1).to eq(original1)
   end
 end

--- a/spec/functions/delete_undef_values_spec.rb
+++ b/spec/functions/delete_undef_values_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
 describe 'delete_undef_values' do
+  let(:is_puppet_6) { Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') == 0 }
+
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError) }
   it { is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError) }
   it { is_expected.to run.with_params('one').and_raise_error(Puppet::ParseError) }
   it { is_expected.to run.with_params('one', 'two').and_raise_error(Puppet::ParseError) }
 
-  # Behavior is different in Puppet 6.0.0, and fixed in PUP-9180 in Puppet 6.0.1
-  let(:is_puppet_6) { Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') == 0 }
-
   describe 'when deleting from an array' do
+    # Behavior is different in Puppet 6.0.0, and fixed in PUP-9180 in Puppet 6.0.1
     [:undef, '', nil].each do |undef_value|
       describe "when undef is represented by #{undef_value.inspect}" do
         before(:each) do

--- a/spec/functions/delete_undef_values_spec.rb
+++ b/spec/functions/delete_undef_values_spec.rb
@@ -7,11 +7,15 @@ describe 'delete_undef_values' do
   it { is_expected.to run.with_params('one').and_raise_error(Puppet::ParseError) }
   it { is_expected.to run.with_params('one', 'two').and_raise_error(Puppet::ParseError) }
 
+  # Behavior is different in Puppet 6.0.0, and fixed in PUP-9180 in Puppet 6.0.1
+  let(:is_puppet_6) { Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') == 0 }
+
   describe 'when deleting from an array' do
     [:undef, '', nil].each do |undef_value|
       describe "when undef is represented by #{undef_value.inspect}" do
         before(:each) do
           pending("review behaviour when being passed undef as #{undef_value.inspect}") if undef_value == ''
+          pending("review behaviour when being passed undef as #{undef_value.inspect}") if undef_value == :undef && is_puppet_6
         end
         it { is_expected.to run.with_params([undef_value]).and_return([]) }
         it { is_expected.to run.with_params(['one', undef_value, 'two', 'three']).and_return(['one', 'two', 'three']) }
@@ -21,7 +25,7 @@ describe 'delete_undef_values' do
       it 'leaves the original argument intact' do
         argument = ['one', undef_value, 'two']
         original = argument.dup
-        _result = subject.call([argument, 2])
+        _result = subject.execute(argument, 2)
         expect(argument).to eq(original)
       end
     end
@@ -34,6 +38,7 @@ describe 'delete_undef_values' do
       describe "when undef is represented by #{undef_value.inspect}" do
         before(:each) do
           pending("review behaviour when being passed undef as #{undef_value.inspect}") if undef_value == ''
+          pending("review behaviour when being passed undef as #{undef_value.inspect}") if undef_value == :undef && is_puppet_6
         end
         it { is_expected.to run.with_params('key' => undef_value).and_return({}) }
         it {
@@ -46,7 +51,7 @@ describe 'delete_undef_values' do
       it 'leaves the original argument intact' do
         argument = { 'key1' => 'value1', 'key2' => undef_value }
         original = argument.dup
-        _result = subject.call([argument, 2])
+        _result = subject.execute(argument, 2)
         expect(argument).to eq(original)
       end
     end

--- a/spec/functions/delete_values_spec.rb
+++ b/spec/functions/delete_values_spec.rb
@@ -39,7 +39,7 @@ describe 'delete_values' do
   it 'leaves the original argument intact' do
     argument = { 'key1' => 'value1', 'key2' => 'value2' }
     original = argument.dup
-    _result = subject.call([argument, 'value2'])
+    _result = subject.execute(argument, 'value2')
     expect(argument).to eq(original)
   end
 end

--- a/spec/functions/dig44_spec.rb
+++ b/spec/functions/dig44_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'dig44' do
+  let(:undef_value) do
+    Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 ? :undef : nil
+  end
+
   let(:data) do
     {
       'a' => {
@@ -19,7 +23,7 @@ describe 'dig44' do
       'b' => true,
       'c' => false,
       'd' => '1',
-      'e' => :undef,
+      'e' => undef_value,
       'f' => nil,
     }
   end

--- a/spec/functions/dig44_spec.rb
+++ b/spec/functions/dig44_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'dig44' do
   let(:undef_value) do
-    Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 ? :undef : nil
+    (Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0) ? :undef : nil
   end
 
   let(:data) do

--- a/spec/functions/ensure_packages_spec.rb
+++ b/spec/functions/ensure_packages_spec.rb
@@ -18,7 +18,7 @@ describe 'ensure_packages' do
     let(:pre_condition) { 'package { puppet: ensure => absent }' }
 
     describe 'after running ensure_package("facter")' do
-      before(:each) { subject.call(['facter']) }
+      before(:each) { subject.execute('facter') }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_package('puppet').with_ensure('absent') }
@@ -26,7 +26,7 @@ describe 'ensure_packages' do
     end
 
     describe 'after running ensure_package("facter", { "provider" => "gem" })' do
-      before(:each) { subject.call(['facter', { 'provider' => 'gem' }]) }
+      before(:each) { subject.execute('facter', { 'provider' => 'gem' }) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_package('puppet').with_ensure('absent').without_provider }
@@ -44,9 +44,9 @@ describe 'ensure_packages' do
 
   context 'when given hash of packages' do
     before(:each) do
-      subject.call([{ 'foo' => { 'provider' => 'rpm' }, 'bar' => { 'provider' => 'gem' } }, { 'ensure' => 'present' }])
-      subject.call([{ 'パッケージ' => { 'ensure' => 'absent' } }])
-      subject.call([{ 'ρǻ¢κầģẻ' => { 'ensure' => 'absent' } }])
+      subject.execute({ 'foo' => { 'provider' => 'rpm' }, 'bar' => { 'provider' => 'gem' } }, { 'ensure' => 'present' })
+      subject.execute({ 'パッケージ' => { 'ensure' => 'absent' } })
+      subject.execute({ 'ρǻ¢κầģẻ' => { 'ensure' => 'absent' } })
     end
 
     # this lambda is required due to strangeness within rspec-puppet's expectation handling
@@ -63,7 +63,7 @@ describe 'ensure_packages' do
     let(:pre_condition) { 'package { puppet: ensure => present }' }
 
     describe 'after running ensure_package("puppet", { "ensure" => "installed" })' do
-      before(:each) { subject.call(['puppet', { 'ensure' => 'installed' }]) }
+      before(:each) { subject.execute('puppet', { 'ensure' => 'installed' }) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_package('puppet').with_ensure('present') }

--- a/spec/functions/ensure_packages_spec.rb
+++ b/spec/functions/ensure_packages_spec.rb
@@ -26,7 +26,7 @@ describe 'ensure_packages' do
     end
 
     describe 'after running ensure_package("facter", { "provider" => "gem" })' do
-      before(:each) { subject.execute('facter', { 'provider' => 'gem' }) }
+      before(:each) { subject.execute('facter', 'provider' => 'gem') }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_package('puppet').with_ensure('absent').without_provider }
@@ -44,9 +44,9 @@ describe 'ensure_packages' do
 
   context 'when given hash of packages' do
     before(:each) do
-      subject.execute({ 'foo' => { 'provider' => 'rpm' }, 'bar' => { 'provider' => 'gem' } }, { 'ensure' => 'present' })
-      subject.execute({ 'パッケージ' => { 'ensure' => 'absent' } })
-      subject.execute({ 'ρǻ¢κầģẻ' => { 'ensure' => 'absent' } })
+      subject.execute({ 'foo' => { 'provider' => 'rpm' }, 'bar' => { 'provider' => 'gem' } }, 'ensure' => 'present')
+      subject.execute('パッケージ' => { 'ensure' => 'absent' })
+      subject.execute('ρǻ¢κầģẻ' => { 'ensure' => 'absent' })
     end
 
     # this lambda is required due to strangeness within rspec-puppet's expectation handling
@@ -63,7 +63,7 @@ describe 'ensure_packages' do
     let(:pre_condition) { 'package { puppet: ensure => present }' }
 
     describe 'after running ensure_package("puppet", { "ensure" => "installed" })' do
-      before(:each) { subject.execute('puppet', { 'ensure' => 'installed' }) }
+      before(:each) { subject.execute('puppet', 'ensure' => 'installed') }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_package('puppet').with_ensure('present') }

--- a/spec/functions/ensure_resource_spec.rb
+++ b/spec/functions/ensure_resource_spec.rb
@@ -24,7 +24,7 @@ describe 'ensure_resource' do
     end
 
     describe 'after running ensure_resource("user", "username1", { gid => undef })' do
-      before(:each) { subject.execute('User', 'username1', { 'gid' => undef_value() }) }
+      before(:each) { subject.execute('User', 'username1', 'gid' => undef_value) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('username1').without_ensure }
@@ -32,7 +32,7 @@ describe 'ensure_resource' do
     end
 
     describe 'after running ensure_resource("user", "username1", { ensure => present, gid => undef })' do
-      before(:each) { subject.execute('User', 'username1', { 'ensure' => 'present', 'gid' => undef_value() }) }
+      before(:each) { subject.execute('User', 'username1', 'ensure' => 'present', 'gid' => undef_value) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('username1').with_ensure('present') }
@@ -41,6 +41,7 @@ describe 'ensure_resource' do
 
     describe 'after running ensure_resource("test::deftype", "foo", {})' do
       let(:pre_condition) { 'define test::deftype { }' }
+
       before(:each) { subject.execute('test::deftype', 'foo', {}) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
@@ -57,7 +58,7 @@ describe 'ensure_resource' do
     end
 
     describe 'after running ensure_resource("user", "Şắოрŀễ Ţë×ť", { gid => undef })' do
-      before(:each) { subject.execute('User', 'Şắოрŀễ Ţë×ť', { 'gid' => undef_value() }) }
+      before(:each) { subject.execute('User', 'Şắოрŀễ Ţë×ť', 'gid' => undef_value) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('Şắოрŀễ Ţë×ť').without_ensure }
@@ -65,7 +66,7 @@ describe 'ensure_resource' do
     end
 
     describe 'after running ensure_resource("user", "Şắოрŀễ Ţë×ť", { ensure => present, gid => undef })' do
-      before(:each) { subject.execute('User', 'Şắოрŀễ Ţë×ť', { 'ensure' => 'present', 'gid' => undef_value() }) }
+      before(:each) { subject.execute('User', 'Şắოрŀễ Ţë×ť', 'ensure' => 'present', 'gid' => undef_value) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('Şắოрŀễ Ţë×ť').with_ensure('present') }
@@ -92,7 +93,7 @@ describe 'ensure_resource' do
     end
 
     describe 'after running ensure_resource("user", "username1", { gid => undef })' do
-      before(:each) { subject.execute('User', 'username1', { 'gid' => undef_value() }) }
+      before(:each) { subject.execute('User', 'username1', 'gid' => undef_value) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('username1').with_ensure('present') }

--- a/spec/functions/ensure_resource_spec.rb
+++ b/spec/functions/ensure_resource_spec.rb
@@ -17,14 +17,14 @@ describe 'ensure_resource' do
 
   context 'when given an empty catalog' do
     describe 'after running ensure_resource("user", "username1", {})' do
-      before(:each) { subject.call(['User', 'username1', {}]) }
+      before(:each) { subject.execute('User', 'username1', {}) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('username1').without_ensure }
     end
 
     describe 'after running ensure_resource("user", "username1", { gid => undef })' do
-      before(:each) { subject.call(['User', 'username1', { 'gid' => :undef }]) }
+      before(:each) { subject.execute('User', 'username1', { 'gid' => undef_value() }) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('username1').without_ensure }
@@ -32,7 +32,7 @@ describe 'ensure_resource' do
     end
 
     describe 'after running ensure_resource("user", "username1", { ensure => present, gid => undef })' do
-      before(:each) { subject.call(['User', 'username1', { 'ensure' => 'present', 'gid' => :undef }]) }
+      before(:each) { subject.execute('User', 'username1', { 'ensure' => 'present', 'gid' => undef_value() }) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('username1').with_ensure('present') }
@@ -40,7 +40,8 @@ describe 'ensure_resource' do
     end
 
     describe 'after running ensure_resource("test::deftype", "foo", {})' do
-      before(:each) { subject.call(['test::deftype', 'foo', {}]) }
+      let(:pre_condition) { 'define test::deftype { }' }
+      before(:each) { subject.execute('test::deftype', 'foo', {}) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_test__deftype('foo').without_ensure }
@@ -49,14 +50,14 @@ describe 'ensure_resource' do
 
   context 'when given a catalog with UTF8 chars' do
     describe 'after running ensure_resource("user", "Şắოрŀễ Ţë×ť", {})' do
-      before(:each) { subject.call(['User', 'Şắოрŀễ Ţë×ť', {}]) }
+      before(:each) { subject.execute('User', 'Şắოрŀễ Ţë×ť', {}) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('Şắოрŀễ Ţë×ť').without_ensure }
     end
 
     describe 'after running ensure_resource("user", "Şắოрŀễ Ţë×ť", { gid => undef })' do
-      before(:each) { subject.call(['User', 'Şắოрŀễ Ţë×ť', { 'gid' => :undef }]) }
+      before(:each) { subject.execute('User', 'Şắოрŀễ Ţë×ť', { 'gid' => undef_value() }) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('Şắოрŀễ Ţë×ť').without_ensure }
@@ -64,7 +65,7 @@ describe 'ensure_resource' do
     end
 
     describe 'after running ensure_resource("user", "Şắოрŀễ Ţë×ť", { ensure => present, gid => undef })' do
-      before(:each) { subject.call(['User', 'Şắოрŀễ Ţë×ť', { 'ensure' => 'present', 'gid' => :undef }]) }
+      before(:each) { subject.execute('User', 'Şắოрŀễ Ţë×ť', { 'ensure' => 'present', 'gid' => undef_value() }) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('Şắოрŀễ Ţë×ť').with_ensure('present') }
@@ -76,14 +77,14 @@ describe 'ensure_resource' do
     let(:pre_condition) { 'user { username1: ensure => present }' }
 
     describe 'after running ensure_resource("user", "username1", {})' do
-      before(:each) { subject.call(['User', 'username1', {}]) }
+      before(:each) { subject.execute('User', 'username1', {}) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('username1').with_ensure('present') }
     end
 
     describe 'after running ensure_resource("user", "username2", {})' do
-      before(:each) { subject.call(['User', 'username2', {}]) }
+      before(:each) { subject.execute('User', 'username2', {}) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('username1').with_ensure('present') }
@@ -91,14 +92,14 @@ describe 'ensure_resource' do
     end
 
     describe 'after running ensure_resource("user", "username1", { gid => undef })' do
-      before(:each) { subject.call(['User', 'username1', { 'gid' => :undef }]) }
+      before(:each) { subject.execute('User', 'username1', { 'gid' => undef_value() }) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('username1').with_ensure('present') }
     end
 
     describe 'after running ensure_resource("user", ["username1", "username2"], {})' do
-      before(:each) { subject.call(['User', ['username1', 'username2'], {}]) }
+      before(:each) { subject.execute('User', ['username1', 'username2'], {}) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('username1').with_ensure('present') }
@@ -108,7 +109,7 @@ describe 'ensure_resource' do
     describe 'when providing already set params' do
       let(:params) { { 'ensure' => 'present' } }
 
-      before(:each) { subject.call(['User', ['username2', 'username3'], params]) }
+      before(:each) { subject.execute('User', ['username2', 'username3'], params) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_user('username1').with(params) }
@@ -125,13 +126,23 @@ describe 'ensure_resource' do
   end
 
   context 'when given a catalog with "test::deftype { foo: }"' do
-    let(:pre_condition) { 'test::deftype { "foo": }' }
+    let(:pre_condition) { 'define test::deftype { } test::deftype { "foo": }' }
 
     describe 'after running ensure_resource("test::deftype", "foo", {})' do
-      before(:each) { subject.call(['test::deftype', 'foo', {}]) }
+      before(:each) { subject.execute('test::deftype', 'foo', {}) }
 
       # this lambda is required due to strangeness within rspec-puppet's expectation handling
       it { expect(-> { catalogue }).to contain_test__deftype('foo').without_ensure }
+    end
+  end
+
+  if Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0
+    def undef_value
+      :undef
+    end
+  else
+    def undef_value
+      nil
     end
   end
 end

--- a/spec/functions/ensure_resources_spec.rb
+++ b/spec/functions/ensure_resources_spec.rb
@@ -6,8 +6,9 @@ describe 'ensure_resources' do
   it { is_expected.to run.with_params('type').and_raise_error(ArgumentError, %r{Must specify a title}) }
 
   describe 'given a title hash of multiple resources' do
-    before(:each) {
-      subject.execute('user', { 'dan' => { 'gid' => 'mygroup', 'uid' => '600' }, 'alex' => { 'gid' => 'mygroup', 'uid' => '700' } }, { 'ensure' => 'present' }) }
+    before(:each) do
+      subject.execute('user', { 'dan' => { 'gid' => 'mygroup', 'uid' => '600' }, 'alex' => { 'gid' => 'mygroup', 'uid' => '700' } }, 'ensure' => 'present')
+    end
 
     # this lambda is required due to strangeness within rspec-puppet's expectation handling
     it { expect(-> { catalogue }).to contain_user('dan').with_ensure('present') }
@@ -17,7 +18,7 @@ describe 'ensure_resources' do
   end
 
   describe 'given a title hash of a single resource' do
-    before(:each) { subject.execute('user', { 'dan' => { 'gid' => 'mygroup', 'uid' => '600' } }, { 'ensure' => 'present' }) }
+    before(:each) { subject.execute('user', { 'dan' => { 'gid' => 'mygroup', 'uid' => '600' } }, 'ensure' => 'present') }
 
     # this lambda is required due to strangeness within rspec-puppet's expectation handling
     it { expect(-> { catalogue }).to contain_user('dan').with_ensure('present') }

--- a/spec/functions/ensure_resources_spec.rb
+++ b/spec/functions/ensure_resources_spec.rb
@@ -6,7 +6,8 @@ describe 'ensure_resources' do
   it { is_expected.to run.with_params('type').and_raise_error(ArgumentError, %r{Must specify a title}) }
 
   describe 'given a title hash of multiple resources' do
-    before(:each) { subject.call(['user', { 'dan' => { 'gid' => 'mygroup', 'uid' => '600' }, 'alex' => { 'gid' => 'mygroup', 'uid' => '700' } }, { 'ensure' => 'present' }]) }
+    before(:each) {
+      subject.execute('user', { 'dan' => { 'gid' => 'mygroup', 'uid' => '600' }, 'alex' => { 'gid' => 'mygroup', 'uid' => '700' } }, { 'ensure' => 'present' }) }
 
     # this lambda is required due to strangeness within rspec-puppet's expectation handling
     it { expect(-> { catalogue }).to contain_user('dan').with_ensure('present') }
@@ -16,7 +17,7 @@ describe 'ensure_resources' do
   end
 
   describe 'given a title hash of a single resource' do
-    before(:each) { subject.call(['user', { 'dan' => { 'gid' => 'mygroup', 'uid' => '600' } }, { 'ensure' => 'present' }]) }
+    before(:each) { subject.execute('user', { 'dan' => { 'gid' => 'mygroup', 'uid' => '600' } }, { 'ensure' => 'present' }) }
 
     # this lambda is required due to strangeness within rspec-puppet's expectation handling
     it { expect(-> { catalogue }).to contain_user('dan').with_ensure('present') }

--- a/spec/functions/getvar_spec.rb
+++ b/spec/functions/getvar_spec.rb
@@ -2,10 +2,19 @@ require 'spec_helper'
 
 describe 'getvar' do
   it { is_expected.not_to eq(nil) }
-  it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
-  it { is_expected.to run.with_params('one', 'two').and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
 
-  it { is_expected.to run.with_params('$::foo').and_return(nil) }
+  describe 'before Puppet 6.0.0', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+    it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
+    it { is_expected.to run.with_params('one', 'two').and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
+  end
+
+  describe 'from Puppet 6.0.0',:if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') >= 0 do
+    it { is_expected.to run.with_params.and_raise_error(ArgumentError, %r{expects between 1 and 2 arguments, got none}i) }
+    it { is_expected.to run.with_params('one', 'two').and_return('two') }
+    it { is_expected.to run.with_params('one', 'two', 'three').and_raise_error(ArgumentError, %r{expects between 1 and 2 arguments, got 3}i) }
+  end
+
+  it { is_expected.to run.with_params('::foo').and_return(nil) }
 
   context 'with given variables in namespaces' do
     let(:pre_condition) do

--- a/spec/functions/getvar_spec.rb
+++ b/spec/functions/getvar_spec.rb
@@ -8,7 +8,7 @@ describe 'getvar' do
     it { is_expected.to run.with_params('one', 'two').and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   end
 
-  describe 'from Puppet 6.0.0',:if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') >= 0 do
+  describe 'from Puppet 6.0.0', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') >= 0 do
     it { is_expected.to run.with_params.and_raise_error(ArgumentError, %r{expects between 1 and 2 arguments, got none}i) }
     it { is_expected.to run.with_params('one', 'two').and_return('two') }
     it { is_expected.to run.with_params('one', 'two', 'three').and_raise_error(ArgumentError, %r{expects between 1 and 2 arguments, got 3}i) }

--- a/spec/functions/join_keys_to_values_spec.rb
+++ b/spec/functions/join_keys_to_values_spec.rb
@@ -19,11 +19,11 @@ describe 'join_keys_to_values' do
 
   it { is_expected.to run.with_params({ 'key' => nil }, ':').and_return(['key:']) }
   it 'runs join_keys_to_values(<hash with multiple keys>, ":") and return the proper array' do
-    result = subject.call([{ 'key1' => 'value1', 'key2' => 'value2' }, ':'])
-    expect(result.sort).to eq(['key1:value1', 'key2:value2'].sort)
+    is_expected.to run.with_params({ 'key1' => 'value1', 'key2' => 'value2' }, ':').and_return(['key1:value1', 'key2:value2'])
   end
+
   it 'runs join_keys_to_values(<hash with array value>, " ") and return the proper array' do
-    result = subject.call([{ 'key1' => 'value1', 'key2' => ['value2', 'value3'] }, ' '])
-    expect(result.sort).to eq(['key1 value1', 'key2 value2', 'key2 value3'].sort)
+    expected_result = ['key1 value1', 'key2 value2', 'key2 value3']
+    is_expected.to run.with_params({ 'key1' => 'value1', 'key2' => ['value2', 'value3'] }, ' ').and_return(expected_result)
   end
 end

--- a/spec/functions/load_module_metadata_spec.rb
+++ b/spec/functions/load_module_metadata_spec.rb
@@ -26,7 +26,7 @@ describe 'load_module_metadata' do
         allow(File).to receive(:exists?).with("#{prefix}/path/to/module/metadata.json").and_return(true)
         allow(File).to receive(:read).with("#{prefix}/path/to/module/metadata.json").and_return('{"name": "spencer-science"}')
 
-        result = subject.call(['science'])
+        result = subject.execute('science')
         expect(result['name']).to eq('spencer-science')
       end
 
@@ -39,7 +39,7 @@ describe 'load_module_metadata' do
       it 'returns nil if user allows empty metadata.json' do
         allow(scope).to receive(:function_get_module_path).with(['science']).and_return("#{prefix}/path/to/module/")
         allow(File).to receive(:exists?).with("#{prefix}/path/to/module/metadata.json").and_return(false)
-        result = subject.call(['science', true])
+        result = subject.execute('science', true)
         expect(result).to eq({})
       end
     end

--- a/spec/functions/pick_default_spec.rb
+++ b/spec/functions/pick_default_spec.rb
@@ -17,10 +17,23 @@ describe 'pick_default' do
       it { is_expected.to run.with_params('ớņệ', value).and_return('ớņệ') }
       it { is_expected.to run.with_params([], value).and_return([]) }
       it { is_expected.to run.with_params({}, value).and_return({}) }
-      it { is_expected.to run.with_params(value, value).and_return(value) }
-      it { is_expected.to run.with_params(:undef, value).and_return(value) }
-      it { is_expected.to run.with_params(:undefined, value).and_return(value) }
-      it { is_expected.to run.with_params(nil, value).and_return(value) }
+      it { is_expected.to run.with_params(value, value).and_return(mapped_value(value)) }
+      it { is_expected.to run.with_params(:undef, value).and_return(mapped_value(value)) }
+      it { is_expected.to run.with_params(:undefined, value).and_return(mapped_value(value)) }
+      it { is_expected.to run.with_params(nil, value).and_return(mapped_value(value)) }
+    end
+  end
+
+  if Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0
+    def mapped_value(v) 
+      v
+    end
+  else
+    def mapped_value(v)
+      # Puppet 6.0.0 will always map arguments the same way as the Puppet Language
+      # even if function is called from Ruby via call_function
+      # The 3x function API expects nil and :undef to be represented as empty string
+      return v.nil? || v == :undef ? '' : v
     end
   end
 end

--- a/spec/functions/pick_default_spec.rb
+++ b/spec/functions/pick_default_spec.rb
@@ -25,7 +25,7 @@ describe 'pick_default' do
   end
 
   if Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0
-    def mapped_value(v) 
+    def mapped_value(v)
       v
     end
   else
@@ -33,7 +33,7 @@ describe 'pick_default' do
       # Puppet 6.0.0 will always map arguments the same way as the Puppet Language
       # even if function is called from Ruby via call_function
       # The 3x function API expects nil and :undef to be represented as empty string
-      return v.nil? || v == :undef ? '' : v
+      (v.nil? || v == :undef) ? '' : v
     end
   end
 end

--- a/spec/functions/private_spec.rb
+++ b/spec/functions/private_spec.rb
@@ -4,7 +4,7 @@ describe 'private' do
   it 'issues a warning' do
     expect(scope).to receive(:warning).with("private() DEPRECATED: This function will cease to function on Puppet 4; please use assert_private() before upgrading to puppet 4 for backwards-compatibility, or migrate to the new parser's typing system.") # rubocop:disable Metrics/LineLength : unable to cut line to required length
     begin
-      subject.execute()
+      subject.execute
     rescue # rubocop:disable Lint/HandleExceptions
       # ignore this
     end
@@ -15,7 +15,7 @@ describe 'private' do
       expect(scope).to receive(:lookupvar).with('module_name').and_return('foo')
       expect(scope).to receive(:lookupvar).with('caller_module_name').and_return('foo')
       expect {
-        subject.execute()
+        subject.execute
       }.not_to raise_error
     end
   end
@@ -36,7 +36,7 @@ describe 'private' do
       expect(scope).to receive(:lookupvar).with('caller_module_name').and_return('bar')
       expect(scope.source).to receive(:name).and_return('foo::baz')
       expect(scope.source).to receive(:type).and_return('hostclass')
-      expect { subject.execute() }.to raise_error(Puppet::ParseError, %r{Class foo::baz is private})
+      expect { subject.execute }.to raise_error(Puppet::ParseError, %r{Class foo::baz is private})
     end
   end
 
@@ -46,7 +46,7 @@ describe 'private' do
       expect(scope).to receive(:lookupvar).with('caller_module_name').and_return('bar')
       expect(scope.source).to receive(:name).and_return('foo::baz')
       expect(scope.source).to receive(:type).and_return('definition')
-      expect { subject.execute() }.to raise_error(Puppet::ParseError, %r{Definition foo::baz is private})
+      expect { subject.execute }.to raise_error(Puppet::ParseError, %r{Definition foo::baz is private})
     end
   end
 end

--- a/spec/functions/private_spec.rb
+++ b/spec/functions/private_spec.rb
@@ -4,7 +4,7 @@ describe 'private' do
   it 'issues a warning' do
     expect(scope).to receive(:warning).with("private() DEPRECATED: This function will cease to function on Puppet 4; please use assert_private() before upgrading to puppet 4 for backwards-compatibility, or migrate to the new parser's typing system.") # rubocop:disable Metrics/LineLength : unable to cut line to required length
     begin
-      subject.call []
+      subject.execute()
     rescue # rubocop:disable Lint/HandleExceptions
       # ignore this
     end
@@ -15,7 +15,7 @@ describe 'private' do
       expect(scope).to receive(:lookupvar).with('module_name').and_return('foo')
       expect(scope).to receive(:lookupvar).with('caller_module_name').and_return('foo')
       expect {
-        subject.call []
+        subject.execute()
       }.not_to raise_error
     end
   end
@@ -25,8 +25,8 @@ describe 'private' do
       expect(scope).to receive(:lookupvar).with('module_name').and_return('foo')
       expect(scope).to receive(:lookupvar).with('caller_module_name').and_return('bar')
       expect {
-        subject.call ['failure message!']
-      }.to raise_error Puppet::ParseError, %r{failure message!}
+        subject.execute('failure message!')
+      }.to raise_error(Puppet::ParseError, %r{failure message!})
     end
   end
 
@@ -36,7 +36,7 @@ describe 'private' do
       expect(scope).to receive(:lookupvar).with('caller_module_name').and_return('bar')
       expect(scope.source).to receive(:name).and_return('foo::baz')
       expect(scope.source).to receive(:type).and_return('hostclass')
-      expect { subject.call [] }.to raise_error Puppet::ParseError, %r{Class foo::baz is private}
+      expect { subject.execute() }.to raise_error(Puppet::ParseError, %r{Class foo::baz is private})
     end
   end
 
@@ -46,7 +46,7 @@ describe 'private' do
       expect(scope).to receive(:lookupvar).with('caller_module_name').and_return('bar')
       expect(scope.source).to receive(:name).and_return('foo::baz')
       expect(scope.source).to receive(:type).and_return('definition')
-      expect { subject.call [] }.to raise_error Puppet::ParseError, %r{Definition foo::baz is private}
+      expect { subject.execute() }.to raise_error(Puppet::ParseError, %r{Definition foo::baz is private})
     end
   end
 end

--- a/spec/functions/reverse_spec.rb
+++ b/spec/functions/reverse_spec.rb
@@ -26,7 +26,7 @@ describe 'reverse' do
   context 'when using a class extending String' do
     it 'calls its reverse method' do
       value = AlsoString.new('asdfghjkl')
-      expect_any_instance_of(AlsoString).to receive(:reverse).and_return("foo")
+      expect_any_instance_of(AlsoString).to receive(:reverse).and_return('foo') # rubocop:disable RSpec/AnyInstance
       expect(subject).to run.with_params(value).and_return('foo')
     end
   end

--- a/spec/functions/reverse_spec.rb
+++ b/spec/functions/reverse_spec.rb
@@ -26,7 +26,7 @@ describe 'reverse' do
   context 'when using a class extending String' do
     it 'calls its reverse method' do
       value = AlsoString.new('asdfghjkl')
-      expect(value).to receive(:reverse).and_return('foo')
+      expect_any_instance_of(AlsoString).to receive(:reverse).and_return("foo")
       expect(subject).to run.with_params(value).and_return('foo')
     end
   end

--- a/spec/functions/size_spec.rb
+++ b/spec/functions/size_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'size' do
+describe 'size', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   it {

--- a/spec/functions/squeeze_spec.rb
+++ b/spec/functions/squeeze_spec.rb
@@ -43,7 +43,7 @@ describe 'squeeze' do
   context 'when using a class extending String' do
     it 'calls its squeeze method' do
       value = AlsoString.new('aaaaaaaaa')
-      expect(value).to receive(:squeeze).and_return('foo')
+      expect_any_instance_of(AlsoString).to receive(:squeeze).and_return("foo")
       expect(subject).to run.with_params(value).and_return('foo')
     end
   end

--- a/spec/functions/squeeze_spec.rb
+++ b/spec/functions/squeeze_spec.rb
@@ -43,7 +43,7 @@ describe 'squeeze' do
   context 'when using a class extending String' do
     it 'calls its squeeze method' do
       value = AlsoString.new('aaaaaaaaa')
-      expect_any_instance_of(AlsoString).to receive(:squeeze).and_return("foo")
+      expect_any_instance_of(AlsoString).to receive(:squeeze).and_return('foo') # rubocop:disable RSpec/AnyInstance
       expect(subject).to run.with_params(value).and_return('foo')
     end
   end


### PR DESCRIPTION
This fixes failing tests for Puppet 6.0.0. There are several causes:

* arguments to functions may be copies of given values - mocking must take that into account
* the rspec_puppet method of calling `subject.call` for a 4x function does not work - the `subject.execute` method should be used instead (the `call` method requires a scope and ends up taking given arguments as the scope - with certain failure as a consequence when called with just arguments).
* it is an error do declare user defined resources that do not exist
* Handling of `undef` is different in Puppet 6.0.0 - calling functions from Ruby will now get the same transformation of arguments as if the call came from the puppet language.
* Tests were marked as pending expecting Puppet to not raise errors for illegal arguments - that problem is fixed with the current combination of rspec_puppet and puppet

This PR also has a few maintenance changes - adding parentheses around calls.

See individual commits for more details regarding the changes made to each failing test.