### PR TITLE
(MODULES-9915) Add type aliases for cloud object store uris

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,51 @@ Match an IPv6 address which may contain `::` used to compress zeros as documente
 Match an IPv6 address in the CIDR format. It will only match if the address contains an address prefix (for example, it will match   'FF01:0:0:0:0:0:0:101/32', 'FF01::101/60', '::/0',
 but not 'FF01:0:0:0:0:0:0:101', 'FF01::101', '::').
 
+#### `Stdlib::ObjectStore`
+
+Matches cloud object store uris.
+
+Acceptable input example:
+
+```shell
+s3://mybucket/path/to/file
+
+gs://bucket/file
+
+```
+Valid values: cloud object store uris.
+
+
+#### `Stdlib::ObjectStore::GSUri`
+
+Matches Google Cloud object store uris.
+
+Acceptable input example:
+
+```shell
+
+gs://bucket/file
+
+gs://bucket/path/to/file
+
+```
+Valid values: Google Cloud object store uris.
+
+
+#### `Stdlib::ObjectStore::S3Uri`
+
+Matches Amazon Web Services S3 object store uris.
+
+Acceptable input example:
+
+```shell
+s3://bucket/file
+
+s3://bucket/path/to/file
+
+```
+Valid values: Amazon Web Services S3 object store uris.
+
 <a id="facts"></a>
 ### Facts
 

--- a/spec/type_aliases/objectstore_gsuri_spec.rb
+++ b/spec/type_aliases/objectstore_gsuri_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
+  describe 'Stdlib::ObjectStore::GSUri' do
+    describe 'accepts case-sensitive google cloud gs uris' do
+      [
+        'gs://mybucket/myfile.csv',
+        'gs://bucket/path/to/file.tar.gz',
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.to allow_value(value) }
+        end
+      end
+    end
+
+    describe 'rejects other values' do
+      [
+        '',
+        'GS://mybucket/myfile.csv',
+        5,
+        'gs//mybucket/myfile.csv',
+        'gs:/mybucket/myfile.csv',
+        'gs:mybucket/myfile.csv',
+        'gs-mybucket/myfile.csv',
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.not_to allow_value(value) }
+        end
+      end
+    end
+  end
+end

--- a/spec/type_aliases/objectstore_s3uri_spec.rb
+++ b/spec/type_aliases/objectstore_s3uri_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
+  describe 'Stdlib::ObjectStore::S3Uri' do
+    describe 'accepts case-sensitive amazon web services s3 uris' do
+      [
+        's3://bucket-name/path',
+        's3://bucket/path/to/file.txt',
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.to allow_value(value) }
+        end
+      end
+    end
+
+    describe 'rejects other values' do
+      [
+        '',
+        'S3://bucket-name/path',
+        3,
+        's3:/bucket-name/path',
+        's3//bucket-name/path',
+        's3:bucket-name/path',
+        's3-bucket-name/path',
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.not_to allow_value(value) }
+        end
+      end
+    end
+  end
+end

--- a/spec/type_aliases/objectstore_spec.rb
+++ b/spec/type_aliases/objectstore_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
+  describe 'Stdlib::ObjectStore' do
+    describe 'accepts case-sensitive google cloud gs or amazon web services s3 uris' do
+      [
+        's3://bucket-name/path',
+        's3://bucket/path/to/file.txt',
+        'gs://mybucket/myfile.csv',
+        'gs://bucket/path/to/file.tar.gz',
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.to allow_value(value) }
+        end
+      end
+    end
+
+    describe 'rejects other values' do
+      [
+        '',
+        'S3://bucket/path',
+        'GS://bucket/path',
+        5,
+        3,
+        'gs//bucket/path/to/file',
+        's3//bucket/path/to/file',
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.not_to allow_value(value) }
+        end
+      end
+    end
+  end
+end

--- a/types/objectstore.pp
+++ b/types/objectstore.pp
@@ -1,0 +1,4 @@
+type Stdlib::ObjectStore = Variant[
+  Stdlib::ObjectStore::GSUri,
+  Stdlib::ObjectStore::S3Uri,
+]

--- a/types/objectstore/gsuri.pp
+++ b/types/objectstore/gsuri.pp
@@ -1,0 +1,2 @@
+type Stdlib::ObjectStore::GSUri = Pattern[/^gs:\/\//]
+

--- a/types/objectstore/s3uri.pp
+++ b/types/objectstore/s3uri.pp
@@ -1,0 +1,1 @@
+type Stdlib::ObjectStore::S3Uri = Pattern[/^s3:\/\//]


### PR DESCRIPTION
Closes https://tickets.puppetlabs.com/browse/MODULES-9915

Add a type alias for Cloud Object Store URIs, e.g., (s3://mybucket/myfile).

These URIs are commonly used as sources for files, packages, etc. in Puppet modules. Some organizations even keep all sources in a specific cloud object store like s3 in order to limit downloads from the internet when applying a Puppet catalogue across potentially thousands of nodes.

It would be useful to have a type alias for these URIs. 

