### PR TITLE
fix ensure_packages duplicate checking

### DIFF
--- a/lib/puppet/parser/functions/ensure_packages.rb
+++ b/lib/puppet/parser/functions/ensure_packages.rb
@@ -39,9 +39,7 @@ module Puppet::Parser::Functions
       Puppet::Parser::Functions.function(:ensure_resource)
       packages.each do |package_name|
         raise(Puppet::ParseError, 'ensure_packages(): Empty String provided for package name') if package_name.empty?
-        unless findresource("Package[#{package_name}]")
-          function_ensure_resource(['package', package_name, defaults])
-        end
+        function_ensure_resource(['package', package_name, defaults])
       end
     end
   end


### PR DESCRIPTION
Instead of just looking for an already existing package resource with
the same name, we should check for the parameters, too. Otherwise having
one ensure_packages call with ensure => present and one with ensure =>
absent leads to the second function call being ignored. It should throw
a duplicate declaration error instead.

Since we are already calling ensure_resource internally and
ensure_resource itself does check for duplicates, we don't need that
extra check in ensure_packages.