### PR TITLE
(MODULES-8404) - Relax `Stdlib::Filesource` type

### DIFF
--- a/spec/type_aliases/filesource_spec.rb
+++ b/spec/type_aliases/filesource_spec.rb
@@ -3,9 +3,30 @@ require 'spec_helper'
 if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'Stdlib::Filesource' do
     describe 'valid handling' do
-      ['https://hello.com', 'https://notcreative.org', 'https://canstillaccepthttps.co.uk', 'http://anhttp.com', 'http://runningoutofideas.gov', 'file:///hello/bla', 'file:///foo/bar.log',
-       'puppet:///modules/foo/bar.log', 'puppet://pm.example.com/modules/foo/bar.log', 'puppet://192.0.2.1/modules/foo/bar.log', '/usr2/username/bin:/usr/local/bin:/usr/bin:.', 'C:/', 'C:\\',
-       'C:\\WINDOWS\\System32', 'C:/windows/system32', 'X:/foo/bar', 'X:\\foo\\bar', '\\\\host\\windows', '//host/windows', '/var/tmp', '/var/opt/../lib/puppet'].each do |value|
+      [
+        'https://hello.com',
+        'https://notcreative.org',
+        'https://canstillaccepthttps.co.uk',
+        'http://anhttp.com',
+        'http://runningoutofideas.gov',
+        'file:///hello/bla',
+        'file:///foo/bar.log',
+        'puppet:///modules/foo/bar.log',
+        'puppet://pm.example.com/modules/foo/bar.log',
+        'puppet://192.0.2.1/modules/foo/bar.log',
+        '/usr2/username/bin:/usr/local/bin:/usr/bin:.',
+        'C:/',
+        'C:\\',
+        'C:\\WINDOWS\\System32',
+        'C:/windows/system32',
+        'X:/foo/bar',
+        'X:\\foo\\bar',
+        '\\\\host\\windows',
+        '//host/windows',
+        '/var/tmp',
+        '/var/opt/../lib/puppet',
+        'puppet:///a_custom_mount_point/foo/bar/foobar.conf',
+      ].each do |value|
         describe value.inspect do
           it { is_expected.to allow_value(value) }
         end
@@ -25,8 +46,6 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
           '\\Users/hc/wksp/stdlib',
           'C:noslashes',
           '\\var\\tmp',
-          'puppet:///foo/bar.log',
-          'puppet:///pm.example.com/modules/foo/bar.log',
           'puppet://bob@pm.example.com/modules/foo/bar.log',
         ].each do |value|
           describe value.inspect do

--- a/types/filesource.pp
+++ b/types/filesource.pp
@@ -4,6 +4,6 @@ type Stdlib::Filesource = Variant[
   Stdlib::HTTPUrl,
   Pattern[
     /^file:\/\/\/([^\/\0]+(\/)?)+$/,
-    /^puppet:\/\/(([\w-]+\.?)+)?\/modules\/([^\/\0]+(\/)?)+$/,
+    /^puppet:\/\/(([\w-]+\.?)+)?\/([^\/\0]+(\/)?)+$/,
   ],
 ]


### PR DESCRIPTION
The previous regex only supported the special `modules` `puppet:///`
mount point.  Custom mount points should also be accepted.

https://puppet.com/docs/puppet/5.5/file_serving.html#whats-a-mount-point-in-a-puppet-uri