### PR TITLE
Add a stdlib::ip_in_range() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1399,6 +1399,17 @@ stdlib::extname('.profile')      => ''
 
 *Type*: rvalue.
 
+#### `stdlib::ip_in_range`
+
+A Puppet function to determine if an IPv4 address is within the IPv4 CIDR. Returns true if the ipaddress is within the given CIDRs.
+
+```puppet
+$ranges = ['192.168.0.0/24', '10.10.10.0/24']
+$valid_ip = stdlib::ip_in_range('10.10.10.53', $ranges) # $valid_ip == true
+```
+
+*Type*: rvalue.
+
 #### `fact`
 
 Return the value of a given fact. Supports the use of dot-notation for referring to structured facts. If a fact requested does not exist, returns Undef.

--- a/lib/puppet/functions/stdlib/ip_in_range.rb
+++ b/lib/puppet/functions/stdlib/ip_in_range.rb
@@ -1,0 +1,30 @@
+# Returns true if the ipaddress is within the given CIDRs
+#
+# @example ip_in_range(<IPv4 Address>, <IPv4 CIDR>)
+#   stdlib::ip_in_range('10.10.10.53', '10.10.10.0/24') => true
+Puppet::Functions.create_function(:'stdlib::ip_in_range') do
+  # @param [String] ipaddress The IP address to check
+  # @param [Variant[String, Array]] range One CIDR or an array of CIDRs
+  #   defining the range(s) to check against
+  #
+  # @return [Boolean] True or False
+  dispatch :ip_in_range do
+    param 'String', :ipaddress
+    param 'Variant[String, Array]', :range
+    return_type 'Boolean'
+  end
+
+  require 'ipaddr'
+
+  def ip_in_range(ipaddress, range)
+    ip = IPAddr.new(ipaddress)
+
+    if range.is_a? Array
+      ranges = range.map { |r| IPAddr.new(r) }
+      ranges.any? { |rng| rng.include?(ip) }
+    elsif range.is_a? String
+      ranges = IPAddr.new(range)
+      ranges.include?(ip)
+    end
+  end
+end

--- a/spec/functions/ip_in_range_spec.rb
+++ b/spec/functions/ip_in_range_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'stdlib::ip_in_range' do
+  describe 'signature validation' do
+    it { is_expected.not_to eq(nil) }
+    it { is_expected.to run.with_params.and_raise_error(ArgumentError, %r{'stdlib::ip_in_range' expects 2 arguments, got none}) }
+    it { is_expected.to run.with_params('one', 'two', '3').and_raise_error(ArgumentError, %r{'stdlib::ip_in_range' expects 2 arguments, got 3}) }
+    it { is_expected.to run.with_params([], []).and_raise_error(ArgumentError, %r{'stdlib::ip_in_range' parameter 'ipaddress' expects a String value, got Array}) }
+    it { is_expected.to run.with_params('1.1.1.1', 7).and_raise_error(ArgumentError, %r{'stdlib::ip_in_range' parameter 'range' expects a value of type String or Array, got Integer}) }
+  end
+
+  describe 'basic validation inputs' do
+    it { is_expected.to run.with_params('192.168.100.12', '192.168.100.0/24').and_return(true) }
+    it { is_expected.to run.with_params('192.168.100.12', ['10.10.10.10/24', '192.168.100.0/24']).and_return(true) }
+    it { is_expected.to run.with_params('10.10.10.10', '192.168.100.0/24').and_return(false) }
+  end
+end


### PR DESCRIPTION
It's very useful function from https://github.com/deanwilson/puppet-ip_in_range . Why you haven't include it so far?