### PR TITLE
Limit the maximum array size produced by range().

### DIFF
--- a/lib/puppet/parser/functions/range.rb
+++ b/lib/puppet/parser/functions/range.rb
@@ -80,7 +80,7 @@ module Puppet::Parser::Functions
             when '...' then (start...stop) # Exclusive of last element
             end
 
-    result = range.step(step).to_a
+    result = range.step(step).first(1_000_000).to_a
 
     return result
   end


### PR DESCRIPTION
It is trivially easy to accidentally DOS a puppet master by requesting
a range larger than was intended, for example
`range('host00/index.html', 'host25/index.html')`. Because jruby's
implementation of unrolling the range is parallelized, this sort of
thing takes down the whole box.

The solution here is a simple sanity-check on it; we could get fancier
with a new argument specifying a larger size etc. if someone thinks it
needed.