### PR TITLE
(FEAT) Add simple standardized header template

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Puppet modules make heavy use of this standard library. The stdlib module adds t
  * Defined types
  * Data types
  * Providers
+ * Templates
 
 > *Note:* As of version 3.7, Puppet Enterprise no longer includes the stdlib module. If you're running Puppet Enterprise, you should install the most recent release of stdlib for compatibility with Puppet modules.
 
@@ -555,6 +556,42 @@ Determines the root home directory, which depends on your operating system. Gene
 #### `service_provider`
 
 Returns the default provider Puppet uses to manage services on this system
+
+<a id="templates"></a>
+### EPP Templates
+
+You can include a standardized comment header in your `.epp` or `.erb` templates with the following:
+
+```puppet
+<%= scope.call_function('epp', ["stdlib/puppet_managed.epp"]) %>
+```
+
+The EPP template takes the following optional parameters:
+
+- String  $message = 'WARNING This file is managed by puppet. Do not edit!',
+- String  $begin_line = '#',
+- String  $end_line = '',
+- Int     $line_length = 70,
+- String  $metadata_title = 'Metadata:',
+- Hash    $metadata = {}
+
+Example:
+
+```puppet
+<%= scope.call_function('epp', ["stdlib/puppet_managed.epp"], {'metadata' => {'fqdn' => $::fqdn}}) %>
+```
+
+Should produce
+```shell
+#
+#
+# WARNING This file is managed by puppet. Do not edit!
+#
+# Metadata:
+#  fqdn=hostname.example.com
+#
+#
+```
 
 ## Limitations
 

--- a/templates/puppet_managed.epp
+++ b/templates/puppet_managed.epp
@@ -1,0 +1,20 @@
+<%- | String  $message = 'WARNING This file is managed by puppet. Do not edit!',
+      String  $begin_line = '#',
+      String  $end_line = '',
+      Int     $line_length = 70,
+      String  $metadata_title = 'Metadata:',
+      Hash    $metadata = {}
+| -%>
+<%- $comment_length = $begin_line.length() + $end_line.length()  -%>
+<%= $begin_line %><% if $end_line != '' %><% ($comment_length...$line_length).step(1).each |a|%> <% end %><% $end_line %><% end %>
+<%= $begin_line %><% if $end_line != '' %><% ($comment_length...$line_length).step(1).each |a|%> <% end %><% $end_line %><% end %>
+<%= $begin_line %> <% $message %><% if $end_line != '' %><% $tmp = $comment_length + $message.length() + 1%><% ($tmp...$line_length).step(1).each |a|%> <% end %><% $end_line %><% end %>
+<% if $metadata -%>
+<%= $begin_line %><% if $end_line != '' %><% ($comment_length...$line_length).step(1).each |a|%> <% end %><% $end_line %><% end %>
+<%= $begin_line %> <%= $metadata_title %><% if $end_line != '' %><% $tmp = $comment_length + $message.length() + 1 %><% ($tmp...$line_length).step(1).each |a|%> <% end %><% $end_line %><% end %>
+<% $metadata.each | $key | -%>
+<%= $begin_line %>  <% $key %>=<%= $metadata[$key] %><% if $end_line != '' %><% $tmp = $comment_length + $key.length() $metadata[$key].length() + 3 %><% ($tmp...$line_length).step(1).each |a|%> <% end %><% $end_line %><% end %>
+<% end -%>
+<% end -%>
+<%= $begin_line %><% if $end_line != '' %><% ($comment_length...$line_length).step(1).each |a|%> <% end %><% $end_line %><% end %>
+<%= $begin_line %><% if $end_line != '' %><% ($comment_length...$line_length).step(1).each |a|%> <% end %><% $end_line %><% end %>


### PR DESCRIPTION
It seems every module has a different way of putting the `This is a puppet managed file don't edit it` in their templates.  They are all a bit different and each one says slightly different things.  This is my attempt to get something a bit more unified in place so folks can have greater consistency in their modules.