### PR TITLE
Add additional types Stdlib::Port::Dynamic,Ephemeral,Registered,User}

### DIFF
--- a/spec/type_aliases/port__dynamic_spec.rb
+++ b/spec/type_aliases/port__dynamic_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
+  describe 'Stdlib::Port::Ephemeral' do
+    describe 'valid ephemeral port' do
+      [
+        49_152,
+        51_337,
+        65_000,
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.to allow_value(value) }
+        end
+      end
+    end
+
+    describe 'invalid path handling' do
+      context 'garbage inputs' do
+        [
+          nil,
+          [nil],
+          [nil, nil],
+          { 'foo' => 'bar' },
+          {},
+          '',
+          'https',
+          '443',
+          -1,
+          80,
+          443,
+          1023,
+          1337,
+          8080,
+          28_080,
+        ].each do |value|
+          describe value.inspect do
+            it { is_expected.not_to allow_value(value) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/type_aliases/port__user_spec.rb
+++ b/spec/type_aliases/port__user_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
+  describe 'Stdlib::Port::User' do
+    describe 'valid user' do
+      [
+        1024,
+        1337,
+        49_151,
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.to allow_value(value) }
+        end
+      end
+    end
+
+    describe 'invalid path handling' do
+      context 'garbage inputs' do
+        [
+          nil,
+          [nil],
+          [nil, nil],
+          { 'foo' => 'bar' },
+          {},
+          '',
+          'https',
+          '443',
+          -1,
+          80,
+          443,
+          1023,
+          49_152,
+        ].each do |value|
+          describe value.inspect do
+            it { is_expected.not_to allow_value(value) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/types/port/dynamic.pp
+++ b/types/port/dynamic.pp
@@ -1,0 +1,1 @@
+type Stdlib::Port::Dynamic = Integer[49152, 65535]

--- a/types/port/ephemeral.pp
+++ b/types/port/ephemeral.pp
@@ -1,0 +1,1 @@
+type Stdlib::Port::Ephemeral = Stdlib::Port::Dynamic

--- a/types/port/registered.pp
+++ b/types/port/registered.pp
@@ -1,0 +1,1 @@
+type Stdlib::Port::Registered = Stdlib::Port::User

--- a/types/port/user.pp
+++ b/types/port/user.pp
@@ -1,0 +1,1 @@
+type Stdlib::Port::User = Integer[1024, 49151]


### PR DESCRIPTION
The IANA port registry and rfc6335 specify the following port ranges

* the System Ports, also known as the Well Known Ports, from 0-1023 (assigned by IANA)
* the User Ports, also known as the Registered Ports, from 1024-49151 (assigned by IANA)
* the Dynamic Ports, also known as the Private or Ephemeral Ports, from 49152-65535 (never assigned)

This PR adds the following types to capture this:
  - `Stdlib::Port::User`
  - `Stdlib::Port::Registered (alias to Stdlib::Port::User)`
  - `Stdlib::Port::Dynamic`
  - `Stdlib::Port::Ephemeral (alias to Stdlib::Port::Dynamic)`

We could drop the aliases and just pick on name to use or use both i dont have a strong prefrence; however my gut feeling is that most uses of the current Stdlib::Port::Unprivileged type would be better served by this newer Stdlib::Port::User type.

https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml