### PR TITLE
(MODULES-10623) explicitly top-scope calls to JSON methods

### DIFF
--- a/lib/facter/facter_dot_d.rb
+++ b/lib/facter/facter_dot_d.rb
@@ -66,8 +66,9 @@ class Facter::Util::DotD
       retry if require 'rubygems'
       raise
     end
-
-    JSON.parse(File.read(file)).each_pair do |f, v|
+    # Call ::JSON to ensure it references the JSON library from Ruby’s standard library
+    # instead of a random JSON namespace that might be in scope due to user code.
+    ::JSON.parse(File.read(file)).each_pair do |f, v|
       Facter.add(f) do
         setcode { v }
       end

--- a/lib/puppet/functions/to_json_pretty.rb
+++ b/lib/puppet/functions/to_json_pretty.rb
@@ -1,4 +1,5 @@
 require 'json'
+
 # @summary
 #   Convert data structure and output to pretty JSON
 #
@@ -72,6 +73,8 @@ max_nesting  => Optional[Integer[-1,default]],
         data = data.reject { |_, value| value.nil? }
       end
     end
-    JSON.pretty_generate(data, opts) << "\n"
+    # Call ::JSON to ensure it references the JSON library from Ruby’s standard library
+    # instead of a random JSON namespace that might be in scope due to user code.
+    ::JSON.pretty_generate(data, opts) << "\n"
   end
 end


### PR DESCRIPTION
Call ::JSON to ensure it references the JSON library
from Ruby’s standard library instead of a random JSON namespace
that might be in scope due to user code.

For example::

https://github.com/puppetlabs/pdk/blob/master/lib/pdk/config/json.rb