### PR TITLE
fix lib/puppet/parser/functions/fqdn_rand_string.rb:21: syntax error

### DIFF
--- a/lib/puppet/parser/functions/fqdn_rand_string.rb
+++ b/lib/puppet/parser/functions/fqdn_rand_string.rb
@@ -18,7 +18,7 @@ Puppet::Parser::Functions.newfunction(
 
   @example Example Usage:
     fqdn_rand_string(10)
-    fqdn_rand_string(10, 'ABCDEF!@#$%^')
+    fqdn_rand_string(10, 'ABCDEF!@$%^')
     fqdn_rand_string(10, '', 'custom seed')
   DOC
 ) do |args|


### PR DESCRIPTION
```
stdlib/lib/puppet/parser/functions/fqdn_rand_string.rb:21: syntax error, unexpected null
    fqdn_rand_string(10, 'ABCDEF!@#$%^')
                                   ^
```

