### PR TITLE
(MODULES-9432) Remove Style/HashSyntax rubocop rule

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -2,9 +2,5 @@ RSpec/NamedSubject:
   Enabled: false
 Lint/ScriptPermission:
   Enabled: false
-Style/HashSyntax:
-  Exclude:
-  - spec/spec_helper.rb
-  EnforcedStyle: hash_rockets
 Layout/IndentHeredoc:
   Enabled: false

--- a/lib/facter/facter_dot_d.rb
+++ b/lib/facter/facter_dot_d.rb
@@ -134,7 +134,7 @@ class Facter::Util::DotD
   def cache_store(file, data)
     load_cache
 
-    @cache[file] = { :data => data, :stored => Time.now.to_i }
+    @cache[file] = { data: data, stored: Time.now.to_i }
   rescue # rubocop:disable Lint/HandleExceptions
   end
 

--- a/lib/facter/package_provider.rb
+++ b/lib/facter/package_provider.rb
@@ -15,9 +15,9 @@ Facter.add(:package_provider) do
   # Instantiates a dummy package resource and return the provider
   setcode do
     if defined? Gem && Gem::Version.new(Facter.value(:puppetversion).split(' ')[0]) >= Gem::Version.new('3.6')
-      Puppet::Type.type(:package).newpackage(:name => 'dummy', :allow_virtual => 'true')[:provider].to_s
+      Puppet::Type.type(:package).newpackage(name: 'dummy', allow_virtual: 'true')[:provider].to_s
     else
-      Puppet::Type.type(:package).newpackage(:name => 'dummy')[:provider].to_s
+      Puppet::Type.type(:package).newpackage(name: 'dummy')[:provider].to_s
     end
   end
 end

--- a/lib/facter/pe_version.rb
+++ b/lib/facter/pe_version.rb
@@ -34,7 +34,7 @@ end
 
 # Fact: pe_major_version
 Facter.add('pe_major_version') do
-  confine :is_pe => true
+  confine is_pe: true
   setcode do
     pe_version = Facter.value(:pe_version)
     if pe_version
@@ -45,7 +45,7 @@ end
 
 # Fact: pe_minor_version
 Facter.add('pe_minor_version') do
-  confine :is_pe => true
+  confine is_pe: true
   setcode do
     pe_version = Facter.value(:pe_version)
     if pe_version
@@ -56,7 +56,7 @@ end
 
 # Fact: pe_patch_version
 Facter.add('pe_patch_version') do
-  confine :is_pe => true
+  confine is_pe: true
   setcode do
     pe_version = Facter.value(:pe_version)
     if pe_version

--- a/lib/facter/root_home.rb
+++ b/lib/facter/root_home.rb
@@ -21,7 +21,7 @@ Facter.add(:root_home) do
 end
 
 Facter.add(:root_home) do
-  confine :kernel => :darwin
+  confine kernel: :darwin
   setcode do
     str = Facter::Util::Resolution.exec('dscacheutil -q user -a name root')
     hash = {}
@@ -34,7 +34,7 @@ Facter.add(:root_home) do
 end
 
 Facter.add(:root_home) do
-  confine :kernel => :aix
+  confine kernel: :aix
   root_home = nil
   setcode do
     str = Facter::Util::Resolution.exec('lsuser -c -a home root')

--- a/lib/facter/service_provider.rb
+++ b/lib/facter/service_provider.rb
@@ -12,6 +12,6 @@ require 'puppet/type/service'
 
 Facter.add(:service_provider) do
   setcode do
-    Puppet::Type.type(:service).newservice(:name => 'dummy')[:provider].to_s
+    Puppet::Type.type(:service).newservice(name: 'dummy')[:provider].to_s
   end
 end

--- a/lib/puppet/parser/functions/abs.rb
+++ b/lib/puppet/parser/functions/abs.rb
@@ -2,7 +2,7 @@
 # abs.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:abs, :type => :rvalue, :doc => <<-DOC
