### PR TITLE
Allow start/end checks on empty strings

### DIFF
--- a/lib/puppet/functions/stdlib/end_with.rb
+++ b/lib/puppet/functions/stdlib/end_with.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'stdlib::end_with') do
   #    'foobar'.stdlib::end_with(['foo', 'baz']) => false
   # @return [Boolean] True or False
   dispatch :end_with do
-    param 'String[1]', :test_string
+    param 'String', :test_string
     param 'Variant[String[1],Array[String[1], 1]]', :suffixes
     return_type 'Boolean'
   end

--- a/lib/puppet/functions/stdlib/start_with.rb
+++ b/lib/puppet/functions/stdlib/start_with.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'stdlib::start_with') do
   #   'foObar'.stdlib::start_with(['bar', 'baz']) => false
   # @return [Boolean] True or False
   dispatch :start_with do
-    param 'String[1]', :test_string
+    param 'String', :test_string
     param 'Variant[String[1],Array[String[1], 1]]', :prefixes
     return_type 'Boolean'
   end

--- a/spec/functions/end_with_spec.rb
+++ b/spec/functions/end_with_spec.rb
@@ -1,14 +1,10 @@
 require 'spec_helper'
 
 describe 'stdlib::end_with' do
+  it { is_expected.to run.with_params('', 'bar').and_return(false) }
   it { is_expected.to run.with_params('foobar', 'bar').and_return(true) }
   it { is_expected.to run.with_params('foobar', 'foo').and_return(false) }
   it { is_expected.to run.with_params('foobar', ['foo', 'baz']).and_return(false) }
-  it do
-    is_expected.to run.with_params('', 'foo').and_raise_error(
-      ArgumentError, %r{'stdlib::end_with' parameter 'test_string' expects a String\[1\] value}
-    )
-  end
   it do
     is_expected.to run.with_params('foobar', '').and_raise_error(
       ArgumentError, %r{'stdlib::end_with' parameter 'suffixes' expects a value of type String\[1\] or Array\[String\[1\], 1\]}

--- a/spec/functions/startswith_spec.rb
+++ b/spec/functions/startswith_spec.rb
@@ -5,6 +5,7 @@ describe 'stdlib::start_with' do
   it { is_expected.to run.with_params.and_raise_error(ArgumentError, %r{expects 2 arguments, got none}i) }
   it { is_expected.to run.with_params('').and_raise_error(ArgumentError, %r{expects 2 arguments, got 1}) }
 
+  it { is_expected.to run.with_params('', 'foo').and_return(false) }
   it { is_expected.to run.with_params('foobar', 'foo').and_return(true) }
   it { is_expected.to run.with_params('foObar', ['bar', 'baz']).and_return(false) }
 end


### PR DESCRIPTION
When using this library function on strings that come from a parameter,
they might be empty sometimes, rendering it difficult to use, having to
force hacks like.

    "_${source}".stdlib::start_with('_puppet:///modules/')

Where `_` is added to make sure that the string is never empty.

In Ruby the `start_with?` function allows being used on empty strings,
and it returns `false` for any assertion to be done:

    p ''.start_with?('test')
    false

Also in Python the `startswith()` method returns `false` for empty
strings:

    In [1]: print(''.startswith('test'))
    False

As this logic seems the most extended and allows for a wider use of the
library, removing these corner cases when the string is empty seems like a good idea.