### PR TITLE
Add start_with function

### DIFF
--- a/lib/puppet/functions/start_with.rb
+++ b/lib/puppet/functions/start_with.rb
@@ -1,0 +1,22 @@
+# @summary
+#   Returns true if str starts with one of the prefixes given. Each of the prefixes should be a String.
+#
+# @example
+#   'foobar'.start_with('foo') => true
+#   'foobar'.start_with('bar') => false
+#   'foObar'.start_with(['bar', 'baz']) => false
+Puppet::Functions.create_function(:start_with) do
+  # @param test_string The string to check
+  # @param prefixes The prefixes to check.
+  #
+  # @return [Boolean] True or False
+  dispatch :start_with do
+    param 'String[1]', :test_string
+    param 'Variant[String[1],Array[String[1], 1]]', :prefixes
+    return_type 'Boolean'
+  end
+
+  def start_with(test_string, prefixes)
+    test_string.start_with?(*prefixes)
+  end
+end

--- a/lib/puppet/functions/stdlib/end_with.rb
+++ b/lib/puppet/functions/stdlib/end_with.rb
@@ -1,21 +1,22 @@
 # @summary
-#   Return true if test_string ends with suffux
+#   Returns true if str ends with one of the prefixes given. Each of the prefixes should be a String.
 #
 #  @example
 #    'foobar'.stdlib::end_with('bar') => true
 #    'foobar'.stdlib::end_with('foo') => false
+#    'foobar'.stdlib::end_with(['foo', 'baz']) => false
 Puppet::Functions.create_function(:'stdlib::end_with') do
-  # @param test_string the string to check
-  # @param suffix the suffix to check
+  # @param test_string The string to check
+  # @param suffixes The suffixes to check
   #
   # @return [Boolean] True or False
   dispatch :end_with do
     param 'String[1]', :test_string
-    param 'String[1]', :suffix
+    param 'Variant[String[1],Array[String[1], 1]]', :suffixes
     return_type 'Boolean'
   end
 
-  def end_with(test_string, suffix)
-    test_string.end_with?(suffix)
+  def end_with(test_string, suffixes)
+    test_string.end_with?(*suffixes)
   end
 end

--- a/spec/functions/end_with_spec.rb
+++ b/spec/functions/end_with_spec.rb
@@ -3,14 +3,15 @@ require 'spec_helper'
 describe 'stdlib::end_with' do
   it { is_expected.to run.with_params('foobar', 'bar').and_return(true) }
   it { is_expected.to run.with_params('foobar', 'foo').and_return(false) }
+  it { is_expected.to run.with_params('foobar', ['foo', 'baz']).and_return(false) }
   it do
     is_expected.to run.with_params('', 'foo').and_raise_error(
-      ArgumentError, %r{'stdlib::end_with' parameter 'test_string' expects a String\[1\]}
+      ArgumentError, %r{'stdlib::end_with' parameter 'test_string' expects a String\[1\] value}
     )
   end
   it do
     is_expected.to run.with_params('foobar', '').and_raise_error(
-      ArgumentError, %r{'stdlib::end_with' parameter 'suffix' expects a String\[1\]}
+      ArgumentError, %r{'stdlib::end_with' parameter 'suffixes' expects a value of type String\[1\] or Array\[String\[1\], 1\]}
     )
   end
 end

--- a/spec/functions/startswith_spec.rb
+++ b/spec/functions/startswith_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'start_with' do
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params.and_raise_error(ArgumentError, %r{expects 2 arguments, got none}i) }
+  it { is_expected.to run.with_params('').and_raise_error(ArgumentError, %r{expects 2 arguments, got 1}) }
+
+  it { is_expected.to run.with_params('foobar', 'foo').and_return(true) }
+  it { is_expected.to run.with_params('foObar', ['bar', 'baz']).and_return(false) }
+end


### PR DESCRIPTION
This is helpful in places where you need to use variables in the string
which needs to be compare e.g. something like this:

```puppet
$test.start_with("part${string}01")
```