### PR TITLE
Add a cron_provider fact

### DIFF
--- a/lib/facter/cron_provider.rb
+++ b/lib/facter/cron_provider.rb
@@ -1,0 +1,18 @@
+# Fact: cron_provider
+#
+# Purpose: Returns the default provider Puppet will choose to manage cron
+#   on this system
+#
+# Resolution: Instantiates a dummy cron resource and return the provider
+#
+# Caveats:
+#
+require 'puppet/type'
+require 'puppet/type/cron'
+
+Facter.add(:cron_provider) do
+  setcode do
+    provider = Puppet::Type.type(:cron).newcron(:name => 'dummy')[:provider]
+    provider.to_s if provider
+  end
+end

--- a/spec/unit/facter/cron_provider_spec.rb
+++ b/spec/unit/facter/cron_provider_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'puppet/type'
+require 'puppet/type/cron'
+
+describe 'cron_provider', :type => :fact do
+  before(:each) { Facter.clear }
+  after(:each) { Facter.clear }
+
+  subject { Facter.fact(:cron_provider) }
+
+  it { is_expected.not_to be_nil }
+
+  context 'when available' do
+    it 'returns crontab' do
+      provider = Puppet::Type.type(:cron).provider(:crontab)
+      allow(Puppet::Type.type(:cron)).to receive(:defaultprovider).and_return(provider)
+
+      expect(subject.value).to eq('crontab')
+    end
+  end
+
+  context 'when unavailable' do
+    it 'returns nil' do
+      allow(Puppet::Type.type(:cron)).to receive(:defaultprovider).and_return(nil)
+
+      expect(subject.value).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Similar to package_provider and service_provider the cron provider is useful to know. On some minimal platforms, crontab is not installed and the cron type should not be used. By having a fact for this, it becomes easy to check.