### PR TITLE
(WIP) Add volatile_fact() function

### DIFF
--- a/functions/volatile_fact.pp
+++ b/functions/volatile_fact.pp
@@ -1,0 +1,3 @@
+function stdlib::volatile_fact(String $fact_name) >> Deferred {
+  Deferred("fact", [$fact_name])
+}

--- a/lib/puppet/functions/fact.rb
+++ b/lib/puppet/functions/fact.rb
@@ -31,7 +31,7 @@ Puppet::Functions.create_function(:fact) do
   end
 
   def fact(fact_name)
-    facts = closure_scope['facts']
+    facts = closure_scope['facts'] || Facter.to_hash
 
     # Transform the dot-notation string into an array of paths to walk. Make
     # sure to correctly extract double-quoted values containing dots as single


### PR DESCRIPTION
This is a quick POC to add a function that resolves facts on the agent
side during catalog application. It's useful only when using cached
catalogs that depend on facts that might change over time.

This was accomplished by slightly modifying `fact()` so that it could be
deferred and then writing a quick Puppet code function to wrap it in a
`Deferred` object. If reviewers agree that this functionality is useful,
then I'll port it to a Ruby fact so the name doesn't have to be
namespaced and it can parallel the existing `fact()` function.

You would use it like so:

```
notify { 'testing':
  message  => stdlib::volatile_fact('some.volatile.fact'),
}
```