### PR TITLE
(MODULES-8732) Cron types

### DIFF
--- a/spec/type_aliases/cron_hour_spec.rb
+++ b/spec/type_aliases/cron_hour_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Stdlib::Cron::Hour' do
+  describe 'accept integers' do
+    [0, 1, 2, 15, 23].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept integers as strings' do
+    ['0', '1', '2', '15', '23'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept ranges' do
+    ['0-23', '0-5', '18-23', '5-11', '19-22'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept step values' do
+    ['0-23/2', '0-23/24', '9-15/3'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept wildcards' do
+    ['*', '*-7', '*/7'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept comma-separated integers, ranges and step values' do
+    ['0,1,2,15,23', '0-5,11-23', '0-11/2,12-23/4', '0,2-5,12-23/2'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept arrays of valid expressions' do
+    [
+      [0, 3, 6, 9, 12, 15, 18, 21],
+      [0, '3', 6, '9', 12, '15', 18, '21'],
+      ['0-5', '18-23'],
+      ['*'],
+      ['*/2', '*/5'],
+      ['*/5', 3],
+      ['0-5', 23],
+      ['*/5', '5-7', 23],
+    ].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'reject leading zeroes in integers and ranges' do
+    ['00', '01', '02', '03', '04', '05', '06', '07', '08', '09', '0-01', '0,1,02'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject leading zeroes in step values' do
+    ['*/01', '*/02', '*/03', '*/04', '*/05', '*/06', '*/07', '*/08', '*/09'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject out of range integers' do
+    [-1, '-1', 24, '24', '0-24', '0-24/5', '*/0', '*/25', '-1,0,1', '22,23,24'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject incorrect values' do
+    ['', [], [''], '1,', '1,2,', '*/*', 'foo'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+end

--- a/spec/type_aliases/cron_minute_spec.rb
+++ b/spec/type_aliases/cron_minute_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Stdlib::Cron::Minute' do
+  describe 'accept integers' do
+    [0, 1, 2, 15, 27, 34, 59].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept integers as strings' do
+    ['0', '1', '2', '15', '27', '34', '59'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept ranges' do
+    ['0-59', '0-15', '30-59', '45-55'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept step values' do
+    ['0-59/2', '0-59/60', '30-59/3'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept wildcards' do
+    ['*', '*-15', '*/15'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept comma-separated integers, ranges and step values' do
+    ['0,5,10,15', '0-5,15-59', '0-29/2,30-59/3', '0,5-10,30-59/2'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept arrays of valid expressions' do
+    [
+      [0, 12, 24, 36, 48],
+      [0, '12', 24, '36', 48],
+      ['0-25', '30-59'],
+      ['*'],
+      ['*/2', '*/5'],
+      ['*/5', 7],
+      ['0-30', 59],
+      ['*/5', '6-9', 59],
+    ].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'reject leading zeroes in integers and ranges' do
+    ['00', '01', '02', '03', '04', '05', '06', '07', '08', '09', '0-01', '0,1,02'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject leading zeroes in step values' do
+    ['*/01', '*/02', '*/03', '*/04', '*/05', '*/06', '*/07', '*/08', '*/09'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject out of range integers' do
+    [-1, '-1', 60, '60', '0-60', '0-60/5', '*/0', '*/61', '-1,0,1', '58,59,60'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject incorrect values' do
+    ['', [], [''], '1,', '1,2,', '*/*', 'foo'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+end

--- a/spec/type_aliases/cron_month_spec.rb
+++ b/spec/type_aliases/cron_month_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Stdlib::Cron::Month' do
+  describe 'accept integers' do
+    [1, 2, 5, 10, 12].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept integers as strings' do
+    ['1', '2', '5', '10', '12'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept uppercase month names' do
+    ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept lowercase month names' do
+    ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept ranges' do
+    ['1-12', '1-6', '7-12', '7-10', 'JAN-DEC', 'JAN-JUN', 'JUN-DEC', '1-DEC', 'JAN-12'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept step values' do
+    ['1-12/2', '1-12/12', '7-12/3', 'JAN-DEC/2', 'JAN-12/2', '1-DEC/2'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept wildcards' do
+    ['*', '*-10', '*-OCT', '*/10'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept comma-separated integers, ranges and step values' do
+    ['1,4,8,12', '1-5,6-10', '1-6/2,7-12/3', '1,MAR-APR,8-12/2', 'JAN,MAR-APR,AUG-DEC/2'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept arrays of valid expressions' do
+    [
+      [1, 3, 6, 9, 12],
+      [1, '3', 6, '9', 12],
+      ['1-6', '7-12'],
+      ['JAN', 'mar', 'JUL'],
+      ['*'],
+      ['*/2', '*/4'],
+      ['*/6', 6],
+      ['1-12', 12],
+      ['*/5', '6-9', 12],
+    ].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'reject leading zeroes in integers and ranges' do
+    ['01', '02', '03', '04', '05', '06', '07', '08', '09', '1-02', '1,2,03'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject leading zeroes in step values' do
+    ['*/01', '*/02', '*/03', '*/04', '*/05', '*/06', '*/07', '*/08', '*/09'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject out of range integers' do
+    [0, '0', 13, '13', '0-12', '1-13', '0-12/5', '1-13/5', '*/0', '*/13', '0,1,2', '11,12,13'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject incorrect values' do
+    ['', [], [''], '1,', '1,2,', '*/*', 'foo', 'JANUARY', 'JANJAN', '1-JANJAN'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+end

--- a/spec/type_aliases/cron_monthday_spec.rb
+++ b/spec/type_aliases/cron_monthday_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Stdlib::Cron::Monthday' do
+  describe 'accept integers' do
+    [1, 2, 10, 15, 31].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept integers as strings' do
+    ['1', '2', '10', '15', '31'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept ranges' do
+    ['1-31', '1-15', '15-31', '20-25'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept step values' do
+    ['1-31/2', '1-31/31', '15-31/3'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept wildcards' do
+    ['*', '*-15', '*/15'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept comma-separated integers, ranges and step values' do
+    ['1,8,15,22', '1-7,16-21', '1-15/2,16-31/3', '1,8-15,16-31/2'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept arrays of valid expressions' do
+    [
+      [1, 8, 15, 22, 29],
+      [1, '8', 15, '22', 29],
+      ['1-20', '21-31'],
+      ['*'],
+      ['*/2', '*/7'],
+      ['*/7', 7],
+      ['1-31', 31],
+      ['*/5', '6-9', 31],
+    ].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'reject leading zeroes in integers and ranges' do
+    ['01', '02', '03', '04', '05', '06', '07', '08', '09', '1-02', '1,2,03'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject leading zeroes in step values' do
+    ['*/01', '*/02', '*/03', '*/04', '*/05', '*/06', '*/07', '*/08', '*/09'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject out of range integers' do
+    [0, '0', 32, '32', '0-31', '1-32', '0-31/5', '1-32/5', '*/0', '*/32', '0,1,2', '30,31,32'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject incorrect values' do
+    ['', [], [''], '1,', '1,2,', '*/*', 'foo'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+end

--- a/spec/type_aliases/cron_weekday_spec.rb
+++ b/spec/type_aliases/cron_weekday_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Stdlib::Cron::Weekday' do
+  describe 'accept integers' do
+    [0, 1, 2, 4, 6, 7].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept integers as strings' do
+    ['0', '1', '2', '4', '6', '7'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept uppercase weekday names' do
+    ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept lowercase weekday names' do
+    ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept ranges' do
+    ['0-6', '1-7', '0-3', '4-7', '3-7', 'MON-SUN', 'MON-FRI', 'SAT-SUN', '0-SAT', '1-SUN', 'MON-7'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept step values' do
+    ['0-6/2', '0-6/6', '1-7/7', '3-7/3', 'MON-SUN/2', 'MON-7/2', '1-SUN/2'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept wildcards' do
+    ['*', '*-3', '*-WED', '*/2'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept comma-separated integers, ranges and step values' do
+    ['0,2,4,6', '1,3,5,7', '0-2,4-5', '0-3/2,4-6/2', '1,3-4,6-7/2', '1,WED-THU,SAT-SUN/2'].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'accept arrays of valid expressions' do
+    [
+      [0, 2, 3, 6, 7],
+      [0, '2', 3, '6', 7],
+      ['0-2', '5-7'],
+      ['*'],
+      ['*/2', '*/3'],
+      ['*/7', 7],
+      ['0-6', 6],
+      ['1-7', 7],
+      ['*/5', '3-5', 7],
+    ].each do |value|
+      it { is_expected.to allow_value(value) }
+    end
+  end
+  describe 'reject leading zeroes in integers and ranges' do
+    ['00', '01', '02', '03', '04', '05', '06', '07', '0-02', '0,1,02'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject leading zeroes in step values' do
+    ['*/00', '*/01', '*/02', '*/03', '*/04', '*/05', '*/06', '*/07'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject out of range integers' do
+    [-1, '-1', 8, '8', '0-8', '0-8/5', '*/-1', '*/8', '-1,0,1', '6,7,8'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+  describe 'reject incorrect values' do
+    ['', [], [''], '1,', '1,2,', '*/*', 'foo'].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+end

--- a/types/cron/hour.pp
+++ b/types/cron/hour.pp
@@ -1,0 +1,28 @@
+# Cron hour type. Accepts integer, string or an array of integers and/or strings.
+#
+# The regex matches:
+# - Standalone wildcard
+# - Integers 0 through 23, without leading zero
+# - Ranges (eg. 0-23)
+# - Ranges starting with a wildcard, eg. *-7
+# - Step values 1 through 24 (eg. */5 or 0-12/2, vixie cron)
+# - All of the above in comma separated list, eg. 1,3,7-9
+#
+# We are not being opinionated on weird syntaxes to keep the validation KISS.
+# Eg. Vixie cron accepts a surprising amount of syntax that seems pointless (and
+# rightly so) but actually works.
+#
+# NOTES:
+# - Should NOT match trailing commas
+# - Will not prevent greater numbers preceding smaller ones in ranges
+# - Leading zeroes are discouraged because of potential parsing bugs such as:
+#   https://tickets.puppetlabs.com/browse/MODULES-7786
+#
+type Stdlib::Cron::Hour = Variant[
+  Integer[0, 23],
+  Pattern[/^(?<everything>(\*|(?<hours>[0-9]|1[0-9]|2[0-3]))(-(\g<hours>))?(\/([1-9]|1[0-9]|2[0-4]))?)(,(\g<everything>))*$/],
+  Array[Variant[
+    Integer[0, 23],
+    Pattern[/^(?<everything>(\*|(?<hours>[0-9]|1[0-9]|2[0-3]))(-(\g<hours>))?(\/([1-9]|1[0-9]|2[0-4]))?)(,(\g<everything>))*$/]
+  ], 1]
+]

--- a/types/cron/minute.pp
+++ b/types/cron/minute.pp
@@ -1,0 +1,28 @@
+# Cron minute type. Accepts integer, string or an array of integers and/or strings.
+#
+# The regex matches:
+# - Standalone wildcard
+# - Integers 0 through 59, without leading zero
+# - Ranges (eg. 0-59)
+# - Ranges starting with a wildcard, eg. *-7
+# - Step values 1 through 60 (eg. */5 or 0-29/2, vixie cron)
+# - All of the above in comma separated list, eg. 0,15,30-35,45
+#
+# We are not being opinionated on weird syntaxes to keep the validation KISS.
+# Eg. Vixie cron accepts a surprising amount of syntax that seems pointless (and
+# rightly so) but actually works.
+#
+# NOTES:
+# - Should NOT match trailing commas
+# - Will not prevent greater numbers preceding smaller ones in ranges
+# - Leading zeroes are discouraged because of potential parsing bugs such as:
+#   https://tickets.puppetlabs.com/browse/MODULES-7786
+#
+type Stdlib::Cron::Minute = Variant[
+  Integer[0, 59],
+  Pattern[/^(?<everything>(\*|(?<minutes>[0-9]|[1-5][0-9]))(-(\g<minutes>))?(\/([1-9]|[1-5][0-9]|60))?)(,(\g<everything>))*$/],
+  Array[Variant[
+    Integer[0, 59],
+    Pattern[/^(?<everything>(\*|(?<minutes>[0-9]|[1-5][0-9]))(-(\g<minutes>))?(\/([1-9]|[1-5][0-9]|60))?)(,(\g<everything>))*$/]
+  ], 1]
+]

--- a/types/cron/month.pp
+++ b/types/cron/month.pp
@@ -1,0 +1,29 @@
+# Cron month type. Accepts integer, string or an array of integers and/or strings.
+#
+# The regex matches:
+# - Standalone wildcard
+# - Integers 1 through 12, without leading zero
+# - Month abbreviation in place of integers (case insensitive)
+# - Ranges (eg. 1-12 or jan-jun)
+# - Ranges starting with a wildcard, eg. *-7
+# - Step values 1 through 12 (eg. */5 or 1-12/2, vixie cron)
+# - All of the above in comma separated list, eg. 1,3,7-9
+#
+# We are not being opinionated on weird syntaxes to keep the validation KISS.
+# Eg. Vixie cron accepts a surprising amount of syntax that seems pointless (and
+# rightly so) but actually works.
+#
+# NOTES:
+# - Should NOT match trailing commas
+# - Will not prevent greater numbers preceding smaller ones in ranges
+# - Leading zeroes are discouraged because of potential parsing bugs such as:
+#   https://tickets.puppetlabs.com/browse/MODULES-7786
+#
+type Stdlib::Cron::Month = Variant[
+  Integer[1, 12],
+  Pattern[/^(?<everything>(?i)(\*|(?<months>[1-9]|1[0-2]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))(-(\g<months>))?(\/(\g<months>))?)(,(\g<everything>))*$/],
+  Array[Variant[
+    Integer[1, 12],
+    Pattern[/^(?<everything>(?i)(\*|(?<months>[1-9]|1[0-2]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))(-(\g<months>))?(\/(\g<months>))?)(,(\g<everything>))*$/]
+  ], 1]
+]

--- a/types/cron/monthday.pp
+++ b/types/cron/monthday.pp
@@ -1,0 +1,28 @@
+# Cron day of month type. Accepts integer, string or an array of integers and/or strings.
+#
+# The regex matches:
+# - Standalone wildcard
+# - Integers 1 through 31, without leading zero
+# - Ranges (eg. 1-31)
+# - Ranges starting with a wildcard, eg. *-7
+# - Step values 1 through 31 (eg. */5 or 1-12/2, vixie cron)
+# - All of the above in comma separated list, eg. 1,3,7-9
+#
+# We are not being opinionated on weird syntaxes to keep the validation KISS.
+# Eg. Vixie cron accepts a surprising amount of syntax that seems pointless (and
+# rightly so) but actually works.
+#
+# NOTES:
+# - Should NOT match trailing commas
+# - Will not prevent greater numbers preceding smaller ones in ranges
+# - Leading zeroes are discouraged because of potential parsing bugs such as:
+#   https://tickets.puppetlabs.com/browse/MODULES-7786
+#
+type Stdlib::Cron::Monthday = Variant[
+  Integer[1, 31],
+  Pattern[/^(?<everything>(\*|(?<monthdays>[1-9]|[1-2][0-9]|3[0-1]))(-(\g<monthdays>))?(\/(\g<monthdays>))?)(,(\g<everything>))*$/],
+  Array[Variant[
+    Integer[1, 31],
+    Pattern[/^(?<everything>(\*|(?<monthdays>[1-9]|[1-2][0-9]|3[0-1]))(-(\g<monthdays>))?(\/(\g<monthdays>))?)(,(\g<everything>))*$/]
+  ], 1]
+]

--- a/types/cron/weekday.pp
+++ b/types/cron/weekday.pp
@@ -1,0 +1,30 @@
+# Cron day of week type. Accepts integer, string or an array of integers and/or strings.
+#
+# The regex matches:
+# - Standalone wildcard
+# - Integers 0 through 7, without leading zero
+# - Day of week abbreviation in place of integers (case insensitive)
+# - Ranges (eg. 0-4 or mon-fri)
+# - Ranges starting with a wildcard, eg. *-7 (but who would ever use these)
+# - Step values 0 through 7 (eg. */5 or 1-4/2, vixie cron)
+# - All of the above in comma separated list, eg. 1,3-5
+#
+# We are not being opinionated on weird syntaxes to keep the validation KISS.
+# Eg. Vixie cron accepts a surprising amount of syntax that seems pointless (and
+# rightly so) but actually works.
+#
+# NOTES:
+# - 0 and 7 are both Sunday, so 0-6 or 1-7 have the same meaning
+# - Should NOT match trailing commas
+# - Will not prevent greater numbers preceding smaller ones in ranges
+# - Leading zeroes are discouraged because of potential parsing bugs such as:
+#   https://tickets.puppetlabs.com/browse/MODULES-7786
+#
+type Stdlib::Cron::Weekday = Variant[
+  Integer[0, 7],
+  Pattern[/^(?<everything>(?i)(\*|(?<weekdays>[0-7]|MON|TUE|WED|THU|FRI|SAT|SUN))(-(\g<weekdays>))?(\/(\g<weekdays>))?)(,(\g<everything>))*$/],
+  Array[Variant[
+    Integer[0, 7],
+    Pattern[/^(?<everything>(?i)(\*|(?<weekdays>[0-7]|MON|TUE|WED|THU|FRI|SAT|SUN))(-(\g<weekdays>))?(\/(\g<weekdays>))?)(,(\g<everything>))*$/]
+  ], 1]
+]


### PR DESCRIPTION
This is a feature request for cron types in stdlib.

I'd like to reason there is a need for good cron datatypes in stdlib that raise the bar when it comes to validating cron parameters.

Some points:

- The cron resource is built-in and is a use case in all Puppet code
- Modules already dependent on stdlib will have these types available without having to depend on other third party modules
- Modules sometimes don't fully support the same datatype combinations the `cron` resource does, eg `Variant[Integer[n,n], String[1], Array[Integer[n,n], String[1]]]`, nor do most of them bother to validate the values of the fields (quite understandably)
- Lacking validation of field values is sometimes made up for in spec tests, when a spec test for each cron type could instead handle invalid values more simply

I've found there are already good cron types in modules like [Vox Pupuli's cron](https://github.com/voxpupuli/puppet-cron/tree/master/types). It would probably be a good idea to not ignore lessons learned while creating them.

This obviously needs a bit more testing, but it works well on vixie cron (CentOS 7) to start. It would be good to find out if `\g` is supported in regexes on all Puppet versions that support types.
