### PR TITLE
Allow options injection for to_yaml

### DIFF
--- a/lib/puppet/functions/to_yaml.rb
+++ b/lib/puppet/functions/to_yaml.rb
@@ -2,21 +2,28 @@ require 'yaml'
 # @summary
 #   Convert a data structure and output it as YAML
 #
-# @example how to output YAML
+# @example How to output YAML
 #   # output yaml to a file
 #     file { '/tmp/my.yaml':
 #       ensure  => file,
 #       content => to_yaml($myhash),
 #     }
+# @example Use options control the output format
+#   file { '/tmp/my.yaml':
+#     ensure  => file,
+#     content => to_yaml($myhash, {indentation: 4})
+#   }
 Puppet::Functions.create_function(:to_yaml) do
   # @param data
+  # @param options
   #
   # @return [String]
   dispatch :to_yaml do
     param 'Any', :data
+    optional_param 'Hash', :options
   end
 
-  def to_yaml(data)
-    data.to_yaml
+  def to_yaml(data, options = {})
+    data.to_yaml(options)
   end
 end

--- a/spec/functions/to_yaml_spec.rb
+++ b/spec/functions/to_yaml_spec.rb
@@ -17,4 +17,6 @@ describe 'to_yaml' do
 
   it { is_expected.to run.with_params('‰').and_return("--- \"‰\"\n") }
   it { is_expected.to run.with_params('∇').and_return("--- \"∇\"\n") }
+
+  it { is_expected.to run.with_params({ 'foo' => { 'bar' => true, 'baz' => false } }, :indentation => 4).and_return("---\nfoo:\n    bar: true\n    baz: false\n") }
 end


### PR DESCRIPTION
This makes it possible to inject formatting options into the to_yaml function.