### PR TITLE
Add support for additional options to to_json_pretty

### DIFF
--- a/lib/puppet/functions/to_json_pretty.rb
+++ b/lib/puppet/functions/to_json_pretty.rb
@@ -17,19 +17,54 @@ require 'json'
 #         param_two => undef,
 #       }, true),
 #     }
+#
+#   * how to output pretty JSON using tabs for indentation
+#     file { '/tmp/my.json':
+#       ensure  => file,
+#       content => to_json_pretty({
+#         param_one => 'value',
+#         param_two => {
+#           param_more => 42,
+#         },
+#       }, nil, {indent => '    '}),
+#     }
+
 Puppet::Functions.create_function(:to_json_pretty) do
   # @param data
   #   data structure which needs to be converted to pretty json
   # @param skip_undef
   #   value `true` or `false`
+  # @param opts
+  #   hash-map of settings passed to JSON.pretty_generate, see
+  #   https://ruby-doc.org/stdlib-2.0.0/libdoc/json/rdoc/JSON.html#method-i-generate.
+  #   Note that `max_nesting` doesn't take the value `false`; use `-1` instead.
   # @return
   #   converted data to pretty json
   dispatch :to_json_pretty do
     param 'Variant[Hash, Array]', :data
-    optional_param 'Boolean', :skip_undef
+    optional_param 'Optional[Boolean]', :skip_undef
+    optional_param 'Struct[{
+indent       => Optional[String],
+space        => Optional[String],
+space_before => Optional[String],
+object_nl    => Optional[String],
+array_nl     => Optional[String],
+allow_nan    => Optional[Boolean],
+max_nesting  => Optional[Integer[-1,default]],
+}]', :opts
   end
 
-  def to_json_pretty(data, skip_undef = false)
+  def to_json_pretty(data, skip_undef = false, opts = nil)
+    # It's not possible to make an abstract type that can be either a boolean
+    # false or an integer, so we use -1 as the falsey value
+    if opts
+      opts = Hash[opts.map { |k, v| [k.to_sym, v] }]
+
+      if opts[:max_nesting] == -1
+        opts[:max_nesting] = false
+      end
+    end
+
     if skip_undef
       if data.is_a? Array
         data = data.reject { |value| value.nil? }
@@ -37,6 +72,6 @@ Puppet::Functions.create_function(:to_json_pretty) do
         data = data.reject { |_, value| value.nil? }
       end
     end
-    JSON.pretty_generate(data) << "\n"
+    JSON.pretty_generate(data, opts) << "\n"
   end
 end

--- a/lib/puppet/functions/to_json_pretty.rb
+++ b/lib/puppet/functions/to_json_pretty.rb
@@ -15,7 +15,7 @@ require 'json'
 #       content => to_json_pretty({
 #         param_one => 'value',
 #         param_two => undef,
-#       }),
+#       }, true),
 #     }
 Puppet::Functions.create_function(:to_json_pretty) do
   # @param data

--- a/spec/functions/to_json_pretty_spec.rb
+++ b/spec/functions/to_json_pretty_spec.rb
@@ -13,4 +13,5 @@ describe 'to_json_pretty' do
   }
   it { is_expected.to run.with_params({ 'one' => '1', 'two' => nil }, true).and_return("{\n  \"one\": \"1\"\n}\n") }
   it { is_expected.to run.with_params(['one', 'two', nil, 'three'], true).and_return("[\n  \"one\",\n  \"two\",\n  \"three\"\n]\n") }
+  it { is_expected.to run.with_params(['one', 'two', nil, 'three'], true, 'indent' => '@@@@').and_return("[\n@@@@\"one\",\n@@@@\"two\",\n@@@@\"three\"\n]\n") }
 end


### PR DESCRIPTION
This PR exposes all of the settings available in Ruby `JSON.pretty_generate`: https://ruby-doc.org/stdlib-2.0.0/libdoc/json/rdoc/JSON.html#method-i-generate

Example:

```puppet
to_json_pretty(['one', 'two', nil, 'three'], true, {'indent' => '@@@@'})
# [
# @@@@"one",
# @@@@"two",
# @@@@"three"
# ]
```