### PR TITLE
stdlib::end_with: create String.end_with function

### DIFF
--- a/lib/puppet/functions/stdlib/end_with.rb
+++ b/lib/puppet/functions/stdlib/end_with.rb
@@ -1,0 +1,21 @@
+# @summary
+#   Return true if test_string ends with suffux
+#
+#  @example
+#    'foobar'.stdlib::end_with('bar') => true
+#    'foobar'.stdlib::end_with('foo') => false
+Puppet::Functions.create_function(:'stdlib::end_with') do
+  # @param test_string the string to check
+  # @param suffix the suffix to check
+  #
+  # @return [Boolean] True or False
+  dispatch :end_with do
+    param 'String[1]', :test_string
+    param 'String[1]', :suffix
+    return_type 'Boolean'
+  end
+
+  def end_with(test_string, suffix)
+    test_string.end_with?(suffix)
+  end
+end

--- a/spec/functions/end_with_spec.rb
+++ b/spec/functions/end_with_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'stdlib::end_with' do
+  it { is_expected.to run.with_params('foobar', 'bar').and_return(true) }
+  it { is_expected.to run.with_params('foobar', 'foo').and_return(false) }
+  it do
+    is_expected.to run.with_params('', 'foo').and_raise_error(
+      ArgumentError, %r{'stdlib::end_with' parameter 'test_string' expects a String\[1\]}
+    )
+  end
+  it do
+    is_expected.to run.with_params('foobar', '').and_raise_error(
+      ArgumentError, %r{'stdlib::end_with' parameter 'suffix' expects a String\[1\]}
+    )
+  end
+end


### PR DESCRIPTION
This PR wraps the ruby `String.end_with?` function and exposes it to the
puppet DSL.