### PR TITLE
Add more ensure types

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,69 @@ Unacceptable input example:
 ../relative_path
 ```
 
+#### `Stdlib::Ensure::File`
+
+Matches acceptable ensure values for file resources.
+
+Acceptable input examples:
+
+```shell
+present
+absent
+file
+directory
+link
+```
+
+Unacceptable input example:
+
+```shell
+true
+false
+```
+#### `Stdlib::Ensure::Package`
+
+Matches acceptable keyword ensure values for package resources. Does **not**
+match package versions; see `Stdlib::Ensure::PackageVersion`.
+
+Acceptable input examples:
+
+```shell
+present
+installed
+absent
+purged
+held
+latest
+```
+
+Unacceptable input example:
+
+```shell
+true
+false
+"v0.2.4"
+```
+#### `Stdlib::Ensure::PackageVersion`
+
+Matches acceptable ensure values for package resources, plus strings and
+`SemVer`.
+
+Acceptable input examples are the ones in `Stdlib::Ensure::Package` and:
+
+```shell
+"v2.5.7"
+"0.2.1"
+"de946be15264ce9736fdfac133ade2eccf4e7b51"
+SemVer('0.4.2')
+```
+
+Unacceptable input example:
+
+```shell
+true
+false
+```
 #### `Stdlib::Ensure::Service`
 
 Matches acceptable ensure values for service resources.

--- a/spec/type_aliases/ensure__package.rb
+++ b/spec/type_aliases/ensure__package.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
+  describe 'Stdlib::Ensure::Package' do
+    describe 'accepts package ensure keywords' do
+      [
+        'present',
+        'absent',
+        'held',
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.to allow_value(value) }
+        end
+      end
+    end
+    describe 'rejects other values' do
+      [
+        'v20.5.2',
+        '2',
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.not_to allow_value(value) }
+        end
+      end
+    end
+  end
+end

--- a/spec/type_aliases/ensure__package_version.rb
+++ b/spec/type_aliases/ensure__package_version.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
+  describe 'Stdlib::Ensure::PackageVersion' do
+    describe 'accepts package ensure keywords and strings' do
+      [
+        'present',
+        'absent',
+        'held',
+        'v20.5.2',
+        '2',
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.to allow_value(value) }
+        end
+      end
+    end
+  end
+end

--- a/types/ensure/file.pp
+++ b/types/ensure/file.pp
@@ -1,0 +1,8 @@
+# https://puppet.com/docs/puppet/latest/type.html#file-attribute-ensure
+type Stdlib::Ensure::File = Enum[
+  'present',
+  'absent',
+  'file',
+  'directory',
+  'link',
+]

--- a/types/ensure/package.pp
+++ b/types/ensure/package.pp
@@ -1,0 +1,9 @@
+# https://puppet.com/docs/puppet/latest/type.html#package-attribute-ensure
+type Stdlib::Ensure::Package = Enum[
+  'present',
+  'installed',
+  'absent',
+  'purged',
+  'held',
+  'latest',
+]

--- a/types/ensure/packageversion.pp
+++ b/types/ensure/packageversion.pp
@@ -1,0 +1,10 @@
+# Same as Stdlib::Ensure::Package, but also allows string versions and SemVer.
+#
+# The reason for having this as a separate type is so that you can choose a type
+# where you always force the package manager to choose (Stdlib::Ensure::Package)
+# if you want to.
+type Stdlib::Ensure::PackageVersion = Variant[
+  Stdlib::Ensure::Package,
+  SemVer,
+  String[1],
+]


### PR DESCRIPTION
Adds the following:

+ `Stdlib::Ensure::File`
+ `Stdlib::Ensure::Package`
+ `Stdlib::Ensure::PackageVersion`
