### PR TITLE
Stdlib::Datasize: This CR adds a new data size type alias

### DIFF
--- a/spec/type_aliases/datasize_spec.rb
+++ b/spec/type_aliases/datasize_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
+  describe 'Stdlib::Datasize' do
+    describe 'valid handling' do
+      ['42b', '42B', '42k', '42K', '42m', '42M', '42g', '42G', '42t', '42T',
+       '42kb', '42Kb', '42mb', '42Mb', '42gb', '42Gb', '42Tb', '42Tb',
+       '42kB', '42KB', '42mB', '42MB', '42gB', '42GB', '42TB', '42TB'].each do |value|
+        describe value.inspect do
+          it { is_expected.to allow_value(value) }
+        end
+      end
+    end
+
+    describe 'invalid path handling' do
+      context 'garbage inputs' do
+        [
+          [nil],
+          [nil, nil],
+          { 'foo' => 'bar' },
+          {},
+          1024,
+          '1024',
+          '1024byte',
+          '1024bit',
+          '1024Gig',
+          '1024Meg',
+          '1024BM',
+          '1024bg',
+          '1024Meb',
+          'asdaSddasd',
+        ].each do |value|
+          describe value.inspect do
+            it { is_expected.not_to allow_value(value) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/types/datasize.pp
+++ b/types/datasize.pp
@@ -1,0 +1,1 @@
+type Stdlib::Datasize = Pattern[/^\d+(?i:[kmgt]b?|b)$/]


### PR DESCRIPTION
Many class/define parameters take a value representing a data size.
e.g. 1024Mb, 1024G, 100k

This new type provides a way to validate most common data type inputs