### PR TITLE
Add correct namespace for start_with function

### DIFF
--- a/lib/puppet/functions/stdlib/start_with.rb
+++ b/lib/puppet/functions/stdlib/start_with.rb
@@ -2,10 +2,10 @@
 #   Returns true if str starts with one of the prefixes given. Each of the prefixes should be a String.
 #
 # @example
-#   'foobar'.start_with('foo') => true
-#   'foobar'.start_with('bar') => false
-#   'foObar'.start_with(['bar', 'baz']) => false
-Puppet::Functions.create_function(:start_with) do
+#   'foobar'.stdlib::start_with('foo') => true
+#   'foobar'.stdlib::start_with('bar') => false
+#   'foObar'.stdlib::start_with(['bar', 'baz']) => false
+Puppet::Functions.create_function(:'stdlib::start_with') do
   # @param test_string The string to check
   # @param prefixes The prefixes to check.
   #

--- a/spec/functions/startswith_spec.rb
+++ b/spec/functions/startswith_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'start_with' do
+describe 'stdlib::start_with' do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(ArgumentError, %r{expects 2 arguments, got none}i) }
   it { is_expected.to run.with_params('').and_raise_error(ArgumentError, %r{expects 2 arguments, got 1}) }


### PR DESCRIPTION
This function was originally introduced in #1086 but never got a
decision about the correct namespace. This commit adds the stdlib::
namespace to the start_with function after a discussion I had with
Daneel on Slack about this. This will at least align the namespace with
the corresponding end_with function to not confuse people.

I'm not considering this a breaking change because the function was never released.