### PR TITLE
(PUP-10653) Remove win32/dir constant usage

### DIFF
--- a/lib/facter/facter_dot_d.rb
+++ b/lib/facter/facter_dot_d.rb
@@ -207,10 +207,8 @@ if mdata
 
       # Windows has a different configuration directory that defaults to a vendor
       # specific sub directory of the %COMMON_APPDATA% directory.
-      if Dir.const_defined? 'COMMON_APPDATA' # rubocop:disable Metrics/BlockNesting : Any attempt to alter this breaks it
-        windows_facts_dot_d = File.join(Dir::COMMON_APPDATA, 'PuppetLabs', 'facter', 'facts.d')
-        Facter::Util::DotD.new(windows_facts_dot_d).create
-      end
+      windows_facts_dot_d = File.join(ENV['ALLUSERSPROFILE'], 'PuppetLabs', 'facter', 'facts.d')
+      Facter::Util::DotD.new(windows_facts_dot_d).create
     end
   end
 end


### PR DESCRIPTION
For Puppet 7 we are dropping the `win32/dir` dependency as we only used constants from it, which we replaced with environment variables (see: https://github.com/puppetlabs/puppet/pull/8314).

This would become breaking when using the stdlib module with Puppet 7, as the win32 dependencies are no longer provided in the puppet gem.

Replace the usage of the `Dir::COMMON_APPDATA` with the `ALLUSERSPROFILE` environment variable.