### PR TITLE
Add new types for Stdlib::Ensure::File

### DIFF
--- a/types/ensure/file.pp
+++ b/types/ensure/file.pp
@@ -1,0 +1,1 @@
+type Stdlib::Ensure::File = Enum['present', 'file', 'directory', 'link', 'absent']

--- a/types/ensure/file/directory.pp
+++ b/types/ensure/file/directory.pp
@@ -1,0 +1,1 @@
+type Stdlib::Ensure::File::Directory = Enum['directory', 'absent']

--- a/types/ensure/file/file.pp
+++ b/types/ensure/file/file.pp
@@ -1,0 +1,1 @@
+type Stdlib::Ensure::File::File = Enum['file', 'absent']

--- a/types/ensure/file/link.pp
+++ b/types/ensure/file/link.pp
@@ -1,0 +1,1 @@
+type Stdlib::Ensure::File::Link = Enum['link', 'absent']


### PR DESCRIPTION
This PR adds some new types
  Stdlib::Ensure::File covers all file ensures
  Stdlib::Ensure::File::Link covers only link and absent
  Stdlib::Ensure::File::File covers only file and absent
  Stdlib::Ensure::File::Directory covers only directory and absent