+  newfunction(:abs, type: :rvalue, doc: <<-DOC
     @summary
       **Deprected:** Returns the absolute value of a number
 

--- a/lib/puppet/parser/functions/any2array.rb
+++ b/lib/puppet/parser/functions/any2array.rb
@@ -2,7 +2,7 @@
 # any2array.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:any2array, :type => :rvalue, :doc => <<-DOC
+  newfunction(:any2array, type: :rvalue, doc: <<-DOC
     @summary
       This converts any object to an array containing that object.
 

--- a/lib/puppet/parser/functions/any2bool.rb
+++ b/lib/puppet/parser/functions/any2bool.rb
@@ -2,7 +2,7 @@
 # any2bool.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:any2bool, :type => :rvalue, :doc => <<-DOC
+  newfunction(:any2bool, type: :rvalue, doc: <<-DOC
     @summary
       Converts 'anything' to a boolean.
 

--- a/lib/puppet/parser/functions/assert_private.rb
+++ b/lib/puppet/parser/functions/assert_private.rb
@@ -2,7 +2,7 @@
 # assert_private.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:assert_private, :doc => <<-DOC
+  newfunction(:assert_private, doc: <<-DOC
     @summary
       Sets the current class or definition as private.
 

--- a/lib/puppet/parser/functions/base64.rb
+++ b/lib/puppet/parser/functions/base64.rb
@@ -1,6 +1,6 @@
 #  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 module Puppet::Parser::Functions
-  newfunction(:base64, :type => :rvalue, :doc => <<-DOC) do |args|
+  newfunction(:base64, type: :rvalue, doc: <<-DOC) do |args|
     @summary
       Base64 encode or decode a string based on the command and the string submitted
 

--- a/lib/puppet/parser/functions/basename.rb
+++ b/lib/puppet/parser/functions/basename.rb
@@ -2,7 +2,7 @@
 # basename.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:basename, :type => :rvalue, :doc => <<-DOC
+  newfunction(:basename, type: :rvalue, doc: <<-DOC
     @summary
       Strips directory (and optional suffix) from a filename
 

--- a/lib/puppet/parser/functions/bool2num.rb
+++ b/lib/puppet/parser/functions/bool2num.rb
@@ -2,7 +2,7 @@
 # bool2num.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:bool2num, :type => :rvalue, :doc => <<-DOC
+  newfunction(:bool2num, type: :rvalue, doc: <<-DOC
     @summary
       Converts a boolean to a number.
 

--- a/lib/puppet/parser/functions/bool2str.rb
+++ b/lib/puppet/parser/functions/bool2str.rb
@@ -2,7 +2,7 @@
 # bool2str.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:bool2str, :type => :rvalue, :doc => <<-DOC
+  newfunction(:bool2str, type: :rvalue, doc: <<-DOC
     @summary
       Converts a boolean to a string using optionally supplied arguments.
 

--- a/lib/puppet/parser/functions/camelcase.rb
+++ b/lib/puppet/parser/functions/camelcase.rb
@@ -3,7 +3,7 @@
 #  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 module Puppet::Parser::Functions
-  newfunction(:camelcase, :type => :rvalue, :doc => <<-DOC
+  newfunction(:camelcase, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated** Converts the case of a string or all strings in an array to camel case.
 

--- a/lib/puppet/parser/functions/capitalize.rb
+++ b/lib/puppet/parser/functions/capitalize.rb
@@ -3,7 +3,7 @@
 #  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 module Puppet::Parser::Functions
-  newfunction(:capitalize, :type => :rvalue, :doc => <<-DOC
+  newfunction(:capitalize, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated** Capitalizes the first letter of a string or array of strings.
 

--- a/lib/puppet/parser/functions/ceiling.rb
+++ b/lib/puppet/parser/functions/ceiling.rb
@@ -2,7 +2,7 @@
 #  ceiling.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:ceiling, :type => :rvalue, :doc => <<-DOC
+  newfunction(:ceiling, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated** Returns the smallest integer greater or equal to the argument.
     Takes a single numeric value as an argument.

--- a/lib/puppet/parser/functions/chomp.rb
+++ b/lib/puppet/parser/functions/chomp.rb
@@ -2,7 +2,7 @@
 #  chomp.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:chomp, :type => :rvalue, :doc => <<-DOC
+  newfunction(:chomp, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated** Removes the record separator from the end of a string or an array of strings.
 

--- a/lib/puppet/parser/functions/chop.rb
+++ b/lib/puppet/parser/functions/chop.rb
@@ -2,7 +2,7 @@
 #  chop.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:chop, :type => :rvalue, :doc => <<-DOC
+  newfunction(:chop, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated** Returns a new string with the last character removed.
 

--- a/lib/puppet/parser/functions/clamp.rb
+++ b/lib/puppet/parser/functions/clamp.rb
@@ -2,7 +2,7 @@
 # clamp.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:clamp, :type => :rvalue, :arity => -2, :doc => <<-DOC
+  newfunction(:clamp, type: :rvalue, arity: -2, doc: <<-DOC
     @summary
       Keeps value within the range [Min, X, Max] by sort based on integer value
       (parameter order doesn't matter).

--- a/lib/puppet/parser/functions/concat.rb
+++ b/lib/puppet/parser/functions/concat.rb
@@ -2,7 +2,7 @@
 # concat.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:concat, :type => :rvalue, :doc => <<-DOC
+  newfunction(:concat, type: :rvalue, doc: <<-DOC
     @summary
       Appends the contents of multiple arrays into array 1.
 

--- a/lib/puppet/parser/functions/convert_base.rb
+++ b/lib/puppet/parser/functions/convert_base.rb
@@ -2,7 +2,7 @@
 # convert_base.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:convert_base, :type => :rvalue, :arity => 2, :doc => <<-'DOC') do |args|
+  newfunction(:convert_base, type: :rvalue, arity: 2, doc: <<-'DOC') do |args|
     @summary
       Converts a given integer or base 10 string representing an integer to a
       specified base, as a string.

--- a/lib/puppet/parser/functions/count.rb
+++ b/lib/puppet/parser/functions/count.rb
@@ -2,7 +2,7 @@
 # count.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:count, :type => :rvalue, :arity => -2, :doc => <<-DOC
+  newfunction(:count, type: :rvalue, arity: -2, doc: <<-DOC
     @summary
       Counts the number of elements in array.
 

--- a/lib/puppet/parser/functions/deep_merge.rb
+++ b/lib/puppet/parser/functions/deep_merge.rb
@@ -2,7 +2,7 @@
 # deep_merge.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:deep_merge, :type => :rvalue, :doc => <<-'DOC') do |args|
+  newfunction(:deep_merge, type: :rvalue, doc: <<-'DOC') do |args|
     @summary
       Recursively merges two or more hashes together and returns the resulting hash.
 

--- a/lib/puppet/parser/functions/defined_with_params.rb
+++ b/lib/puppet/parser/functions/defined_with_params.rb
@@ -2,8 +2,8 @@
 require 'puppet/parser/functions'
 
 Puppet::Parser::Functions.newfunction(:defined_with_params,
-                                      :type => :rvalue,
-                                      :doc => <<-DOC
+                                      type: :rvalue,
+                                      doc: <<-DOC
     @summary
       Takes a resource reference and an optional hash of attributes.
 

--- a/lib/puppet/parser/functions/delete.rb
+++ b/lib/puppet/parser/functions/delete.rb
@@ -2,7 +2,7 @@
 # delete.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:delete, :type => :rvalue, :doc => <<-DOC
+  newfunction(:delete, type: :rvalue, doc: <<-DOC
     @summary
       Deletes all instances of a given element from an array, substring from a
       string, or key from a hash.

--- a/lib/puppet/parser/functions/delete_at.rb
+++ b/lib/puppet/parser/functions/delete_at.rb
@@ -2,7 +2,7 @@
 # delete_at.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:delete_at, :type => :rvalue, :doc => <<-DOC) do |arguments|
+  newfunction(:delete_at, type: :rvalue, doc: <<-DOC) do |arguments|
     @summary
       Deletes a determined indexed value from an array.
 

--- a/lib/puppet/parser/functions/delete_regex.rb
+++ b/lib/puppet/parser/functions/delete_regex.rb
@@ -3,7 +3,7 @@
 #  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 module Puppet::Parser::Functions
-  newfunction(:delete_regex, :type => :rvalue, :doc => <<-DOC
+  newfunction(:delete_regex, type: :rvalue, doc: <<-DOC
     @summary
       Deletes all instances of a given element that match a regular expression
       from an array or key from a hash.

--- a/lib/puppet/parser/functions/delete_undef_values.rb
+++ b/lib/puppet/parser/functions/delete_undef_values.rb
@@ -2,7 +2,7 @@
 # delete_undef_values.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:delete_undef_values, :type => :rvalue, :doc => <<-DOC
+  newfunction(:delete_undef_values, type: :rvalue, doc: <<-DOC
     @summary
       Returns a copy of input hash or array with all undefs deleted.
 

--- a/lib/puppet/parser/functions/delete_values.rb
+++ b/lib/puppet/parser/functions/delete_values.rb
@@ -2,7 +2,7 @@
 # delete_values.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:delete_values, :type => :rvalue, :doc => <<-DOC
+  newfunction(:delete_values, type: :rvalue, doc: <<-DOC
     @summary
       Deletes all instances of a given value from a hash.
 

--- a/lib/puppet/parser/functions/deprecation.rb
+++ b/lib/puppet/parser/functions/deprecation.rb
@@ -2,7 +2,7 @@
 # deprecation.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:deprecation, :doc => <<-DOC
+  newfunction(:deprecation, doc: <<-DOC
   @summary
     Function to print deprecation warnings (this is the 3.X version of it).
 

--- a/lib/puppet/parser/functions/difference.rb
+++ b/lib/puppet/parser/functions/difference.rb
@@ -2,7 +2,7 @@
 # difference.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:difference, :type => :rvalue, :doc => <<-DOC
+  newfunction(:difference, type: :rvalue, doc: <<-DOC
     @summary
       This function returns the difference between two arrays.
 

--- a/lib/puppet/parser/functions/dig.rb
+++ b/lib/puppet/parser/functions/dig.rb
@@ -2,7 +2,7 @@
 # dig.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:dig, :type => :rvalue, :doc => <<-DOC
+  newfunction(:dig, type: :rvalue, doc: <<-DOC
     @summary
       **DEPRECATED** Retrieves a value within multiple layers of hashes and arrays via an
       array of keys containing a path.

--- a/lib/puppet/parser/functions/dig44.rb
+++ b/lib/puppet/parser/functions/dig44.rb
@@ -4,9 +4,9 @@
 module Puppet::Parser::Functions
   newfunction(
     :dig44,
-    :type => :rvalue,
-    :arity => -2,
-    :doc => <<-DOC
+    type: :rvalue,
+    arity: -2,
+    doc: <<-DOC
     @summary
       **DEPRECATED**: Looks up into a complex structure of arrays and hashes and returns a value
       or the default value if nothing was found.

--- a/lib/puppet/parser/functions/dirname.rb
+++ b/lib/puppet/parser/functions/dirname.rb
@@ -2,7 +2,7 @@
 # dirname.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:dirname, :type => :rvalue, :doc => <<-DOC
+  newfunction(:dirname, type: :rvalue, doc: <<-DOC
     @summary
       Returns the dirname of a path.
 

--- a/lib/puppet/parser/functions/dos2unix.rb
+++ b/lib/puppet/parser/functions/dos2unix.rb
@@ -1,6 +1,6 @@
 # Custom Puppet function to convert dos to unix format
 module Puppet::Parser::Functions
-  newfunction(:dos2unix, :type => :rvalue, :arity => 1, :doc => <<-DOC
+  newfunction(:dos2unix, type: :rvalue, arity: 1, doc: <<-DOC
     @summary
       Returns the Unix version of the given string.
 

--- a/lib/puppet/parser/functions/downcase.rb
+++ b/lib/puppet/parser/functions/downcase.rb
@@ -3,7 +3,7 @@
 #  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 module Puppet::Parser::Functions
-  newfunction(:downcase, :type => :rvalue, :doc => <<-DOC
+  newfunction(:downcase, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Converts the case of a string or all strings in an array to lower case.
 

--- a/lib/puppet/parser/functions/empty.rb
+++ b/lib/puppet/parser/functions/empty.rb
@@ -2,7 +2,7 @@
 # empty.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:empty, :type => :rvalue, :doc => <<-DOC
+  newfunction(:empty, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the variable is empty.
 

--- a/lib/puppet/parser/functions/enclose_ipv6.rb
+++ b/lib/puppet/parser/functions/enclose_ipv6.rb
@@ -2,7 +2,7 @@
 # enclose_ipv6.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:enclose_ipv6, :type => :rvalue, :doc => <<-DOC
+  newfunction(:enclose_ipv6, type: :rvalue, doc: <<-DOC
     @summary
       Takes an array of ip addresses and encloses the ipv6 addresses with square brackets.
 

--- a/lib/puppet/parser/functions/ensure_packages.rb
+++ b/lib/puppet/parser/functions/ensure_packages.rb
@@ -2,7 +2,7 @@
 # ensure_packages.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:ensure_packages, :type => :statement, :doc => <<-DOC
+  newfunction(:ensure_packages, type: :statement, doc: <<-DOC
     @summary
       Takes a list of packages and only installs them if they don't already exist.
 

--- a/lib/puppet/parser/functions/ensure_resource.rb
+++ b/lib/puppet/parser/functions/ensure_resource.rb
@@ -2,8 +2,8 @@
 require 'puppet/parser/functions'
 
 Puppet::Parser::Functions.newfunction(:ensure_resource,
-                                      :type => :statement,
-                                      :doc => <<-DOC
+                                      type: :statement,
+                                      doc: <<-DOC
   @summary
     Takes a resource type, title, and a list of attributes that describe a
     resource.

--- a/lib/puppet/parser/functions/ensure_resources.rb
+++ b/lib/puppet/parser/functions/ensure_resources.rb
@@ -1,8 +1,8 @@
 require 'puppet/parser/functions'
 
 Puppet::Parser::Functions.newfunction(:ensure_resources,
-                                      :type => :statement,
-                                      :doc => <<-DOC
+                                      type: :statement,
+                                      doc: <<-DOC
   @summary
     Takes a resource type, title (only hash), and a list of attributes that describe a
     resource.

--- a/lib/puppet/parser/functions/flatten.rb
+++ b/lib/puppet/parser/functions/flatten.rb
@@ -2,7 +2,7 @@
 # flatten.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:flatten, :type => :rvalue, :doc => <<-DOC
+  newfunction(:flatten, type: :rvalue, doc: <<-DOC
     @summary
       This function flattens any deeply nested arrays and returns a single flat array
       as a result.

--- a/lib/puppet/parser/functions/floor.rb
+++ b/lib/puppet/parser/functions/floor.rb
@@ -2,7 +2,7 @@
 # floor.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:floor, :type => :rvalue, :doc => <<-DOC
+  newfunction(:floor, type: :rvalue, doc: <<-DOC
     @summary
       Returns the largest integer less or equal to the argument.
 

--- a/lib/puppet/parser/functions/fqdn_rand_string.rb
+++ b/lib/puppet/parser/functions/fqdn_rand_string.rb
@@ -1,8 +1,8 @@
 Puppet::Parser::Functions.newfunction(
   :fqdn_rand_string,
-  :arity => -2,
-  :type => :rvalue,
-  :doc => <<-DOC
+  arity: -2,
+  type: :rvalue,
+  doc: <<-DOC
   @summary
     Generates a random alphanumeric string. Combining the `$fqdn` fact and an
     optional seed for repeatable randomness.

--- a/lib/puppet/parser/functions/fqdn_rotate.rb
+++ b/lib/puppet/parser/functions/fqdn_rotate.rb
@@ -3,8 +3,8 @@
 #
 Puppet::Parser::Functions.newfunction(
   :fqdn_rotate,
-  :type => :rvalue,
-  :doc => <<-DOC
+  type: :rvalue,
+  doc: <<-DOC
   @summary
     Rotates an array or string a random number of times, combining the `$fqdn` fact
     and an optional seed for repeatable randomness.

--- a/lib/puppet/parser/functions/fqdn_uuid.rb
+++ b/lib/puppet/parser/functions/fqdn_uuid.rb
@@ -3,7 +3,7 @@ require 'digest/sha1'
 # fqdn_uuid.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:fqdn_uuid, :type => :rvalue, :doc => <<-DOC) do |args|
+  newfunction(:fqdn_uuid, type: :rvalue, doc: <<-DOC) do |args|
     @summary
       Returns a [RFC 4122](https://tools.ietf.org/html/rfc4122) valid version 5 UUID based
       on an FQDN string under the DNS namespace

--- a/lib/puppet/parser/functions/get_module_path.rb
+++ b/lib/puppet/parser/functions/get_module_path.rb
@@ -2,7 +2,7 @@
 # get_module_path.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:get_module_path, :type => :rvalue, :doc => <<-DOC
+  newfunction(:get_module_path, type: :rvalue, doc: <<-DOC
     @summary
       Returns the absolute path of the specified module for the current
       environment.

--- a/lib/puppet/parser/functions/getparam.rb
+++ b/lib/puppet/parser/functions/getparam.rb
@@ -2,8 +2,8 @@
 require 'puppet/parser/functions'
 
 Puppet::Parser::Functions.newfunction(:getparam,
-                                      :type => :rvalue,
-                                      :doc => <<-'DOC'
+                                      type: :rvalue,
+                                      doc: <<-'DOC'
     @summary
       Returns the value of a resource's parameter.
 

--- a/lib/puppet/parser/functions/getvar.rb
+++ b/lib/puppet/parser/functions/getvar.rb
@@ -2,7 +2,7 @@
 # getvar.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:getvar, :type => :rvalue, :doc => <<-'DOC') do |args|
+  newfunction(:getvar, type: :rvalue, doc: <<-'DOC') do |args|
     @summary
       Lookup a variable in a given namespace.
 

--- a/lib/puppet/parser/functions/glob.rb
+++ b/lib/puppet/parser/functions/glob.rb
@@ -2,7 +2,7 @@
 #  glob.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:glob, :type => :rvalue, :doc => <<-DOC
+  newfunction(:glob, type: :rvalue, doc: <<-DOC
     @summary
       Uses same patterns as Dir#glob.
 

--- a/lib/puppet/parser/functions/grep.rb
+++ b/lib/puppet/parser/functions/grep.rb
@@ -2,7 +2,7 @@
 # grep.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:grep, :type => :rvalue, :doc => <<-DOC
+  newfunction(:grep, type: :rvalue, doc: <<-DOC
     @summary
       This function searches through an array and returns any elements that match
       the provided regular expression.

--- a/lib/puppet/parser/functions/has_interface_with.rb
+++ b/lib/puppet/parser/functions/has_interface_with.rb
@@ -2,7 +2,7 @@
 # has_interface_with
 #
 module Puppet::Parser::Functions
-  newfunction(:has_interface_with, :type => :rvalue, :doc => <<-DOC
+  newfunction(:has_interface_with, type: :rvalue, doc: <<-DOC
     @summary
       Returns boolean based on kind and value.
 

--- a/lib/puppet/parser/functions/has_ip_address.rb
+++ b/lib/puppet/parser/functions/has_ip_address.rb
@@ -2,7 +2,7 @@
 # has_ip_address
 #
 module Puppet::Parser::Functions
-  newfunction(:has_ip_address, :type => :rvalue, :doc => <<-DOC
+  newfunction(:has_ip_address, type: :rvalue, doc: <<-DOC
     @summary
       Returns true if the client has the requested IP address on some interface.
 

--- a/lib/puppet/parser/functions/has_ip_network.rb
+++ b/lib/puppet/parser/functions/has_ip_network.rb
@@ -2,7 +2,7 @@
 # has_ip_network
 #
 module Puppet::Parser::Functions
-  newfunction(:has_ip_network, :type => :rvalue, :doc => <<-DOC
+  newfunction(:has_ip_network, type: :rvalue, doc: <<-DOC
     @summary
       Returns true if the client has an IP address within the requested network.
 

--- a/lib/puppet/parser/functions/has_key.rb
+++ b/lib/puppet/parser/functions/has_key.rb
@@ -2,7 +2,7 @@
 # has_key.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:has_key, :type => :rvalue, :doc => <<-'DOC') do |args|
+  newfunction(:has_key, type: :rvalue, doc: <<-'DOC') do |args|
     @summary
       **Deprecated:** Determine if a hash has a certain key value.
 

--- a/lib/puppet/parser/functions/hash.rb
+++ b/lib/puppet/parser/functions/hash.rb
@@ -2,7 +2,7 @@
 # hash.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:hash, :type => :rvalue, :doc => <<-DOC
+  newfunction(:hash, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** This function converts an array into a hash.
 

--- a/lib/puppet/parser/functions/intersection.rb
+++ b/lib/puppet/parser/functions/intersection.rb
@@ -2,7 +2,7 @@
 # intersection.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:intersection, :type => :rvalue, :doc => <<-DOC
+  newfunction(:intersection, type: :rvalue, doc: <<-DOC
     @summary
       This function returns an array of the intersection of two.
 

--- a/lib/puppet/parser/functions/is_absolute_path.rb
+++ b/lib/puppet/parser/functions/is_absolute_path.rb
@@ -2,7 +2,7 @@
 # is_absolute_path.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_absolute_path, :type => :rvalue, :arity => 1, :doc => <<-'DOC') do |args|
+  newfunction(:is_absolute_path, type: :rvalue, arity: 1, doc: <<-'DOC') do |args|
     @summary
       **Deprecated:** Returns boolean true if the string represents an absolute path in the filesystem.
 
@@ -49,8 +49,8 @@ module Puppet::Parser::Functions
       slash = '[\\\\/]'
       name = '[^\\\\/]+'
       regexes = {
-        :windows => %r{^(([A-Z]:#{slash})|(#{slash}#{slash}#{name}#{slash}#{name})|(#{slash}#{slash}\?#{slash}#{name}))}i,
-        :posix => %r{^/},
+        windows: %r{^(([A-Z]:#{slash})|(#{slash}#{slash}#{name}#{slash}#{name})|(#{slash}#{slash}\?#{slash}#{name}))}i,
+        posix: %r{^/},
       }
       value = !!(path =~ regexes[:posix]) || !!(path =~ regexes[:windows]) # rubocop:disable Style/DoubleNegation : No alternative known
     end

--- a/lib/puppet/parser/functions/is_array.rb
+++ b/lib/puppet/parser/functions/is_array.rb
@@ -2,7 +2,7 @@
 # is_array.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_array, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_array, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the variable passed to this function is an array.
 

--- a/lib/puppet/parser/functions/is_bool.rb
+++ b/lib/puppet/parser/functions/is_bool.rb
@@ -2,7 +2,7 @@
 # is_bool.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_bool, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_bool, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the variable passed to this function is a boolean.
 

--- a/lib/puppet/parser/functions/is_domain_name.rb
+++ b/lib/puppet/parser/functions/is_domain_name.rb
@@ -2,7 +2,7 @@
 # is_domain_name.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_domain_name, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_domain_name, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the string passed to this function is
       a syntactically correct domain name.

--- a/lib/puppet/parser/functions/is_email_address.rb
+++ b/lib/puppet/parser/functions/is_email_address.rb
@@ -2,7 +2,7 @@
 # is_email_address.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_email_address, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_email_address, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the string passed to this function is a valid email address.
 

--- a/lib/puppet/parser/functions/is_float.rb
+++ b/lib/puppet/parser/functions/is_float.rb
@@ -2,7 +2,7 @@
 # is_float.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_float, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_float, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the variable passed to this function is a float.
 

--- a/lib/puppet/parser/functions/is_function_available.rb
+++ b/lib/puppet/parser/functions/is_function_available.rb
@@ -2,7 +2,7 @@
 # is_function_available.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_function_available, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_function_available, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Determines whether the Puppet runtime has access to a function by that name.
 

--- a/lib/puppet/parser/functions/is_hash.rb
+++ b/lib/puppet/parser/functions/is_hash.rb
@@ -2,7 +2,7 @@
 # is_hash.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_hash, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_hash, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the variable passed to this function is a hash.
 

--- a/lib/puppet/parser/functions/is_integer.rb
+++ b/lib/puppet/parser/functions/is_integer.rb
@@ -2,7 +2,7 @@
 # is_integer.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_integer, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_integer, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the variable passed to this function is an Integer or
       a decimal (base 10) integer in String form.

--- a/lib/puppet/parser/functions/is_ip_address.rb
+++ b/lib/puppet/parser/functions/is_ip_address.rb
@@ -2,7 +2,7 @@
 # is_ip_address.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_ip_address, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_ip_address, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the string passed to this function is a valid IP address.
 

--- a/lib/puppet/parser/functions/is_ipv4_address.rb
+++ b/lib/puppet/parser/functions/is_ipv4_address.rb
@@ -2,7 +2,7 @@
 # is_ipv4_address.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_ipv4_address, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_ipv4_address, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the string passed to this function is a valid IPv4 address.
 

--- a/lib/puppet/parser/functions/is_ipv6_address.rb
+++ b/lib/puppet/parser/functions/is_ipv6_address.rb
@@ -2,7 +2,7 @@
 # is_ipv6_address.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_ipv6_address, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_ipv6_address, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the string passed to this function is a valid IPv6 address.
 

--- a/lib/puppet/parser/functions/is_mac_address.rb
+++ b/lib/puppet/parser/functions/is_mac_address.rb
@@ -2,7 +2,7 @@
 # is_mac_address.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_mac_address, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_mac_address, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the string passed to this function is a valid mac address.
 

--- a/lib/puppet/parser/functions/is_numeric.rb
+++ b/lib/puppet/parser/functions/is_numeric.rb
@@ -2,7 +2,7 @@
 # is_numeric.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_numeric, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_numeric, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the given value is numeric.
 

--- a/lib/puppet/parser/functions/is_string.rb
+++ b/lib/puppet/parser/functions/is_string.rb
@@ -2,7 +2,7 @@
 # is_string.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:is_string, :type => :rvalue, :doc => <<-DOC
+  newfunction(:is_string, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns true if the variable passed to this function is a string.
 

--- a/lib/puppet/parser/functions/join.rb
+++ b/lib/puppet/parser/functions/join.rb
@@ -2,7 +2,7 @@
 # join.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:join, :type => :rvalue, :doc => <<-DOC
+  newfunction(:join, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** This function joins an array into a string using a separator.
 

--- a/lib/puppet/parser/functions/join_keys_to_values.rb
+++ b/lib/puppet/parser/functions/join_keys_to_values.rb
@@ -2,7 +2,7 @@
 # join_keys_to_values.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:join_keys_to_values, :type => :rvalue, :doc => <<-DOC
+  newfunction(:join_keys_to_values, type: :rvalue, doc: <<-DOC
     @summary
       This function joins each key of a hash to that key's corresponding value with a
       separator.

--- a/lib/puppet/parser/functions/keys.rb
+++ b/lib/puppet/parser/functions/keys.rb
@@ -2,7 +2,7 @@
 # keys.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:keys, :type => :rvalue, :doc => <<-DOC
+  newfunction(:keys, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns the keys of a hash as an array.
 

--- a/lib/puppet/parser/functions/load_module_metadata.rb
+++ b/lib/puppet/parser/functions/load_module_metadata.rb
@@ -2,7 +2,7 @@
 # load_module_metadata.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:load_module_metadata, :type => :rvalue, :doc => <<-DOC
+  newfunction(:load_module_metadata, type: :rvalue, doc: <<-DOC
     @summary
       This function loads the metadata of a given module.
 

--- a/lib/puppet/parser/functions/loadjson.rb
+++ b/lib/puppet/parser/functions/loadjson.rb
@@ -3,7 +3,7 @@
 #
 
 module Puppet::Parser::Functions
-  newfunction(:loadjson, :type => :rvalue, :arity => -2, :doc => <<-'DOC') do |args|
+  newfunction(:loadjson, type: :rvalue, arity: -2, doc: <<-'DOC') do |args|
     @summary
       Load a JSON file containing an array, string, or hash, and return the data
       in the corresponding native data type.
@@ -40,7 +40,7 @@ module Puppet::Parser::Functions
           url = args[0]
         end
         begin
-          contents = OpenURI.open_uri(url, :http_basic_authentication => [username, password])
+          contents = OpenURI.open_uri(url, http_basic_authentication: [username, password])
         rescue OpenURI::HTTPError => err
           res = err.io
           warning("Can't load '#{url}' HTTP Error Code: '#{res.status[0]}'")

--- a/lib/puppet/parser/functions/loadyaml.rb
+++ b/lib/puppet/parser/functions/loadyaml.rb
@@ -2,7 +2,7 @@
 # loadyaml.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:loadyaml, :type => :rvalue, :arity => -2, :doc => <<-'DOC') do |args|
+  newfunction(:loadyaml, type: :rvalue, arity: -2, doc: <<-'DOC') do |args|
     @summary
       Load a YAML file containing an array, string, or hash, and return the data
       in the corresponding native data type.
@@ -40,7 +40,7 @@ module Puppet::Parser::Functions
           url = args[0]
         end
         begin
-          contents = OpenURI.open_uri(url, :http_basic_authentication => [username, password])
+          contents = OpenURI.open_uri(url, http_basic_authentication: [username, password])
         rescue OpenURI::HTTPError => err
           res = err.io
           warning("Can't load '#{url}' HTTP Error Code: '#{res.status[0]}'")

--- a/lib/puppet/parser/functions/lstrip.rb
+++ b/lib/puppet/parser/functions/lstrip.rb
@@ -2,7 +2,7 @@
 #  lstrip.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:lstrip, :type => :rvalue, :doc => <<-DOC
+  newfunction(:lstrip, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Strips leading spaces to the left of a string.
 

--- a/lib/puppet/parser/functions/max.rb
+++ b/lib/puppet/parser/functions/max.rb
@@ -2,7 +2,7 @@
 # max.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:max, :type => :rvalue, :doc => <<-DOC
+  newfunction(:max, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns the highest value of all arguments.
 

--- a/lib/puppet/parser/functions/member.rb
+++ b/lib/puppet/parser/functions/member.rb
@@ -4,7 +4,7 @@
 # member.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:member, :type => :rvalue, :doc => <<-DOC
+  newfunction(:member, type: :rvalue, doc: <<-DOC
     @summary
       This function determines if a variable is a member of an array.
 

--- a/lib/puppet/parser/functions/merge.rb
+++ b/lib/puppet/parser/functions/merge.rb
@@ -2,7 +2,7 @@
 # merge.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:merge, :type => :rvalue, :doc => <<-'DOC') do |args|
+  newfunction(:merge, type: :rvalue, doc: <<-'DOC') do |args|
     @summary
       Merges two or more hashes together and returns the resulting hash.
 

--- a/lib/puppet/parser/functions/min.rb
+++ b/lib/puppet/parser/functions/min.rb
@@ -2,7 +2,7 @@
 # min.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:min, :type => :rvalue, :doc => <<-DOC
+  newfunction(:min, type: :rvalue, doc: <<-DOC
     @summary
       **Deprecated:** Returns the lowest value of all arguments.
 

--- a/lib/puppet/parser/functions/num2bool.rb
+++ b/lib/puppet/parser/functions/num2bool.rb
@@ -2,7 +2,7 @@
 # num2bool.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:num2bool, :type => :rvalue, :doc => <<-DOC
+  newfunction(:num2bool, type: :rvalue, doc: <<-DOC
     @summary
       This function converts a number or a string representation of a number into a
       true boolean.

--- a/lib/puppet/parser/functions/parsejson.rb
+++ b/lib/puppet/parser/functions/parsejson.rb
@@ -2,7 +2,7 @@
 # parsejson.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:parsejson, :type => :rvalue, :doc => <<-DOC
+  newfunction(:parsejson, type: :rvalue, doc: <<-DOC
     @summary
       This function accepts JSON as a string and converts it into the correct
       Puppet structure.

--- a/lib/puppet/parser/functions/parseyaml.rb
+++ b/lib/puppet/parser/functions/parseyaml.rb
@@ -2,7 +2,7 @@
 # parseyaml.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:parseyaml, :type => :rvalue, :doc => <<-DOC
+  newfunction(:parseyaml, type: :rvalue, doc: <<-DOC
     @summary
       This function accepts YAML as a string and converts it into the correct
       Puppet structure.

--- a/lib/puppet/parser/functions/pick.rb
+++ b/lib/puppet/parser/functions/pick.rb
@@ -2,7 +2,7 @@
 # pick.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:pick, :type => :rvalue, :doc => <<-EOS
+  newfunction(:pick, type: :rvalue, doc: <<-EOS
     @summary
       This function is similar to a coalesce function in SQL in that it will return
       the first value in a list of values that is not undefined or an empty string.

--- a/lib/puppet/parser/functions/pick_default.rb
+++ b/lib/puppet/parser/functions/pick_default.rb
@@ -2,7 +2,7 @@
 # pick_default.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:pick_default, :type => :rvalue, :doc => <<-DOC
+  newfunction(:pick_default, type: :rvalue, doc: <<-DOC
     @summary
       This function will return the first value in a list of values that is not undefined or an empty string.
 

--- a/lib/puppet/parser/functions/prefix.rb
+++ b/lib/puppet/parser/functions/prefix.rb
@@ -2,7 +2,7 @@
 # prefix.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:prefix, :type => :rvalue, :doc => <<-DOC
+  newfunction(:prefix, type: :rvalue, doc: <<-DOC
     @summary
       This function applies a prefix to all elements in an array or a hash.
 

--- a/lib/puppet/parser/functions/private.rb
+++ b/lib/puppet/parser/functions/private.rb
@@ -2,7 +2,7 @@
 # private.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:private, :doc => <<-'DOC'
+  newfunction(:private, doc: <<-'DOC'
    @summary
     **Deprecated:** Sets the current class or definition as private.
     Calling the class or definition from outside the current module will fail.

--- a/lib/puppet/parser/functions/pry.rb
+++ b/lib/puppet/parser/functions/pry.rb
@@ -2,7 +2,7 @@
 # pry.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:pry, :type => :statement, :doc => <<-DOC
+  newfunction(:pry, type: :statement, doc: <<-DOC
     @summary
       This function invokes a pry debugging session in the current scope object.
     This is useful for debugging manifest code at specific points during a compilation.

--- a/lib/puppet/parser/functions/pw_hash.rb
+++ b/lib/puppet/parser/functions/pw_hash.rb
@@ -3,9 +3,9 @@
 #
 Puppet::Parser::Functions.newfunction(
   :pw_hash,
-  :type => :rvalue,
-  :arity => 3,
-  :doc => <<-DOC
+  type: :rvalue,
+  arity: 3,
+  doc: <<-DOC
   @summary
     Hashes a password using the crypt function. Provides a hash usable
     on most POSIX systems.

--- a/lib/puppet/parser/functions/range.rb
+++ b/lib/puppet/parser/functions/range.rb
@@ -3,7 +3,7 @@
 #
 # TODO(Krzysztof Wilczynski): We probably need to approach numeric values differently ...
 module Puppet::Parser::Functions
-  newfunction(:range, :type => :rvalue, :doc => <<-DOC
+  newfunction(:range, type: :rvalue, doc: <<-DOC
     @summary
       When given range in the form of (start, stop) it will extrapolate a range as
       an array.

--- a/lib/puppet/parser/functions/regexpescape.rb
+++ b/lib/puppet/parser/functions/regexpescape.rb
@@ -2,7 +2,7 @@
 #  regexpescape.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:regexpescape, :type => :rvalue, :doc => <<-DOC
+  newfunction(:regexpescape, type: :rvalue, doc: <<-DOC
     @summary
       Regexp escape a string or array of strings.
       Requires either a single string or an array as an input.

--- a/lib/puppet/parser/functions/reject.rb
+++ b/lib/puppet/parser/functions/reject.rb
@@ -2,7 +2,7 @@
 # reject.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:reject, :type => :rvalue, :doc => <<-DOC) do |args|
+  newfunction(:reject, type: :rvalue, doc: <<-DOC) do |args|
     @summary
       This function searches through an array and rejects all elements that match
       the provided regular expression.

--- a/lib/puppet/parser/functions/reverse.rb
+++ b/lib/puppet/parser/functions/reverse.rb
@@ -2,7 +2,7 @@
 # reverse.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:reverse, :type => :rvalue, :doc => <<-DOC
+  newfunction(:reverse, type: :rvalue, doc: <<-DOC
     @summary
       Reverses the order of a string or array.
 

--- a/lib/puppet/parser/functions/round.rb
+++ b/lib/puppet/parser/functions/round.rb
@@ -2,7 +2,7 @@
 # round.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:round, :type => :rvalue, :doc => <<-DOC
+  newfunction(:round, type: :rvalue, doc: <<-DOC
     @summary
       Rounds a number to the nearest integer
 

--- a/lib/puppet/parser/functions/rstrip.rb
+++ b/lib/puppet/parser/functions/rstrip.rb
@@ -2,7 +2,7 @@
 #  rstrip.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:rstrip, :type => :rvalue, :doc => <<-DOC
+  newfunction(:rstrip, type: :rvalue, doc: <<-DOC
     @summary
       Strips leading spaces to the right of the string.
 

--- a/lib/puppet/parser/functions/seeded_rand.rb
+++ b/lib/puppet/parser/functions/seeded_rand.rb
@@ -3,9 +3,9 @@
 #
 Puppet::Parser::Functions.newfunction(
   :seeded_rand,
-  :arity => 2,
-  :type => :rvalue,
-  :doc => <<-DOC
+  arity: 2,
+  type: :rvalue,
+  doc: <<-DOC
     @summary
       Generates a random whole number greater than or equal to 0 and less than MAX, using the value of SEED for repeatable randomness.
 

--- a/lib/puppet/parser/functions/shell_escape.rb
+++ b/lib/puppet/parser/functions/shell_escape.rb
@@ -3,7 +3,7 @@ require 'shellwords'
 # shell_escape.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:shell_escape, :type => :rvalue, :doc => <<-DOC
+  newfunction(:shell_escape, type: :rvalue, doc: <<-DOC
     @summary
       Escapes a string so that it can be safely used in a Bourne shell command line.
 

--- a/lib/puppet/parser/functions/shell_join.rb
+++ b/lib/puppet/parser/functions/shell_join.rb
@@ -4,7 +4,7 @@ require 'shellwords'
 # shell_join.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:shell_join, :type => :rvalue, :doc => <<-DOC
+  newfunction(:shell_join, type: :rvalue, doc: <<-DOC
     @summary
     Builds a command line string from the given array of strings.
     Each array item is escaped for Bourne shell. All items are then joined together, with a single space in between.

--- a/lib/puppet/parser/functions/shell_split.rb
+++ b/lib/puppet/parser/functions/shell_split.rb
@@ -3,7 +3,7 @@ require 'shellwords'
 # shell_split.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:shell_split, :type => :rvalue, :doc => <<-DOC
+  newfunction(:shell_split, type: :rvalue, doc: <<-DOC
     @summary
       Splits a string into an array of tokens in the same way the Bourne shell does.
 

--- a/lib/puppet/parser/functions/shuffle.rb
+++ b/lib/puppet/parser/functions/shuffle.rb
@@ -2,7 +2,7 @@
 # shuffle.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:shuffle, :type => :rvalue, :doc => <<-DOC
+  newfunction(:shuffle, type: :rvalue, doc: <<-DOC
   @summary
     Randomizes the order of a string or array elements.
 

--- a/lib/puppet/parser/functions/size.rb
+++ b/lib/puppet/parser/functions/size.rb
@@ -2,7 +2,7 @@
 # size.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:size, :type => :rvalue, :doc => <<-DOC
+  newfunction(:size, type: :rvalue, doc: <<-DOC
     @summary
       Returns the number of elements in a string, an array or a hash
 

--- a/lib/puppet/parser/functions/sort.rb
+++ b/lib/puppet/parser/functions/sort.rb
@@ -3,7 +3,7 @@
 #  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 module Puppet::Parser::Functions
-  newfunction(:sort, :type => :rvalue, :doc => <<-DOC
+  newfunction(:sort, type: :rvalue, doc: <<-DOC
     @summary
       Sorts strings and arrays lexically.
 

--- a/lib/puppet/parser/functions/squeeze.rb
+++ b/lib/puppet/parser/functions/squeeze.rb
@@ -2,7 +2,7 @@
 # squeeze.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:squeeze, :type => :rvalue, :doc => <<-DOC
+  newfunction(:squeeze, type: :rvalue, doc: <<-DOC
     @summary
       Returns a new string where runs of the same character that occur in this set are replaced by a single character.
 

--- a/lib/puppet/parser/functions/str2bool.rb
+++ b/lib/puppet/parser/functions/str2bool.rb
@@ -2,7 +2,7 @@
 # str2bool.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:str2bool, :type => :rvalue, :doc => <<-DOC
+  newfunction(:str2bool, type: :rvalue, doc: <<-DOC
     @summary
       This converts a string to a boolean.
 

--- a/lib/puppet/parser/functions/str2saltedsha512.rb
+++ b/lib/puppet/parser/functions/str2saltedsha512.rb
@@ -3,7 +3,7 @@
 #  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 module Puppet::Parser::Functions
-  newfunction(:str2saltedsha512, :type => :rvalue, :doc => <<-DOC
+  newfunction(:str2saltedsha512, type: :rvalue, doc: <<-DOC
     @summary
       This converts a string to a salted-SHA512 password hash (which is used for
       OS X versions >= 10.7).

--- a/lib/puppet/parser/functions/strftime.rb
+++ b/lib/puppet/parser/functions/strftime.rb
@@ -3,7 +3,7 @@
 #  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 module Puppet::Parser::Functions
-  newfunction(:strftime, :type => :rvalue, :doc => <<-DOC
+  newfunction(:strftime, type: :rvalue, doc: <<-DOC
     @summary
       This function returns formatted time.
 

--- a/lib/puppet/parser/functions/strip.rb
+++ b/lib/puppet/parser/functions/strip.rb
@@ -2,7 +2,7 @@
 #  strip.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:strip, :type => :rvalue, :doc => <<-DOC
+  newfunction(:strip, type: :rvalue, doc: <<-DOC
     @summary
       This function removes leading and trailing whitespace from a string or from
       every string inside an array.

--- a/lib/puppet/parser/functions/suffix.rb
+++ b/lib/puppet/parser/functions/suffix.rb
@@ -2,7 +2,7 @@
 # suffix.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:suffix, :type => :rvalue, :doc => <<-DOC
+  newfunction(:suffix, type: :rvalue, doc: <<-DOC
     @summary
       This function applies a suffix to all elements in an array, or to the keys
       in a hash.

--- a/lib/puppet/parser/functions/swapcase.rb
+++ b/lib/puppet/parser/functions/swapcase.rb
@@ -3,7 +3,7 @@
 #  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 module Puppet::Parser::Functions
-  newfunction(:swapcase, :type => :rvalue, :doc => <<-DOC
+  newfunction(:swapcase, type: :rvalue, doc: <<-DOC
     @summary
       This function will swap the existing case of a string.
 

--- a/lib/puppet/parser/functions/time.rb
+++ b/lib/puppet/parser/functions/time.rb
@@ -2,7 +2,7 @@
 # time.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:time, :type => :rvalue, :doc => <<-DOC
+  newfunction(:time, type: :rvalue, doc: <<-DOC
     @summary
       This function will return the current time since epoch as an integer.
 

--- a/lib/puppet/parser/functions/to_bytes.rb
+++ b/lib/puppet/parser/functions/to_bytes.rb
@@ -2,7 +2,7 @@
 # to_bytes.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:to_bytes, :type => :rvalue, :doc => <<-DOC
+  newfunction(:to_bytes, type: :rvalue, doc: <<-DOC
     @summary
         Converts the argument into bytes, for example 4 kB becomes 4096.
 

--- a/lib/puppet/parser/functions/try_get_value.rb
+++ b/lib/puppet/parser/functions/try_get_value.rb
@@ -4,9 +4,9 @@
 module Puppet::Parser::Functions
   newfunction(
     :try_get_value,
-    :type => :rvalue,
-    :arity => -2,
-    :doc => <<-DOC
+    type: :rvalue,
+    arity: -2,
+    doc: <<-DOC
       @summary
         **DEPRECATED:** this function is deprecated, please use dig() instead.
 

--- a/lib/puppet/parser/functions/type.rb
+++ b/lib/puppet/parser/functions/type.rb
@@ -2,7 +2,7 @@
 # type.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:type, :type => :rvalue, :doc => <<-DOC
+  newfunction(:type, type: :rvalue, doc: <<-DOC
     @summary
       **DEPRECATED:** This function will cease to function on Puppet 4;
      please use type3x() before upgrading to Puppet 4 for backwards-compatibility, or migrate to the new parser's typing system.

--- a/lib/puppet/parser/functions/type3x.rb
+++ b/lib/puppet/parser/functions/type3x.rb
@@ -2,7 +2,7 @@
 # type3x.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:type3x, :type => :rvalue, :doc => <<-DOC
+  newfunction(:type3x, type: :rvalue, doc: <<-DOC
     @summary
       **DEPRECATED:** This function will be removed when Puppet 3 support is dropped; please migrate to the new parser's typing system.
 

--- a/lib/puppet/parser/functions/union.rb
+++ b/lib/puppet/parser/functions/union.rb
@@ -2,7 +2,7 @@
 # union.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:union, :type => :rvalue, :doc => <<-DOC
+  newfunction(:union, type: :rvalue, doc: <<-DOC
     @summary
       This function returns a union of two or more arrays.
 

--- a/lib/puppet/parser/functions/unique.rb
+++ b/lib/puppet/parser/functions/unique.rb
@@ -2,7 +2,7 @@
 # unique.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:unique, :type => :rvalue, :doc => <<-DOC
+  newfunction(:unique, type: :rvalue, doc: <<-DOC
     @summary
       This function will remove duplicates from strings and arrays.
 

--- a/lib/puppet/parser/functions/unix2dos.rb
+++ b/lib/puppet/parser/functions/unix2dos.rb
@@ -1,6 +1,6 @@
 # Custom Puppet function to convert unix to dos format
 module Puppet::Parser::Functions
-  newfunction(:unix2dos, :type => :rvalue, :arity => 1, :doc => <<-DOC
+  newfunction(:unix2dos, type: :rvalue, arity: 1, doc: <<-DOC
     @summary
       Returns the DOS version of the given string.
 

--- a/lib/puppet/parser/functions/upcase.rb
+++ b/lib/puppet/parser/functions/upcase.rb
@@ -3,7 +3,7 @@
 #  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 module Puppet::Parser::Functions
-  newfunction(:upcase, :type => :rvalue, :doc => <<-DOC
+  newfunction(:upcase, type: :rvalue, doc: <<-DOC
     @summary
       Converts a string or an array of strings to uppercase.
 

--- a/lib/puppet/parser/functions/uriescape.rb
+++ b/lib/puppet/parser/functions/uriescape.rb
@@ -4,7 +4,7 @@ require 'uri'
 #  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
 #
 module Puppet::Parser::Functions
-  newfunction(:uriescape, :type => :rvalue, :doc => <<-DOC
+  newfunction(:uriescape, type: :rvalue, doc: <<-DOC
     @summary
       Urlencodes a string or array of strings.
       Requires either a single string or an array as an input.

--- a/lib/puppet/parser/functions/validate_absolute_path.rb
+++ b/lib/puppet/parser/functions/validate_absolute_path.rb
@@ -2,7 +2,7 @@
 # validate_absolute_path.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_absolute_path, :doc => <<-DOC) do |args|
+  newfunction(:validate_absolute_path, doc: <<-DOC) do |args|
     @summary
       Validate the string represents an absolute path in the filesystem.  This function works
       for windows and unix style paths.

--- a/lib/puppet/parser/functions/validate_array.rb
+++ b/lib/puppet/parser/functions/validate_array.rb
@@ -2,7 +2,7 @@
 # validate_array.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_array, :doc => <<-DOC) do |args|
+  newfunction(:validate_array, doc: <<-DOC) do |args|
     @summary
       Validate that all passed values are array data structures. Abort catalog
       compilation if any value fails this check.

--- a/lib/puppet/parser/functions/validate_augeas.rb
+++ b/lib/puppet/parser/functions/validate_augeas.rb
@@ -4,7 +4,7 @@ require 'tempfile'
 # validate_augaes.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_augeas, :doc => <<-DOC
+  newfunction(:validate_augeas, doc: <<-DOC
     @summary
       Perform validation of a string using an Augeas lens
 
@@ -67,9 +67,9 @@ module Puppet::Parser::Functions
       # Check for syntax
       lens = args[1]
       aug.transform(
-        :lens => lens,
-        :name => 'Validate_augeas',
-        :incl => tmpfile.path,
+        lens: lens,
+        name: 'Validate_augeas',
+        incl: tmpfile.path,
       )
       aug.load!
 

--- a/lib/puppet/parser/functions/validate_bool.rb
+++ b/lib/puppet/parser/functions/validate_bool.rb
@@ -2,7 +2,7 @@
 # validate_bool.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_bool, :doc => <<-DOC
+  newfunction(:validate_bool, doc: <<-DOC
     @summary
       Validate that all passed values are either true or false. Abort catalog
       compilation if any value fails this check.

--- a/lib/puppet/parser/functions/validate_cmd.rb
+++ b/lib/puppet/parser/functions/validate_cmd.rb
@@ -5,7 +5,7 @@ require 'tempfile'
 # validate_cmd.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_cmd, :doc => <<-DOC
+  newfunction(:validate_cmd, doc: <<-DOC
     @summary
       Perform validation of a string with an external command.
 

--- a/lib/puppet/parser/functions/validate_domain_name.rb
+++ b/lib/puppet/parser/functions/validate_domain_name.rb
@@ -2,7 +2,7 @@
 # validate_domain_name.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_domain_name, :doc => <<-DOC
+  newfunction(:validate_domain_name, doc: <<-DOC
     @summary
       Validate that all values passed are syntactically correct domain names.
       Fail compilation if any value fails this check.

--- a/lib/puppet/parser/functions/validate_email_address.rb
+++ b/lib/puppet/parser/functions/validate_email_address.rb
@@ -2,7 +2,7 @@
 # validate_email_address.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_email_address, :doc => <<-DOC
+  newfunction(:validate_email_address, doc: <<-DOC
     @summary
       Validate that all values passed are valid email addresses.
       Fail compilation if any value fails this check.

--- a/lib/puppet/parser/functions/validate_hash.rb
+++ b/lib/puppet/parser/functions/validate_hash.rb
@@ -2,7 +2,7 @@
 # validate_hash.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_hash, :doc => <<-DOC
+  newfunction(:validate_hash, doc: <<-DOC
     @summary
       Validate that all passed values are hash data structures. Abort catalog
       compilation if any value fails this check.

--- a/lib/puppet/parser/functions/validate_integer.rb
+++ b/lib/puppet/parser/functions/validate_integer.rb
@@ -2,7 +2,7 @@
 # validate_interger.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_integer, :doc => <<-DOC
+  newfunction(:validate_integer, doc: <<-DOC
     @summary
       Validate that the first argument is an integer (or an array of integers). Abort catalog compilation if any of the checks fail.
 

--- a/lib/puppet/parser/functions/validate_ip_address.rb
+++ b/lib/puppet/parser/functions/validate_ip_address.rb
@@ -2,7 +2,7 @@
 # validate_ip_address.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_ip_address, :doc => <<-DOC
+  newfunction(:validate_ip_address, doc: <<-DOC
     @summary
       Validate that all values passed are valid IP addresses,
       regardless they are IPv4 or IPv6

--- a/lib/puppet/parser/functions/validate_ipv4_address.rb
+++ b/lib/puppet/parser/functions/validate_ipv4_address.rb
@@ -2,7 +2,7 @@
 # validate_ipv4_address.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_ipv4_address, :doc => <<-DOC
+  newfunction(:validate_ipv4_address, doc: <<-DOC
     @summary
       Validate that all values passed are valid IPv4 addresses.
       Fail compilation if any value fails this check.

--- a/lib/puppet/parser/functions/validate_ipv6_address.rb
+++ b/lib/puppet/parser/functions/validate_ipv6_address.rb
@@ -2,7 +2,7 @@
 # validate_ipv7_address.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_ipv6_address, :doc => <<-DOC
+  newfunction(:validate_ipv6_address, doc: <<-DOC
     @summary
       Validate that all values passed are valid IPv6 addresses.
       Fail compilation if any value fails this check.

--- a/lib/puppet/parser/functions/validate_numeric.rb
+++ b/lib/puppet/parser/functions/validate_numeric.rb
@@ -2,7 +2,7 @@
 # validate_numeric.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_numeric, :doc => <<-DOC
+  newfunction(:validate_numeric, doc: <<-DOC
     @summary
       Validate that the first argument is a numeric value (or an array of numeric values). Abort catalog compilation if any of the checks fail.
 

--- a/lib/puppet/parser/functions/validate_re.rb
+++ b/lib/puppet/parser/functions/validate_re.rb
@@ -2,7 +2,7 @@
 # validate.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_re, :doc => <<-DOC
+  newfunction(:validate_re, doc: <<-DOC
   @summary
     Perform simple validation of a string against one or more regular
     expressions.

--- a/lib/puppet/parser/functions/validate_slength.rb
+++ b/lib/puppet/parser/functions/validate_slength.rb
@@ -2,7 +2,7 @@
 # validate_slength.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_slength, :doc => <<-DOC
+  newfunction(:validate_slength, doc: <<-DOC
     @summary
       Validate that the first argument is a string (or an array of strings), and less/equal to than the length of the second argument.
       An optional third parameter can be given the minimum length. It fails if the first argument is not a string or array of strings,

--- a/lib/puppet/parser/functions/validate_string.rb
+++ b/lib/puppet/parser/functions/validate_string.rb
@@ -2,7 +2,7 @@
 # validate_String.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_string, :doc => <<-DOC
+  newfunction(:validate_string, doc: <<-DOC
     @summary
       Validate that all passed values are string data structures
 

--- a/lib/puppet/parser/functions/validate_x509_rsa_key_pair.rb
+++ b/lib/puppet/parser/functions/validate_x509_rsa_key_pair.rb
@@ -2,7 +2,7 @@
 # validate_x509_rsa_key_pair.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:validate_x509_rsa_key_pair, :doc => <<-DOC
+  newfunction(:validate_x509_rsa_key_pair, doc: <<-DOC
     @summary
       Validates a PEM-formatted X.509 certificate and RSA private key using
       OpenSSL. Verifies that the certficate's signature was created from the

--- a/lib/puppet/parser/functions/values.rb
+++ b/lib/puppet/parser/functions/values.rb
@@ -2,7 +2,7 @@
 # values.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:values, :type => :rvalue, :doc => <<-DOC
+  newfunction(:values, type: :rvalue, doc: <<-DOC
     @summary
       When given a hash this function will return the values of that hash.
 

--- a/lib/puppet/parser/functions/values_at.rb
+++ b/lib/puppet/parser/functions/values_at.rb
@@ -2,7 +2,7 @@
 # values_at.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:values_at, :type => :rvalue, :doc => <<-DOC
+  newfunction(:values_at, type: :rvalue, doc: <<-DOC
     @summary
       Finds value inside an array based on location.
 

--- a/lib/puppet/parser/functions/zip.rb
+++ b/lib/puppet/parser/functions/zip.rb
@@ -2,7 +2,7 @@
 # zip.rb
 #
 module Puppet::Parser::Functions
-  newfunction(:zip, :type => :rvalue, :doc => <<-DOC
+  newfunction(:zip, type: :rvalue, doc: <<-DOC
     @summary
       Takes one element from first array and merges corresponding elements from second array.
 

--- a/lib/puppet/provider/file_line/ruby.rb
+++ b/lib/puppet/provider/file_line/ruby.rb
@@ -77,7 +77,7 @@ Puppet::Type.type(:file_line).provide(:ruby) do
     #  small-ish config files that can fit into memory without
     #  too much trouble.
 
-    @lines ||= File.readlines(resource[:path], :encoding => resource[:encoding])
+    @lines ||= File.readlines(resource[:path], encoding: resource[:encoding])
   rescue TypeError => _e
     # Ruby 1.8 doesn't support open_args
     @lines ||= File.readlines(resource[:path])

--- a/lib/puppet/type/file_line.rb
+++ b/lib/puppet/type/file_line.rb
@@ -104,7 +104,7 @@ Puppet::Type.newtype(:file_line) do
     defaultto :present
   end
 
-  newparam(:name, :namevar => true) do
+  newparam(:name, namevar: true) do
     desc 'An arbitrary name used as the identity of the resource.'
   end
 

--- a/spec/acceptance/anchor_spec.rb
+++ b/spec/acceptance/anchor_spec.rb
@@ -17,7 +17,7 @@ describe 'anchor type' do
       include anchorrefresh
     DOC
     it 'effects proper chaining of resources' do
-      apply_manifest(pp, :catch_failures => true) do |r|
+      apply_manifest(pp, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{Anchor\[final\]: Triggered 'refresh'})
       end
     end

--- a/spec/acceptance/has_interface_with_spec.rb
+++ b/spec/acceptance/has_interface_with_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'has_interface_with function', :unless => ((fact('osfamily') == 'windows') || (fact('osfamily') == 'AIX')) do
+describe 'has_interface_with function', unless: ((fact('osfamily') == 'windows') || (fact('osfamily') == 'AIX')) do
   describe 'success' do
     pp1 = <<-DOC
       $a = $::ipaddress
@@ -8,7 +8,7 @@ describe 'has_interface_with function', :unless => ((fact('osfamily') == 'window
       notice(inline_template('has_interface_with is <%= @o.inspect %>'))
     DOC
     it 'has_interface_with existing ipaddress' do
-      apply_manifest(pp1, :catch_failures => true) do |r|
+      apply_manifest(pp1, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{has_interface_with is true})
       end
     end
@@ -19,7 +19,7 @@ describe 'has_interface_with function', :unless => ((fact('osfamily') == 'window
       notice(inline_template('has_interface_with is <%= @o.inspect %>'))
     DOC
     it 'has_interface_with absent ipaddress' do
-      apply_manifest(pp2, :catch_failures => true) do |r|
+      apply_manifest(pp2, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{has_interface_with is false})
       end
     end
@@ -40,7 +40,7 @@ describe 'has_interface_with function', :unless => ((fact('osfamily') == 'window
       notice(inline_template('has_interface_with is <%= @o.inspect %>'))
     DOC
     it 'has_interface_with existing interface' do
-      apply_manifest(pp3, :catch_failures => true) do |r|
+      apply_manifest(pp3, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{has_interface_with is true})
       end
     end

--- a/spec/acceptance/is_a_spec.rb
+++ b/spec/acceptance/is_a_spec.rb
@@ -8,7 +8,7 @@ if return_puppet_version =~ %r{^4}
       }
     DOC
     it 'matches a string' do
-      apply_manifest(pp1, :catch_failures => true) do |r|
+      apply_manifest(pp1, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{Notice: output correct})
       end
     end
@@ -19,7 +19,7 @@ if return_puppet_version =~ %r{^4}
       }
     DOC
     it 'does not match a integer as string' do
-      apply_manifest(pp2, :catch_failures => true) do |r|
+      apply_manifest(pp2, catch_failures: true) do |r|
         expect(r.stdout).not_to match(%r{Notice: output wrong})
       end
     end

--- a/spec/acceptance/is_mac_address_spec.rb
+++ b/spec/acceptance/is_mac_address_spec.rb
@@ -11,7 +11,7 @@ describe 'is_mac_address function' do
       }
     DOC
     it 'is_mac_addresss a mac' do
-      apply_manifest(pp1, :catch_failures => true) do |r|
+      apply_manifest(pp1, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{Notice: output correct})
       end
     end
@@ -25,7 +25,7 @@ describe 'is_mac_address function' do
       }
     DOC
     it 'is_mac_addresss a mac out of range' do
-      apply_manifest(pp2, :catch_failures => true) do |r|
+      apply_manifest(pp2, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{Notice: output correct})
       end
     end
@@ -39,7 +39,7 @@ describe 'is_mac_address function' do
       }
     DOC
     it 'is_mac_addresss a 20-octet mac' do
-      apply_manifest(pp3, :catch_failures => true) do |r|
+      apply_manifest(pp3, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{Notice: output correct})
       end
     end

--- a/spec/acceptance/pw_hash_spec.rb
+++ b/spec/acceptance/pw_hash_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper_acceptance'
 
 # Windows and OS X do not have useful implementations of crypt(3)
-describe 'pw_hash function', :unless => ['windows', 'Darwin', 'SLES'].include?(fact('operatingsystem')) do
+describe 'pw_hash function', unless: ['windows', 'Darwin', 'SLES'].include?(fact('operatingsystem')) do
   describe 'success' do
     pp1 = <<-DOC
       $o = pw_hash('password', 'sha-512', 'salt')
       notice(inline_template('pw_hash is <%= @o.inspect %>'))
     DOC
     it 'hashes passwords' do
-      apply_manifest(pp1, :catch_failures => true) do |r|
+      apply_manifest(pp1, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{pw_hash is "\$6\$salt\$IxDD3jeSOb5eB1CX5LBsqZFVkJdido3OUILO5Ifz5iwMuTS4XMS130MTSuDDl3aCI6WouIL9AjRbLCelDCy\.g\."})
       end
     end
@@ -18,7 +18,7 @@ describe 'pw_hash function', :unless => ['windows', 'Darwin', 'SLES'].include?(f
       notice(inline_template('pw_hash is <%= @o.inspect %>'))
     DOC
     it 'returns nil if no password is provided' do
-      apply_manifest(pp2, :catch_failures => true) do |r|
+      apply_manifest(pp2, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{pw_hash is nil})
       end
     end

--- a/spec/acceptance/size_spec.rb
+++ b/spec/acceptance/size_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'size function', :if => Puppet::Util::Package.versioncmp(return_puppet_version, '6.0.0') < 0 do
+describe 'size function', if: Puppet::Util::Package.versioncmp(return_puppet_version, '6.0.0') < 0 do
   describe 'success' do
     pp1 = <<-DOC
       $a = 'discombobulate'
@@ -8,7 +8,7 @@ describe 'size function', :if => Puppet::Util::Package.versioncmp(return_puppet_
       notice(inline_template('size is <%= @o.inspect %>'))
     DOC
     it 'single string size' do
-      apply_manifest(pp1, :catch_failures => true) do |r|
+      apply_manifest(pp1, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{size is 14})
       end
     end
@@ -19,7 +19,7 @@ describe 'size function', :if => Puppet::Util::Package.versioncmp(return_puppet_
       notice(inline_template('size is <%= @o.inspect %>'))
     DOC
     it 'with empty string' do
-      apply_manifest(pp2, :catch_failures => true) do |r|
+      apply_manifest(pp2, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{size is 0})
       end
     end
@@ -30,7 +30,7 @@ describe 'size function', :if => Puppet::Util::Package.versioncmp(return_puppet_
       notice(inline_template('size is <%= @o.inspect %>'))
     DOC
     it 'with undef' do
-      apply_manifest(pp3, :catch_failures => true) do |r|
+      apply_manifest(pp3, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{size is 0})
       end
     end
@@ -41,7 +41,7 @@ describe 'size function', :if => Puppet::Util::Package.versioncmp(return_puppet_
       notice(inline_template('size is <%= @o.inspect %>'))
     DOC
     it 'strings in array' do
-      apply_manifest(pp4, :catch_failures => true) do |r|
+      apply_manifest(pp4, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{size is 2})
       end
     end

--- a/spec/acceptance/strftime_spec.rb
+++ b/spec/acceptance/strftime_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper_acceptance'
 
-describe 'strftime function', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.8.0') < 0 do
+describe 'strftime function', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.8.0') < 0 do
   describe 'success' do
     pp = <<-DOC
       $o = strftime('%C')
       notice(inline_template('strftime is <%= @o.inspect %>'))
     DOC
     it 'gives the Century' do
-      apply_manifest(pp, :catch_failures => true) do |r|
+      apply_manifest(pp, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{strftime is "20"})
       end
     end

--- a/spec/acceptance/type3x_spec.rb
+++ b/spec/acceptance/type3x_spec.rb
@@ -11,7 +11,7 @@ describe 'type3x function' do
       %{type3x(3.14)}              => 'Float',
     }.each do |pp, type|
       it "with type #{type}" do
-        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, catch_failures: true)
       end
     end
   end
@@ -21,7 +21,7 @@ describe 'type3x function' do
       type3x('one','two')
     MANIFEST
     it 'handles improper number of arguments' do
-      expect(apply_manifest(pp_fail, :expect_failures => true).stderr).to match(%r{Wrong number of arguments})
+      expect(apply_manifest(pp_fail, expect_failures: true).stderr).to match(%r{Wrong number of arguments})
     end
   end
 end

--- a/spec/acceptance/type_spec.rb
+++ b/spec/acceptance/type_spec.rb
@@ -9,7 +9,7 @@ describe 'type function' do
       notice(inline_template('type is <%= @o.to_s %>'))
     DOC
     it 'types arrays' do
-      apply_manifest(pp1, :catch_failures => true) do |r|
+      apply_manifest(pp1, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{type is Tuple\[String.*, String.*, String.*, String.*\]})
       end
     end
@@ -20,7 +20,7 @@ describe 'type function' do
       notice(inline_template('type is <%= @o.to_s %>'))
     DOC
     it 'types strings' do
-      apply_manifest(pp2, :catch_failures => true) do |r|
+      apply_manifest(pp2, catch_failures: true) do |r|
         expect(r.stdout).to match(%r{type is String})
       end
     end

--- a/spec/acceptance/validate_augeas_spec.rb
+++ b/spec/acceptance/validate_augeas_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'validate_augeas function', :unless => (fact('osfamily') == 'windows') do
+describe 'validate_augeas function', unless: (fact('osfamily') == 'windows') do
   describe 'prep' do
     it 'installs augeas for tests'
   end
@@ -16,7 +16,7 @@ describe 'validate_augeas function', :unless => (fact('osfamily') == 'windows') 
           validate_augeas($line, $lens)
         DOC
         it "validates a single argument for #{lens}" do
-          apply_manifest(pp1, :catch_failures => true)
+          apply_manifest(pp1, catch_failures: true)
         end
       end
     end
@@ -32,7 +32,7 @@ describe 'validate_augeas function', :unless => (fact('osfamily') == 'windows') 
         validate_augeas($line, $lens, $restriction, "my custom failure message")
       DOC
       it 'validates a restricted value' do
-        expect(apply_manifest(pp2, :expect_failures => true).stderr).to match(%r{my custom failure message})
+        expect(apply_manifest(pp2, expect_failures: true).stderr).to match(%r{my custom failure message})
       end
     end
 
@@ -47,7 +47,7 @@ describe 'validate_augeas function', :unless => (fact('osfamily') == 'windows') 
           validate_augeas($line, $lens)
         DOC
         it "validates a single argument for #{lens}" do
-          apply_manifest(pp3, :expect_failures => true)
+          apply_manifest(pp3, expect_failures: true)
         end
       end
     end

--- a/spec/acceptance/validate_cmd_spec.rb
+++ b/spec/acceptance/validate_cmd_spec.rb
@@ -12,7 +12,7 @@ describe 'validate_cmd function' do
       validate_cmd($one,$two)
     DOC
     it 'validates a true command' do
-      apply_manifest(pp1, :catch_failures => true)
+      apply_manifest(pp1, catch_failures: true)
     end
 
     pp2 = <<-DOC
@@ -25,7 +25,7 @@ describe 'validate_cmd function' do
       validate_cmd($one,$two)
     DOC
     it 'validates a fail command' do
-      apply_manifest(pp2, :expect_failures => true)
+      apply_manifest(pp2, expect_failures: true)
     end
 
     pp3 = <<-DOC
@@ -38,7 +38,7 @@ describe 'validate_cmd function' do
       validate_cmd($one,$two,"aoeu is dvorak")
     DOC
     it 'validates a fail command with a custom error message' do
-      apply_manifest(pp3, :expect_failures => true) do |output|
+      apply_manifest(pp3, expect_failures: true) do |output|
         expect(output.stderr).to match(%r{aoeu is dvorak})
       end
     end

--- a/spec/functions/any2bool_spec.rb
+++ b/spec/functions/any2bool_spec.rb
@@ -34,7 +34,7 @@ describe 'any2bool' do
   end
 
   describe 'everything else returns true' do
-    [[], {}, ['1'], [1], { :one => 1 }].each do |value|
+    [[], {}, ['1'], [1], { one: 1 }].each do |value|
       it { is_expected.to run.with_params(value).and_return(true) }
     end
   end

--- a/spec/functions/camelcase_spec.rb
+++ b/spec/functions/camelcase_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'camelcase', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'camelcase', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError) }
   it { is_expected.to run.with_params(100).and_raise_error(Puppet::ParseError) }

--- a/spec/functions/capitalize_spec.rb
+++ b/spec/functions/capitalize_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'capitalize', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'capitalize', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError) }
   it { is_expected.to run.with_params(100).and_raise_error(Puppet::ParseError) }

--- a/spec/functions/ceiling_spec.rb
+++ b/spec/functions/ceiling_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'ceiling', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'ceiling', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{Wrong number of arguments}) }
   it { is_expected.to run.with_params('foo').and_raise_error(Puppet::ParseError, %r{Wrong argument type given}) }

--- a/spec/functions/chomp_spec.rb
+++ b/spec/functions/chomp_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'chomp', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'chomp', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{Wrong number of arguments given}) }
   it { is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError, %r{Requires either array or string}) }

--- a/spec/functions/chop_spec.rb
+++ b/spec/functions/chop_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'chop', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'chop', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{Wrong number of arguments}) }
   it { is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError, %r{Requires either an array or string}) }

--- a/spec/functions/downcase_spec.rb
+++ b/spec/functions/downcase_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'downcase', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'downcase', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{Wrong number of arguments}) }
   it { is_expected.to run.with_params(100).and_raise_error(Puppet::ParseError, %r{Requires either array or string}) }

--- a/spec/functions/empty_spec.rb
+++ b/spec/functions/empty_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'empty', :if => Puppet::Util::Package.versioncmp(Puppet.version, '5.5.0') < 0 do
+describe 'empty', if: Puppet::Util::Package.versioncmp(Puppet.version, '5.5.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{Wrong number of arguments}) }
   it {

--- a/spec/functions/flatten_spec.rb
+++ b/spec/functions/flatten_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'flatten', :if => Puppet::Util::Package.versioncmp(Puppet.version, '5.5.0') < 0 do
+describe 'flatten', if: Puppet::Util::Package.versioncmp(Puppet.version, '5.5.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{Wrong number of arguments}) }
   it { is_expected.to run.with_params([], []).and_raise_error(Puppet::ParseError, %r{Wrong number of arguments}) }

--- a/spec/functions/floor_spec.rb
+++ b/spec/functions/floor_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'floor', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'floor', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{Wrong number of arguments}) }
   it { is_expected.to run.with_params('foo').and_raise_error(Puppet::ParseError, %r{Wrong argument type}) }

--- a/spec/functions/fqdn_rand_string_spec.rb
+++ b/spec/functions/fqdn_rand_string_spec.rb
@@ -28,22 +28,22 @@ describe 'fqdn_rand_string' do
   end
 
   it 'considers the same host and same extra arguments to have the same random sequence' do
-    first_random = fqdn_rand_string(10, :extra_identifier => [1, 'same', 'host'])
-    second_random = fqdn_rand_string(10, :extra_identifier => [1, 'same', 'host'])
+    first_random = fqdn_rand_string(10, extra_identifier: [1, 'same', 'host'])
+    second_random = fqdn_rand_string(10, extra_identifier: [1, 'same', 'host'])
 
     expect(first_random).to eql(second_random)
   end
 
   it 'allows extra arguments to control the random value on a single host' do
-    first_random = fqdn_rand_string(10, :extra_identifier => [1, 'different', 'host'])
-    second_different_random = fqdn_rand_string(10, :extra_identifier => [2, 'different', 'host'])
+    first_random = fqdn_rand_string(10, extra_identifier: [1, 'different', 'host'])
+    second_different_random = fqdn_rand_string(10, extra_identifier: [2, 'different', 'host'])
 
     expect(first_random).not_to eql(second_different_random)
   end
 
   it 'returns different strings for different hosts' do
-    val1 = fqdn_rand_string(10, :host => 'first.host.com')
-    val2 = fqdn_rand_string(10, :host => 'second.host.com')
+    val1 = fqdn_rand_string(10, host: 'first.host.com')
+    val2 = fqdn_rand_string(10, host: 'second.host.com')
 
     expect(val1).not_to eql(val2)
   end

--- a/spec/functions/fqdn_rotate_spec.rb
+++ b/spec/functions/fqdn_rotate_spec.rb
@@ -17,26 +17,26 @@ describe 'fqdn_rotate' do
   end
 
   it 'rotates a string to give the same results for one host' do
-    val1 = fqdn_rotate('abcdefg', :host => 'one')
-    val2 = fqdn_rotate('abcdefg', :host => 'one')
+    val1 = fqdn_rotate('abcdefg', host: 'one')
+    val2 = fqdn_rotate('abcdefg', host: 'one')
     expect(val1).to eq(val2)
   end
 
   it 'allows extra arguments to control the random rotation on a single host' do
-    val1 = fqdn_rotate('abcdefg', :extra_identifier => [1, 'different', 'host'])
-    val2 = fqdn_rotate('abcdefg', :extra_identifier => [2, 'different', 'host'])
+    val1 = fqdn_rotate('abcdefg', extra_identifier: [1, 'different', 'host'])
+    val2 = fqdn_rotate('abcdefg', extra_identifier: [2, 'different', 'host'])
     expect(val1).not_to eq(val2)
   end
 
   it 'considers the same host and same extra arguments to have the same random rotation' do
-    val1 = fqdn_rotate('abcdefg', :extra_identifier => [1, 'same', 'host'])
-    val2 = fqdn_rotate('abcdefg', :extra_identifier => [1, 'same', 'host'])
+    val1 = fqdn_rotate('abcdefg', extra_identifier: [1, 'same', 'host'])
+    val2 = fqdn_rotate('abcdefg', extra_identifier: [1, 'same', 'host'])
     expect(val1).to eq(val2)
   end
 
   it 'rotates a string to give different values on different hosts' do
-    val1 = fqdn_rotate('abcdefg', :host => 'one')
-    val2 = fqdn_rotate('abcdefg', :host => 'two')
+    val1 = fqdn_rotate('abcdefg', host: 'one')
+    val2 = fqdn_rotate('abcdefg', host: 'two')
     expect(val1).not_to eq(val2)
   end
 

--- a/spec/functions/getvar_spec.rb
+++ b/spec/functions/getvar_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe 'getvar' do
   it { is_expected.not_to eq(nil) }
 
-  describe 'before Puppet 6.0.0', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+  describe 'before Puppet 6.0.0', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
     it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
     it { is_expected.to run.with_params('one', 'two').and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   end
 
-  describe 'from Puppet 6.0.0', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') >= 0 do
+  describe 'from Puppet 6.0.0', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') >= 0 do
     it { is_expected.to run.with_params.and_raise_error(ArgumentError, %r{expects between 1 and 2 arguments, got none}i) }
     it { is_expected.to run.with_params('one', 'two').and_return('two') }
     it { is_expected.to run.with_params('one', 'two', 'three').and_raise_error(ArgumentError, %r{expects between 1 and 2 arguments, got 3}i) }

--- a/spec/functions/has_interface_with_spec.rb
+++ b/spec/functions/has_interface_with_spec.rb
@@ -8,7 +8,7 @@ describe 'has_interface_with' do
   # We need to mock out the Facts so we can specify how we expect this function
   # to behave on different platforms.
   context 'when on Mac OS X Systems' do
-    let(:facts) { { :interfaces => 'lo0,gif0,stf0,en1,p2p0,fw0,en0,vmnet1,vmnet8,utun0' } }
+    let(:facts) { { interfaces: 'lo0,gif0,stf0,en1,p2p0,fw0,en0,vmnet1,vmnet8,utun0' } }
 
     it { is_expected.to run.with_params('lo0').and_return(true) }
     it { is_expected.to run.with_params('lo').and_return(false) }
@@ -17,13 +17,13 @@ describe 'has_interface_with' do
   context 'when on Linux Systems' do
     let(:facts) do
       {
-        :interfaces => 'eth0,lo',
-        :ipaddress => '10.0.0.1',
-        :ipaddress_lo => '127.0.0.1',
-        :ipaddress_eth0 => '10.0.0.1',
-        :muppet => 'kermit',
-        :muppet_lo => 'mspiggy',
-        :muppet_eth0 => 'kermit',
+        interfaces: 'eth0,lo',
+        ipaddress: '10.0.0.1',
+        ipaddress_lo: '127.0.0.1',
+        ipaddress_eth0: '10.0.0.1',
+        muppet: 'kermit',
+        muppet_lo: 'mspiggy',
+        muppet_eth0: 'kermit',
       }
     end
 

--- a/spec/functions/has_ip_address_spec.rb
+++ b/spec/functions/has_ip_address_spec.rb
@@ -8,10 +8,10 @@ describe 'has_ip_address' do
   context 'when on Linux Systems' do
     let(:facts) do
       {
-        :interfaces => 'eth0,lo',
-        :ipaddress => '10.0.0.1',
-        :ipaddress_lo => '127.0.0.1',
-        :ipaddress_eth0 => '10.0.0.1',
+        interfaces: 'eth0,lo',
+        ipaddress: '10.0.0.1',
+        ipaddress_lo: '127.0.0.1',
+        ipaddress_eth0: '10.0.0.1',
       }
     end
 

--- a/spec/functions/has_ip_network_spec.rb
+++ b/spec/functions/has_ip_network_spec.rb
@@ -8,9 +8,9 @@ describe 'has_ip_network' do
   context 'when on Linux Systems' do
     let(:facts) do
       {
-        :interfaces => 'eth0,lo',
-        :network_lo => '127.0.0.0',
-        :network_eth0 => '10.0.0.0',
+        interfaces: 'eth0,lo',
+        network_lo: '127.0.0.0',
+        network_eth0: '10.0.0.0',
       }
     end
 

--- a/spec/functions/is_ipv4_address_spec.rb
+++ b/spec/functions/is_ipv4_address_spec.rb
@@ -12,7 +12,7 @@ describe 'is_ipv4_address' do
     it { is_expected.to run.with_params(value).and_return(false) }
   end
 
-  context 'Checking for deprecation warning', :if => Puppet.version.to_f < 4.0 do
+  context 'Checking for deprecation warning', if: Puppet.version.to_f < 4.0 do
     after(:each) do
       ENV.delete('STDLIB_LOG_DEPRECATIONS')
     end

--- a/spec/functions/is_ipv6_address_spec.rb
+++ b/spec/functions/is_ipv6_address_spec.rb
@@ -11,7 +11,7 @@ describe 'is_ipv6_address' do
   it { is_expected.to run.with_params('one').and_return(false) }
   it { is_expected.to run.with_params('2001:0db8:85a3:0000:0000:8a2e:0370:7334:ggg').and_return(false) }
 
-  context 'Checking for deprecation warning', :if => Puppet.version.to_f < 4.0 do
+  context 'Checking for deprecation warning', if: Puppet.version.to_f < 4.0 do
     after(:each) do
       ENV.delete('STDLIB_LOG_DEPRECATIONS')
     end

--- a/spec/functions/join_spec.rb
+++ b/spec/functions/join_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'join', :if => Puppet::Util::Package.versioncmp(Puppet.version, '5.5.0') < 0 do
+describe 'join', if: Puppet::Util::Package.versioncmp(Puppet.version, '5.5.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   it {

--- a/spec/functions/keys_spec.rb
+++ b/spec/functions/keys_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'keys', :if => Puppet::Util::Package.versioncmp(Puppet.version, '5.5.0') < 0 do
+describe 'keys', if: Puppet::Util::Package.versioncmp(Puppet.version, '5.5.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   it {

--- a/spec/functions/length_spec.rb
+++ b/spec/functions/length_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'length', :if => Puppet::Util::Package.versioncmp(Puppet.version, '5.5.0') < 0 do
+describe 'length', if: Puppet::Util::Package.versioncmp(Puppet.version, '5.5.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(ArgumentError, %r{'length' expects 1 argument, got none}) }
   it { is_expected.to run.with_params([], 'extra').and_raise_error(ArgumentError, %r{'length' expects 1 argument, got 2}) }

--- a/spec/functions/load_module_metadata_spec.rb
+++ b/spec/functions/load_module_metadata_spec.rb
@@ -7,13 +7,13 @@ describe 'load_module_metadata' do
 
   describe 'when calling with valid arguments' do
     before :each do
-      allow(File).to receive(:read).with(%r{\/(stdlib|test)\/metadata.json}, :encoding => 'utf-8').and_return('{"name": "puppetlabs-stdlib"}')
+      allow(File).to receive(:read).with(%r{\/(stdlib|test)\/metadata.json}, encoding: 'utf-8').and_return('{"name": "puppetlabs-stdlib"}')
       allow(File).to receive(:read).with(%r{\/(stdlib|test)\/metadata.json}).and_return('{"name": "puppetlabs-stdlib"}')
     end
 
     context 'when calling with valid utf8 and double byte character arguments' do
       before :each do
-        allow(File).to receive(:read).with(%r{\/(stdlib|test)\/metadata.json}, :encoding => 'utf-8').and_return('{"ĭďèŉţĩƒіểя": "ċơņťęאּť ỡƒ ţħíš -
+        allow(File).to receive(:read).with(%r{\/(stdlib|test)\/metadata.json}, encoding: 'utf-8').and_return('{"ĭďèŉţĩƒіểя": "ċơņťęאּť ỡƒ ţħíš -
 この文字"}')
         allow(File).to receive(:read).with(%r{\/(stdlib|test)\/metadata.json}).and_return('{"ĭďèŉţĩƒіểя": "ċơņťęאּť ỡƒ ţħíš -
 この文字"}')

--- a/spec/functions/loadjson_spec.rb
+++ b/spec/functions/loadjson_spec.rb
@@ -6,7 +6,7 @@ describe 'loadjson' do
 
   describe 'when calling with valid arguments' do
     before :each do
-      allow(File).to receive(:read).with(%r{\/(stdlib|test)\/metadata.json}, :encoding => 'utf-8').and_return('{"name": "puppetlabs-stdlib"}')
+      allow(File).to receive(:read).with(%r{\/(stdlib|test)\/metadata.json}, encoding: 'utf-8').and_return('{"name": "puppetlabs-stdlib"}')
       allow(File).to receive(:read).with(%r{\/(stdlib|test)\/metadata.json}).and_return('{"name": "puppetlabs-stdlib"}')
     end
 
@@ -70,7 +70,7 @@ describe 'loadjson' do
       let(:filename) do
         'https://example.local/myhash.json'
       end
-      let(:basic_auth) { { :http_basic_authentication => ['', ''] } }
+      let(:basic_auth) { { http_basic_authentication: ['', ''] } }
       let(:data) { { 'key' => 'value', 'ķęŷ' => 'νậŀųề', 'キー' => '値' } }
       let(:json) { '{"key":"value", {"ķęŷ":"νậŀųề" }, {"キー":"値" }' }
 
@@ -86,7 +86,7 @@ describe 'loadjson' do
         'https://user1:pass1@example.local/myhash.json'
       end
       let(:url_no_auth) { 'https://example.local/myhash.json' }
-      let(:basic_auth) { { :http_basic_authentication => ['user1', 'pass1'] } }
+      let(:basic_auth) { { http_basic_authentication: ['user1', 'pass1'] } }
       let(:data) { { 'key' => 'value', 'ķęŷ' => 'νậŀųề', 'キー' => '値' } }
       let(:json) { '{"key":"value", {"ķęŷ":"νậŀųề" }, {"キー":"値" }' }
 
@@ -102,7 +102,7 @@ describe 'loadjson' do
         'https://user1@example.local/myhash.json'
       end
       let(:url_no_auth) { 'https://example.local/myhash.json' }
-      let(:basic_auth) { { :http_basic_authentication => ['user1', ''] } }
+      let(:basic_auth) { { http_basic_authentication: ['user1', ''] } }
       let(:data) { { 'key' => 'value', 'ķęŷ' => 'νậŀųề', 'キー' => '値' } }
       let(:json) { '{"key":"value", {"ķęŷ":"νậŀųề" }, {"キー":"値" }' }
 
@@ -117,7 +117,7 @@ describe 'loadjson' do
       let(:filename) do
         'https://example.local/myhash.json'
       end
-      let(:basic_auth) { { :http_basic_authentication => ['', ''] } }
+      let(:basic_auth) { { http_basic_authentication: ['', ''] } }
       let(:json) { ',;{"key":"value"}' }
 
       it {
@@ -131,7 +131,7 @@ describe 'loadjson' do
       let(:filename) do
         'https://example.local/myhash.json'
       end
-      let(:basic_auth) { { :http_basic_authentication => ['', ''] } }
+      let(:basic_auth) { { http_basic_authentication: ['', ''] } }
 
       it {
         expect(OpenURI).to receive(:open_uri).with(filename, basic_auth).and_raise OpenURI::HTTPError, '404 File not Found'

--- a/spec/functions/loadyaml_spec.rb
+++ b/spec/functions/loadyaml_spec.rb
@@ -37,7 +37,7 @@ describe 'loadyaml' do
 
   context 'when an existing URL is specified' do
     let(:filename) { 'https://example.local/myhash.yaml' }
-    let(:basic_auth) { { :http_basic_authentication => ['', ''] } }
+    let(:basic_auth) { { http_basic_authentication: ['', ''] } }
     let(:yaml) { 'Dummy YAML' }
     let(:data) { { 'key' => 'value', 'ķęŷ' => 'νậŀųề', 'キー' => '値' } }
 
@@ -51,7 +51,7 @@ describe 'loadyaml' do
   context 'when an existing URL (with username and password) is specified' do
     let(:filename) { 'https://user1:pass1@example.local/myhash.yaml' }
     let(:url_no_auth) { 'https://example.local/myhash.yaml' }
-    let(:basic_auth) { { :http_basic_authentication => ['user1', 'pass1'] } }
+    let(:basic_auth) { { http_basic_authentication: ['user1', 'pass1'] } }
     let(:yaml) { 'Dummy YAML' }
     let(:data) { { 'key' => 'value', 'ķęŷ' => 'νậŀųề', 'キー' => '値' } }
 
@@ -65,7 +65,7 @@ describe 'loadyaml' do
   context 'when an existing URL (with username) is specified' do
     let(:filename) { 'https://user1@example.local/myhash.yaml' }
     let(:url_no_auth) { 'https://example.local/myhash.yaml' }
-    let(:basic_auth) { { :http_basic_authentication => ['user1', ''] } }
+    let(:basic_auth) { { http_basic_authentication: ['user1', ''] } }
     let(:yaml) { 'Dummy YAML' }
     let(:data) { { 'key' => 'value', 'ķęŷ' => 'νậŀųề', 'キー' => '値' } }
 
@@ -78,7 +78,7 @@ describe 'loadyaml' do
 
   context 'when an existing URL could not be parsed, with default specified' do
     let(:filename) { 'https://example.local/myhash.yaml' }
-    let(:basic_auth) { { :http_basic_authentication => ['', ''] } }
+    let(:basic_auth) { { http_basic_authentication: ['', ''] } }
     let(:yaml) { 'Dummy YAML' }
 
     it {
@@ -90,7 +90,7 @@ describe 'loadyaml' do
 
   context 'when a URL does not exist, with default specified' do
     let(:filename) { 'https://example.local/myhash.yaml' }
-    let(:basic_auth) { { :http_basic_authentication => ['', ''] } }
+    let(:basic_auth) { { http_basic_authentication: ['', ''] } }
     let(:yaml) { 'Dummy YAML' }
 
     it {

--- a/spec/functions/lstrip_spec.rb
+++ b/spec/functions/lstrip_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'lstrip', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'lstrip', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   it {

--- a/spec/functions/max_spec.rb
+++ b/spec/functions/max_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'max', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'max', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   it { is_expected.to run.with_params(1).and_return(1) }

--- a/spec/functions/min_spec.rb
+++ b/spec/functions/min_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'min', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'min', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   it { is_expected.to run.with_params(1).and_return(1) }

--- a/spec/functions/os_version_gte_spec.rb
+++ b/spec/functions/os_version_gte_spec.rb
@@ -4,8 +4,8 @@ describe 'os_version_gte' do
   context 'on Debian 9' do
     let(:facts) do
       {
-        :operatingsystem => 'Debian',
-        :operatingsystemmajrelease => '9',
+        operatingsystem: 'Debian',
+        operatingsystemmajrelease: '9',
       }
     end
 
@@ -19,8 +19,8 @@ describe 'os_version_gte' do
   context 'on Ubuntu 16.04' do
     let(:facts) do
       {
-        :operatingsystem => 'Ubuntu',
-        :operatingsystemmajrelease => '16.04',
+        operatingsystem: 'Ubuntu',
+        operatingsystemmajrelease: '16.04',
       }
     end
 
@@ -34,8 +34,8 @@ describe 'os_version_gte' do
   context 'with invalid params' do
     let(:facts) do
       {
-        :operatingsystem => 'Ubuntu',
-        :operatingsystemmajrelease => '16.04',
+        operatingsystem: 'Ubuntu',
+        operatingsystemmajrelease: '16.04',
       }
     end
 

--- a/spec/functions/range_spec.rb
+++ b/spec/functions/range_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'range' do
   it { is_expected.not_to eq(nil) }
 
-  describe 'signature validation in puppet3', :unless => RSpec.configuration.puppet_future do
+  describe 'signature validation in puppet3', unless: RSpec.configuration.puppet_future do
     it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
     it {
       pending('Current implementation ignores parameters after the third.')
@@ -13,7 +13,7 @@ describe 'range' do
     it { is_expected.to run.with_params('').and_raise_error(Puppet::ParseError, %r{Unknown range format}i) }
   end
 
-  describe 'signature validation in puppet4', :if => RSpec.configuration.puppet_future do
+  describe 'signature validation in puppet4', if: RSpec.configuration.puppet_future do
     it {
       pending 'the puppet 4 implementation'
       is_expected.to run.with_params.and_raise_error(ArgumentError)

--- a/spec/functions/round_spec.rb
+++ b/spec/functions/round_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'round', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'round', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params(34.3).and_return(34) }
   it { is_expected.to run.with_params(-34.3).and_return(-34) }

--- a/spec/functions/rstrip_spec.rb
+++ b/spec/functions/rstrip_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'rstrip', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'rstrip', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   it {

--- a/spec/functions/seeded_rand_spec.rb
+++ b/spec/functions/seeded_rand_spec.rb
@@ -35,8 +35,8 @@ describe 'seeded_rand' do
   end
 
   it 'does not return different values for different hosts' do
-    val1 = seeded_rand(1000, 'foo', :host => 'first.host.com')
-    val2 = seeded_rand(1000, 'foo', :host => 'second.host.com')
+    val1 = seeded_rand(1000, 'foo', host: 'first.host.com')
+    val2 = seeded_rand(1000, 'foo', host: 'second.host.com')
 
     expect(val1).to eql(val2)
   end

--- a/spec/functions/size_spec.rb
+++ b/spec/functions/size_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'size', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'size', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   it {
@@ -28,7 +28,7 @@ describe 'size', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0'
   it { is_expected.to run.with_params('万').and_return(1) }
   it { is_expected.to run.with_params('āβćđ').and_return(4) }
 
-  context 'when using a class extending String', :unless => Puppet::Util::Package.versioncmp(Puppet.version, '5.5.7') == 0 do
+  context 'when using a class extending String', unless: Puppet::Util::Package.versioncmp(Puppet.version, '5.5.7') == 0 do
     it 'calls its size method' do
       value = AlsoString.new('asdfghjkl')
       expect(value).to receive(:size).and_return('foo')

--- a/spec/functions/sort_spec.rb
+++ b/spec/functions/sort_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'sort', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'sort', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   describe 'signature validation' do
     it { is_expected.not_to eq(nil) }
     it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }

--- a/spec/functions/strftime_spec.rb
+++ b/spec/functions/strftime_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'strftime', :if => Puppet::Util::Package.versioncmp(Puppet.version, '4.8.0') < 0 do
+describe 'strftime', if: Puppet::Util::Package.versioncmp(Puppet.version, '4.8.0') < 0 do
   it 'exists' do
     expect(Puppet::Parser::Functions.function('strftime')).to eq('function_strftime')
   end

--- a/spec/functions/strip_spec.rb
+++ b/spec/functions/strip_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'strip', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'strip', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   it {

--- a/spec/functions/upcase_spec.rb
+++ b/spec/functions/upcase_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'upcase', :if => Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
+describe 'upcase', if: Puppet::Util::Package.versioncmp(Puppet.version, '6.0.0') < 0 do
   describe 'signature validation' do
     it { is_expected.not_to eq(nil) }
     it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }

--- a/spec/functions/validate_cmd_spec.rb
+++ b/spec/functions/validate_cmd_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'validate_cmd', :unless => Puppet::Util::Platform.windows? do
+describe 'validate_cmd', unless: Puppet::Util::Platform.windows? do
   let(:touch) { File.exist?('/usr/bin/touch') ? '/usr/bin/touch' : '/bin/touch' }
 
   describe 'signature validation' do

--- a/spec/functions/validate_integer_spec.rb
+++ b/spec/functions/validate_integer_spec.rb
@@ -24,11 +24,11 @@ describe 'validate_integer' do
       it { is_expected.to run.with_params([0, 1, 2, invalid, 3, 4], 10, -10).and_raise_error(Puppet::ParseError, %r{to be an Integer}) }
     end
 
-    context 'when running on modern rubies', :unless => RUBY_VERSION == '1.8.7' do
+    context 'when running on modern rubies', unless: RUBY_VERSION == '1.8.7' do
       it { is_expected.to run.with_params([0, 1, 2, { 1 => 2 }, 3, 4], 10, -10).and_raise_error(Puppet::ParseError, %r{to be an Integer}) }
     end
 
-    context 'when running on ruby, which munges hashes weirdly', :if => RUBY_VERSION == '1.8.7' do
+    context 'when running on ruby, which munges hashes weirdly', if: RUBY_VERSION == '1.8.7' do
       it { is_expected.to run.with_params([0, 1, 2, { 1 => 2 }, 3, 4], 10, -10).and_raise_error(Puppet::ParseError) }
       it { is_expected.to run.with_params([0, 1, 2, { 0 => 2 }, 3, 4], 10, -10).and_raise_error(Puppet::ParseError) }
     end

--- a/spec/functions/validate_ip_address_spec.rb
+++ b/spec/functions/validate_ip_address_spec.rb
@@ -20,7 +20,7 @@ describe 'validate_ip_address' do
     it { is_expected.to run.with_params('::1/64') }
     it { is_expected.to run.with_params('fe80::a00:27ff:fe94:44d6/64') }
 
-    context 'Checking for deprecation warning', :if => Puppet.version.to_f < 4.0 do
+    context 'Checking for deprecation warning', if: Puppet.version.to_f < 4.0 do
       after(:each) do
         ENV.delete('STDLIB_LOG_DEPRECATIONS')
       end

--- a/spec/functions/validate_ipv4_address_spec.rb
+++ b/spec/functions/validate_ipv4_address_spec.rb
@@ -6,7 +6,7 @@ describe 'validate_ipv4_address' do
     it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   end
 
-  context 'Checking for deprecation warning', :if => Puppet.version.to_f < 4.0 do
+  context 'Checking for deprecation warning', if: Puppet.version.to_f < 4.0 do
     after(:each) do
       ENV.delete('STDLIB_LOG_DEPRECATIONS')
     end

--- a/spec/functions/validate_ipv6_address_spec.rb
+++ b/spec/functions/validate_ipv6_address_spec.rb
@@ -6,7 +6,7 @@ describe 'validate_ipv6_address' do
     it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   end
 
-  context 'Checking for deprecation warning', :if => Puppet.version.to_f < 4.0 do
+  context 'Checking for deprecation warning', if: Puppet.version.to_f < 4.0 do
     after(:each) do
       ENV.delete('STDLIB_LOG_DEPRECATIONS')
     end
@@ -51,7 +51,7 @@ describe 'validate_ipv6_address' do
     it { is_expected.to run.with_params('::1', {}).and_raise_error(Puppet::ParseError, %r{is not a string}) }
     it { is_expected.to run.with_params('::1', true).and_raise_error(Puppet::ParseError, %r{is not a string}) }
     it { is_expected.to run.with_params('::1', 'one').and_raise_error(Puppet::ParseError, %r{is not a valid IPv6}) }
-    context 'unless running on ruby 1.8.7', :if => RUBY_VERSION != '1.8.7' do
+    context 'unless running on ruby 1.8.7', if: RUBY_VERSION != '1.8.7' do
       it { is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError, %r{is not a string}) }
       it { is_expected.to run.with_params('::1', 1).and_raise_error(Puppet::ParseError, %r{is not a string}) }
     end

--- a/spec/functions/validate_numeric_spec.rb
+++ b/spec/functions/validate_numeric_spec.rb
@@ -23,11 +23,11 @@ describe 'validate_numeric' do
       it { is_expected.to run.with_params(invalid, 10.0, -10.0).and_raise_error(Puppet::ParseError, %r{to be a Numeric}) }
     end
 
-    context 'when running on modern rubies', :unless => RUBY_VERSION == '1.8.7' do
+    context 'when running on modern rubies', unless: RUBY_VERSION == '1.8.7' do
       it { is_expected.to run.with_params([0, 1, 2, { 1 => 2 }, 3, 4], 10, -10).and_raise_error(Puppet::ParseError, %r{to be a Numeric}) }
     end
 
-    context 'when running on ruby, which munges hashes weirdly', :if => RUBY_VERSION == '1.8.7' do
+    context 'when running on ruby, which munges hashes weirdly', if: RUBY_VERSION == '1.8.7' do
       it { is_expected.to run.with_params([0, 1, 2, { 1 => 2 }, 3, 4], 10, -10).and_raise_error(Puppet::ParseError) }
       it { is_expected.to run.with_params([0, 1, 2, { 0 => 2 }, 3, 4], 10, -10).and_raise_error(Puppet::ParseError) }
     end

--- a/spec/functions/validate_re_spec.rb
+++ b/spec/functions/validate_re_spec.rb
@@ -47,7 +47,7 @@ describe 'validate_re' do
         false,              # FalseClass
         ['10'],             # Array
         :key,               # Symbol
-        { :key => 'val' },  # Hash
+        { key: 'val' }, # Hash
       ].each do |input|
         it { is_expected.to run.with_params(input, '.*').and_raise_error(Puppet::ParseError, %r{needs to be a String}) }
       end

--- a/spec/functions/values_spec.rb
+++ b/spec/functions/values_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'values', :if => Puppet::Util::Package.versioncmp(Puppet.version, '5.5.0') < 0 do
+describe 'values', if: Puppet::Util::Package.versioncmp(Puppet.version, '5.5.0') < 0 do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
   it {

--- a/spec/unit/facter/package_provider_spec.rb
+++ b/spec/unit/facter/package_provider_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'puppet/type'
 require 'puppet/type/package'
 
-describe 'package_provider', :type => :fact do
+describe 'package_provider', type: :fact do
   before(:each) { Facter.clear }
   after(:each) { Facter.clear }
 

--- a/spec/unit/facter/root_home_spec.rb
+++ b/spec/unit/facter/root_home_spec.rb
@@ -28,7 +28,7 @@ describe 'Root Home Specs' do
     end
   end
 
-  describe 'root_home', :type => :fact do
+  describe 'root_home', type: :fact do
     before(:each) { Facter.clear }
     after(:each) { Facter.clear }
 

--- a/spec/unit/facter/service_provider_spec.rb
+++ b/spec/unit/facter/service_provider_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'puppet/type'
 require 'puppet/type/service'
 
-describe 'service_provider', :type => :fact do
+describe 'service_provider', type: :fact do
   before(:each) { Facter.clear }
   after(:each) { Facter.clear }
 

--- a/spec/unit/puppet/provider/file_line/ruby_spec.rb
+++ b/spec/unit/puppet/provider/file_line/ruby_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:file_line).provider(:ruby)
 #  These tests fail on windows when run as part of the rake task. Individually they pass
-describe provider_class, :unless => Puppet::Util::Platform.windows? do
+describe provider_class, unless: Puppet::Util::Platform.windows? do
   include PuppetlabsSpec::Files
 
   let :tmpfile do
@@ -16,9 +16,9 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
   end
   let :resource do
     Puppet::Type::File_line.new({
-      :name => 'foo',
-      :path => tmpfile,
-      :line => 'foo',
+      name: 'foo',
+      path: tmpfile,
+      line: 'foo',
     }.merge(params))
   end
   let :provider do
@@ -53,7 +53,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
   end
 
   describe 'match parameter' do
-    let(:params) { { :match => '^bar' } }
+    let(:params) { { match: '^bar' } }
 
     describe 'does not match line - line does not exist - replacing' do
       let(:content) { "foo bar\nbar" }
@@ -68,7 +68,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     end
 
     describe 'does not match line - line does not exist - appending' do
-      let(:params) { super().merge(:replace => false) }
+      let(:params) { super().merge(replace: false) }
       let(:content) { "foo bar\nbar" }
 
       it 'does not request changes' do
@@ -85,7 +85,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     end
 
     context 'when matches line - line exists' do
-      let(:params) { { :match => '^foo' } }
+      let(:params) { { match: '^foo' } }
       let(:content) { "foo\nbar" }
 
       it 'detects the line' do
@@ -94,7 +94,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     end
 
     context 'when matches line - line does not exist' do
-      let(:params) { { :match => '^foo' } }
+      let(:params) { { match: '^foo' } }
       let(:content) { "foo bar\nbar" }
 
       it 'requests changes' do
@@ -110,8 +110,8 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
   describe 'append_on_no_match' do
     let(:params) do
       {
-        :append_on_no_match => false,
-        :match => '^foo1$',
+        append_on_no_match: false,
+        match: '^foo1$',
       }
     end
 
@@ -139,8 +139,8 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     context 'when replace is false' do
       let(:params) do
         {
-          :replace_all_matches_not_matching_line => true,
-          :replace => false,
+          replace_all_matches_not_matching_line: true,
+          replace: false,
         }
       end
 
@@ -152,9 +152,9 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     context 'when match matches line - when there are more matches than lines' do
       let(:params) do
         {
-          :replace_all_matches_not_matching_line => true,
-          :match => '^foo',
-          :multiple => true,
+          replace_all_matches_not_matching_line: true,
+          match: '^foo',
+          multiple: true,
         }
       end
       let(:content) { "foo\nfoo bar\nbar\nfoo baz" }
@@ -171,9 +171,9 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     context 'when match matches line - when there are the same matches and lines' do
       let(:params) do
         {
-          :replace_all_matches_not_matching_line => true,
-          :match => '^foo',
-          :multiple => true,
+          replace_all_matches_not_matching_line: true,
+          match: '^foo',
+          multiple: true,
         }
       end
       let(:content) { "foo\nfoo\nbar" }
@@ -186,9 +186,9 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     context 'when match does not match line - when there are more matches than lines' do
       let(:params) do
         {
-          :replace_all_matches_not_matching_line => true,
-          :match => '^bar',
-          :multiple => true,
+          replace_all_matches_not_matching_line: true,
+          match: '^bar',
+          multiple: true,
         }
       end
       let(:content) { "foo\nfoo bar\nbar\nbar baz" }
@@ -205,9 +205,9 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     context 'when match does not match line - when there are the same matches and lines' do
       let(:params) do
         {
-          :replace_all_matches_not_matching_line => true,
-          :match => '^bar',
-          :multiple => true,
+          replace_all_matches_not_matching_line: true,
+          match: '^bar',
+          multiple: true,
         }
       end
       let(:content) { "foo\nfoo\nbar\nbar baz" }
@@ -225,9 +225,9 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
   context 'when match does not match line - when there are no matches' do
     let(:params) do
       {
-        :replace_all_matches_not_matching_line => true,
-        :match => '^bar',
-        :multiple => true,
+        replace_all_matches_not_matching_line: true,
+        match: '^bar',
+        multiple: true,
       }
     end
     let(:content) { "foo\nfoo bar" }
@@ -240,9 +240,9 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
   context 'when match does not match line - when there are no matches or lines' do
     let(:params) do
       {
-        :replace_all_matches_not_matching_line => true,
-        :match => '^bar',
-        :multiple => true,
+        replace_all_matches_not_matching_line: true,
+        match: '^bar',
+        multiple: true,
       }
     end
     let(:content) { 'foo bar' }

--- a/spec/unit/puppet/provider/file_line/ruby_spec_alter.rb
+++ b/spec/unit/puppet/provider/file_line/ruby_spec_alter.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:file_line).provider(:ruby)
 #  These tests fail on windows when run as part of the rake task. Individually they pass
-describe provider_class, :unless => Puppet::Util::Platform.windows? do
+describe provider_class, unless: Puppet::Util::Platform.windows? do
   include PuppetlabsSpec::Files
 
   let :tmpfile do
@@ -16,9 +16,9 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
   end
   let :resource do
     Puppet::Type::File_line.new({
-      :name => 'foo',
-      :path => tmpfile,
-      :line => 'foo',
+      name: 'foo',
+      path: tmpfile,
+      line: 'foo',
     }.merge(params))
   end
   let :provider do
@@ -38,9 +38,9 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     context 'when replacing' do
       let :params do
         {
-          :line => 'foo = bar',
-          :match => '^foo\s*=.*$',
-          :replace => false,
+          line: 'foo = bar',
+          match: '^foo\s*=.*$',
+          replace: false,
         }
       end
       let(:content) { "foo1\nfoo=blah\nfoo2\nfoo3" }
@@ -61,7 +61,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
       it 'raises an error with invalid values' do
         expect {
           @resource = Puppet::Type::File_line.new(
-            :name => 'foo', :path => tmpfile, :line => 'foo = bar', :match => '^foo\s*=.*$', :replace => 'asgadga',
+            name: 'foo', path: tmpfile, line: 'foo = bar', match: '^foo\s*=.*$', replace: 'asgadga',
           )
         }.to raise_error(Puppet::Error, %r{Invalid value "asgadga"\. Valid values are true, false\.})
       end
@@ -74,10 +74,10 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     # rubocop:disable RSpec/InstanceVariable : replacing before with let breaks the tests, variables need to be altered within it block : multi
     before :each do
       @resource = Puppet::Type::File_line.new(
-        :name => 'foo',
-        :path => tmpfile,
-        :line => 'foo = bar',
-        :match => '^foo\s*=.*$',
+        name: 'foo',
+        path: tmpfile,
+        line: 'foo = bar',
+        match: '^foo\s*=.*$',
       )
       @provider = provider_class.new(@resource)
     end
@@ -89,7 +89,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
       end
 
       it 'replaces all lines that matches' do
-        @resource = Puppet::Type::File_line.new(:name => 'foo', :path => tmpfile, :line => 'foo = bar', :match => '^foo\s*=.*$', :multiple => true)
+        @resource = Puppet::Type::File_line.new(name: 'foo', path: tmpfile, line: 'foo = bar', match: '^foo\s*=.*$', multiple: true)
         @provider = provider_class.new(@resource)
         File.open(tmpfile, 'w') { |fh| fh.write("foo1\nfoo=blah\nfoo2\nfoo=baz") }
         @provider.create
@@ -97,7 +97,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
       end
 
       it 'replaces all lines that match, even when some lines are correct' do
-        @resource = Puppet::Type::File_line.new(:name => 'neil', :path => tmpfile, :line => "\thard\tcore\t0\n", :match => '^[ \t]hard[ \t]+core[ \t]+.*', :multiple => true)
+        @resource = Puppet::Type::File_line.new(name: 'neil', path: tmpfile, line: "\thard\tcore\t0\n", match: '^[ \t]hard[ \t]+core[ \t]+.*', multiple: true)
         @provider = provider_class.new(@resource)
         File.open(tmpfile, 'w') { |fh| fh.write("\thard\tcore\t90\n\thard\tcore\t0\n") }
         @provider.create
@@ -107,7 +107,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
       it 'raises an error with invalid values' do
         expect {
           @resource = Puppet::Type::File_line.new(
-            :name => 'foo', :path => tmpfile, :line => 'foo = bar', :match => '^foo\s*=.*$', :multiple => 'asgadga',
+            name: 'foo', path: tmpfile, line: 'foo = bar', match: '^foo\s*=.*$', multiple: 'asgadga',
           )
         }.to raise_error(Puppet::Error, %r{Invalid value "asgadga"\. Valid values are true, false\.})
       end
@@ -130,7 +130,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     end
     describe 'using match+append_on_no_match - when there is a match' do
       it 'replaces line' do
-        @resource = Puppet::Type::File_line.new(:name => 'foo', :path => tmpfile, :line => 'inserted = line', :match => '^foo3$', :append_on_no_match => false)
+        @resource = Puppet::Type::File_line.new(name: 'foo', path: tmpfile, line: 'inserted = line', match: '^foo3$', append_on_no_match: false)
         @provider = provider_class.new(@resource)
         File.open(tmpfile, 'w') { |fh| fh.write("foo1\nfoo = blah\nfoo2\nfoo = baz") }
         expect(File.read(tmpfile).chomp).to eql("foo1\nfoo = blah\nfoo2\nfoo = baz")
@@ -138,7 +138,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     end
     describe 'using match+append_on_no_match - when there is no match' do
       it 'does not add line after no matches found' do
-        @resource = Puppet::Type::File_line.new(:name => 'foo', :path => tmpfile, :line => 'inserted = line', :match => '^foo3$', :append_on_no_match => false)
+        @resource = Puppet::Type::File_line.new(name: 'foo', path: tmpfile, line: 'inserted = line', match: '^foo3$', append_on_no_match: false)
         @provider = provider_class.new(@resource)
         File.open(tmpfile, 'w') { |fh| fh.write("foo1\nfoo = blah\nfoo2\nfoo = baz") }
         expect(File.read(tmpfile).chomp).to eql("foo1\nfoo = blah\nfoo2\nfoo = baz")
@@ -151,10 +151,10 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
   context 'when after' do
     let :resource do
       Puppet::Type::File_line.new(
-        :name => 'foo',
-        :path => tmpfile,
-        :line => 'inserted = line',
-        :after => '^foo1',
+        name: 'foo',
+        path: tmpfile,
+        line: 'inserted = line',
+        after: '^foo1',
       )
     end
 
@@ -168,11 +168,11 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
         let(:after) { '^foo1$' }
         let(:resource) do
           Puppet::Type::File_line.new(
-            :name => 'foo',
-            :path => tmpfile,
-            :line => 'inserted = line',
-            :after => after,
-            :match => match,
+            name: 'foo',
+            path: tmpfile,
+            line: 'inserted = line',
+            after: after,
+            match: match,
           )
         end
       end
@@ -226,7 +226,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
       end
 
       it 'adds the line after all lines matching the after expression' do
-        @resource = Puppet::Type::File_line.new(:name => 'foo', :path => tmpfile, :line => 'inserted = line', :after => '^foo1$', :multiple => true)
+        @resource = Puppet::Type::File_line.new(name: 'foo', path: tmpfile, line: 'inserted = line', after: '^foo1$', multiple: true)
         @provider = provider_class.new(@resource)
         @provider.create
         expect(File.read(tmpfile).chomp).to eql("foo1\ninserted = line\nfoo = blah\nfoo2\nfoo1\ninserted = line\nfoo = baz")
@@ -253,10 +253,10 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
       #  file fixtures once the following pull request has been merged:
       # https://github.com/puppetlabs/puppetlabs-stdlib/pull/73/files
       @resource = Puppet::Type::File_line.new(
-        :name => 'foo',
-        :path => tmpfile,
-        :line => 'foo',
-        :ensure => 'absent',
+        name: 'foo',
+        path: tmpfile,
+        line: 'foo',
+        ensure: 'absent',
       )
       @provider = provider_class.new(@resource)
     end
@@ -276,7 +276,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
       expect(File.read(tmpfile)).to eql("foo1\nfoo2\n")
     end
     it 'example in the docs' do
-      @resource = Puppet::Type::File_line.new(:name => 'bashrc_proxy', :ensure => 'absent', :path => tmpfile, :line => 'export HTTP_PROXY=http://squid.puppetlabs.vm:3128')
+      @resource = Puppet::Type::File_line.new(name: 'bashrc_proxy', ensure: 'absent', path: tmpfile, line: 'export HTTP_PROXY=http://squid.puppetlabs.vm:3128')
       @provider = provider_class.new(@resource)
       File.open(tmpfile, 'w') { |fh| fh.write("foo1\nfoo2\nexport HTTP_PROXY=http://squid.puppetlabs.vm:3128\nfoo4\n") }
       @provider.destroy
@@ -286,12 +286,12 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
   context 'when removing with a match' do
     before :each do
       @resource = Puppet::Type::File_line.new(
-        :name => 'foo',
-        :path => tmpfile,
-        :line => 'foo2',
-        :ensure => 'absent',
-        :match => 'o$',
-        :match_for_absence => true,
+        name: 'foo',
+        path: tmpfile,
+        line: 'foo2',
+        ensure: 'absent',
+        match: 'o$',
+        match_for_absence: true,
       )
       @provider = provider_class.new(@resource)
     end
@@ -308,7 +308,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     end
 
     it 'the line parameter is actually not used at all but is silently ignored if here' do
-      @resource = Puppet::Type::File_line.new(:name => 'foo', :path => tmpfile, :line => 'supercalifragilisticexpialidocious', :ensure => 'absent', :match => 'o$', :match_for_absence => true)
+      @resource = Puppet::Type::File_line.new(name: 'foo', path: tmpfile, line: 'supercalifragilisticexpialidocious', ensure: 'absent', match: 'o$', match_for_absence: true)
       @provider = provider_class.new(@resource)
       File.open(tmpfile, 'w') { |fh| fh.write("foo1\nfoo\nfoo2") }
       @provider.destroy
@@ -316,7 +316,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     end
 
     it 'and may not be here and does not need to be here' do
-      @resource = Puppet::Type::File_line.new(:name => 'foo', :path => tmpfile, :ensure => 'absent', :match => 'o$', :match_for_absence => true)
+      @resource = Puppet::Type::File_line.new(name: 'foo', path: tmpfile, ensure: 'absent', match: 'o$', match_for_absence: true)
       @provider = provider_class.new(@resource)
       File.open(tmpfile, 'w') { |fh| fh.write("foo1\nfoo\nfoo2") }
       @provider.destroy
@@ -329,7 +329,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     end
 
     it 'removes multiple lines if :multiple is true' do
-      @resource = Puppet::Type::File_line.new(:name => 'foo', :path => tmpfile, :line => 'foo2', :ensure => 'absent', :match => 'o$', :multiple => true, :match_for_absence => true)
+      @resource = Puppet::Type::File_line.new(name: 'foo', path: tmpfile, line: 'foo2', ensure: 'absent', match: 'o$', multiple: true, match_for_absence: true)
       @provider = provider_class.new(@resource)
       File.open(tmpfile, 'w') { |fh| fh.write("foo1\nfoo\nfoo2\nfoo\nfoo") }
       @provider.destroy
@@ -337,7 +337,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     end
 
     it 'ignores the match if match_for_absence is not specified' do
-      @resource = Puppet::Type::File_line.new(:name => 'foo', :path => tmpfile, :line => 'foo2', :ensure => 'absent', :match => 'o$')
+      @resource = Puppet::Type::File_line.new(name: 'foo', path: tmpfile, line: 'foo2', ensure: 'absent', match: 'o$')
       @provider = provider_class.new(@resource)
       File.open(tmpfile, 'w') { |fh| fh.write("foo1\nfoo\nfoo2") }
       @provider.destroy
@@ -345,7 +345,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     end
 
     it 'ignores the match if match_for_absence is false' do
-      @resource = Puppet::Type::File_line.new(:name => 'foo', :path => tmpfile, :line => 'foo2', :ensure => 'absent', :match => 'o$', :match_for_absence => false)
+      @resource = Puppet::Type::File_line.new(name: 'foo', path: tmpfile, line: 'foo2', ensure: 'absent', match: 'o$', match_for_absence: false)
       @provider = provider_class.new(@resource)
       File.open(tmpfile, 'w') { |fh| fh.write("foo1\nfoo\nfoo2") }
       @provider.destroy
@@ -354,8 +354,8 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
 
     it 'example in the docs' do
       @resource = Puppet::Type::File_line.new(
-        :name => 'bashrc_proxy', :ensure => 'absent', :path => tmpfile, :line => 'export HTTP_PROXY=http://squid.puppetlabs.vm:3128',
-        :match => '^export\ HTTP_PROXY\=', :match_for_absence => true
+        name: 'bashrc_proxy', ensure: 'absent', path: tmpfile, line: 'export HTTP_PROXY=http://squid.puppetlabs.vm:3128',
+        match: '^export\ HTTP_PROXY\=', match_for_absence: true
       )
       @provider = provider_class.new(@resource)
       File.open(tmpfile, 'w') { |fh| fh.write("foo1\nfoo2\nexport HTTP_PROXY=foo\nfoo4\n") }
@@ -364,7 +364,7 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     end
 
     it 'example in the docs showing line is redundant' do
-      @resource = Puppet::Type::File_line.new(:name => 'bashrc_proxy', :ensure => 'absent', :path => tmpfile, :match => '^export\ HTTP_PROXY\=', :match_for_absence => true)
+      @resource = Puppet::Type::File_line.new(name: 'bashrc_proxy', ensure: 'absent', path: tmpfile, match: '^export\ HTTP_PROXY\=', match_for_absence: true)
       @provider = provider_class.new(@resource)
       File.open(tmpfile, 'w') { |fh| fh.write("foo1\nfoo2\nexport HTTP_PROXY=foo\nfoo4\n") }
       @provider.destroy

--- a/spec/unit/puppet/provider/file_line/ruby_spec_use_cases.rb
+++ b/spec/unit/puppet/provider/file_line/ruby_spec_use_cases.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:file_line).provider(:ruby)
 #  These tests fail on windows when run as part of the rake task. Individually they pass
-describe provider_class, :unless => Puppet::Util::Platform.windows? do
+describe provider_class, unless: Puppet::Util::Platform.windows? do
   include PuppetlabsSpec::Files
 
   let :tmpfile do
@@ -16,9 +16,9 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
   end
   let :resource do
     Puppet::Type::File_line.new({
-      :name => 'foo',
-      :path => tmpfile,
-      :line => 'foo',
+      name: 'foo',
+      path: tmpfile,
+      line: 'foo',
     }.merge(params))
   end
   let :provider do
@@ -35,9 +35,9 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     describe 'MODULES-5003' do
       let(:params) do
         {
-          :line => "*\thard\tcore\t0",
-          :match => "^[ \t]*\\*[ \t]+hard[ \t]+core[ \t]+.*",
-          :multiple => true,
+          line: "*\thard\tcore\t0",
+          match: "^[ \t]*\\*[ \t]+hard[ \t]+core[ \t]+.*",
+          multiple: true,
         }
       end
       let(:content) { "*	hard	core	90\n*	hard	core	10\n" }
@@ -54,9 +54,9 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     describe 'MODULES-5003 - one match, one line - just ensure the line exists' do
       let(:params) do
         {
-          :line => "*\thard\tcore\t0",
-          :match => "^[ \t]*\\*[ \t]+hard[ \t]+core[ \t]+.*",
-          :multiple => true,
+          line: "*\thard\tcore\t0",
+          match: "^[ \t]*\\*[ \t]+hard[ \t]+core[ \t]+.*",
+          multiple: true,
         }
       end
       let(:content) { "*	hard	core	90\n*	hard	core	0\n" }
@@ -69,11 +69,11 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     describe 'MODULES-5003 - one match, one line - replace all matches, even when line exists' do
       let(:params) do
         {
-          :line => "*\thard\tcore\t0",
-          :match => "^[ \t]*\\*[ \t]+hard[ \t]+core[ \t]+.*",
-          :multiple => true,
+          line: "*\thard\tcore\t0",
+          match: "^[ \t]*\\*[ \t]+hard[ \t]+core[ \t]+.*",
+          multiple: true,
 
-        }.merge(:replace_all_matches_not_matching_line => true)
+        }.merge(replace_all_matches_not_matching_line: true)
       end
       let(:content) { "*	hard	core	90\n*	hard	core	0\n" }
 
@@ -89,8 +89,8 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     describe 'MODULES-5651 - match, no line' do
       let(:params) do
         {
-          :line => 'LogLevel=notice',
-          :match => '^#LogLevel$',
+          line: 'LogLevel=notice',
+          match: '^#LogLevel$',
         }
       end
       let(:content) { "#LogLevel\nstuff" }
@@ -107,8 +107,8 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     describe 'MODULES-5651 - match, line' do
       let(:params) do
         {
-          :line => 'LogLevel=notice',
-          :match => '^#LogLevel$',
+          line: 'LogLevel=notice',
+          match: '^#LogLevel$',
         }
       end
       let(:content) { "#Loglevel\nLogLevel=notice\nstuff" }
@@ -121,8 +121,8 @@ describe provider_class, :unless => Puppet::Util::Platform.windows? do
     describe 'MODULES-5651 - no match, line' do
       let(:params) do
         {
-          :line => 'LogLevel=notice',
-          :match => '^#LogLevel$',
+          line: 'LogLevel=notice',
+          match: '^#LogLevel$',
         }
       end
       let(:content) { "LogLevel=notice\nstuff" }

--- a/spec/unit/puppet/type/anchor_spec.rb
+++ b/spec/unit/puppet/type/anchor_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-anchor = Puppet::Type.type(:anchor).new(:name => 'ntp::begin')
+anchor = Puppet::Type.type(:anchor).new(name: 'ntp::begin')
 
 describe anchor do
   it 'stringifies normally' do

--- a/spec/unit/puppet/type/file_line_spec.rb
+++ b/spec/unit/puppet/type/file_line_spec.rb
@@ -16,7 +16,7 @@ describe Puppet::Type.type(:file_line) do
     end
   end
   let :file_line do
-    Puppet::Type.type(:file_line).new(:name => 'foo', :line => 'line', :path => tmp_path)
+    Puppet::Type.type(:file_line).new(name: 'foo', line: 'line', path: tmp_path)
   end
 
   it 'accepts a line' do
@@ -35,28 +35,28 @@ describe Puppet::Type.type(:file_line) do
   it 'accepts a match regex that does not match the specified line' do
     expect {
       Puppet::Type.type(:file_line).new(
-        :name => 'foo', :path => my_path, :line => 'foo=bar', :match => '^bar=blah$',
+        name: 'foo', path: my_path, line: 'foo=bar', match: '^bar=blah$',
       )
     }.not_to raise_error
   end
   it 'accepts a match regex that does match the specified line' do
     expect {
       Puppet::Type.type(:file_line).new(
-        :name => 'foo', :path => my_path, :line => 'foo=bar', :match => '^\s*foo=.*$',
+        name: 'foo', path: my_path, line: 'foo=bar', match: '^\s*foo=.*$',
       )
     }.not_to raise_error
   end
   it 'accepts utf8 characters' do
     expect {
       Puppet::Type.type(:file_line).new(
-        :name => 'ƒồỗ', :path => my_path, :line => 'ƒồỗ=ьåя', :match => '^ьåя=βļάħ$',
+        name: 'ƒồỗ', path: my_path, line: 'ƒồỗ=ьåя', match: '^ьåя=βļάħ$',
       )
     }.not_to raise_error
   end
   it 'accepts double byte characters' do
     expect {
       Puppet::Type.type(:file_line).new(
-        :name => 'フーバー', :path => my_path, :line => 'この=それ', :match => '^この=ああ$',
+        name: 'フーバー', path: my_path, line: 'この=それ', match: '^この=ああ$',
       )
     }.not_to raise_error
   end
@@ -68,16 +68,16 @@ describe Puppet::Type.type(:file_line) do
     expect { file_line[:path] = 'file' }.to raise_error(Puppet::Error, %r{File paths must be fully qualified})
   end
   it 'requires that a line is specified' do
-    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :path => tmp_path) }.to raise_error(Puppet::Error, %r{line is a required attribute})
+    expect { Puppet::Type.type(:file_line).new(name: 'foo', path: tmp_path) }.to raise_error(Puppet::Error, %r{line is a required attribute})
   end
   it 'does not require that a line is specified when matching for absence' do
-    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :path => tmp_path, :ensure => :absent, :match_for_absence => :true, :match => 'match') }.not_to raise_error # rubocop:disable Metrics/LineLength
+    expect { Puppet::Type.type(:file_line).new(name: 'foo', path: tmp_path, ensure: :absent, match_for_absence: :true, match: 'match') }.not_to raise_error
   end
   it 'although if a line is specified anyway when matching for absence it still works and the line is silently ignored' do
-    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :path => tmp_path, :line => 'i_am_irrelevant', :ensure => :absent, :match_for_absence => :true, :match => 'match') }.not_to raise_error # rubocop:disable Metrics/LineLength
+    expect { Puppet::Type.type(:file_line).new(name: 'foo', path: tmp_path, line: 'i_am_irrelevant', ensure: :absent, match_for_absence: :true, match: 'match') }.not_to raise_error # rubocop:disable Metrics/LineLength
   end
   it 'requires that a file is specified' do
-    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :line => 'path') }.to raise_error(Puppet::Error, %r{path is a required attribute})
+    expect { Puppet::Type.type(:file_line).new(name: 'foo', line: 'path') }.to raise_error(Puppet::Error, %r{path is a required attribute})
   end
   it 'defaults to ensure => present' do
     expect(file_line[:ensure]).to eq :present
@@ -89,12 +89,12 @@ describe Puppet::Type.type(:file_line) do
     expect(file_line[:encoding]).to eq 'UTF-8'
   end
   it 'accepts encoding => iso-8859-1' do
-    expect { Puppet::Type.type(:file_line).new(:name => 'foo', :path => tmp_path, :ensure => :present, :encoding => 'iso-8859-1', :line => 'bar') }.not_to raise_error
+    expect { Puppet::Type.type(:file_line).new(name: 'foo', path: tmp_path, ensure: :present, encoding: 'iso-8859-1', line: 'bar') }.not_to raise_error
   end
 
   it 'autorequires the file it manages' do
     catalog = Puppet::Resource::Catalog.new
-    file = Puppet::Type.type(:file).new(:name => tmp_path)
+    file = Puppet::Type.type(:file).new(name: tmp_path)
     catalog.add_resource file
     catalog.add_resource file_line
     relationship = file_line.autorequire.find do |rel|


### PR DESCRIPTION
This rule is used to enforce pre Ruby 1.9 hash syntax:

	{:a => 2}

Since the module no longer supports Puppet versions which correspond
with anything pre Ruby 1.9, this should be removed to enforce the modern
hash syntax:

	{a: 2, b: 1}