### PR TITLE
(maint) Match HTTP[S]Url case to the actual types

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ true
 false
 ```
 
-#### `Stdlib::Httpsurl`
+#### `Stdlib::HTTPSUrl`
 
 Matches HTTPS URLs. It is a case insensitive match.
 
@@ -341,7 +341,7 @@ Unacceptable input example:
 httds://notquiteright.org`
 ```
 
-#### `Stdlib::Httpurl`
+#### `Stdlib::HTTPUrl`
 
 Matches both HTTPS and HTTP URLs. It is a case insensitive match.
 


### PR DESCRIPTION
In the type the casing is HTTPUrl and HTTPSUrl. This matches the docs to reality.