### PR TITLE
stdlib::ensure: new fuction to cast ensure values

### DIFF
--- a/functions/ensure.pp
+++ b/functions/ensure.pp
@@ -1,0 +1,24 @@
+# @summary function to cast ensure parameter to resource specific value
+function stdlib::ensure(
+    Variant[Boolean, Enum['present', 'absent']]               $ensure,
+    Enum['directory', 'link', 'mounted', 'service', 'file'] $resource,
+) >> String {
+    $_ensure = $ensure ? {
+        Boolean => $ensure.bool2str('present', 'absent'),
+        default => $ensure,
+    }
+    case $resource {
+        'service': {
+            $_ensure ? {
+                'present' => 'running',
+                default   => 'stopped',
+            }
+        }
+        default: {
+            $_ensure ? {
+                'present' => $resource,
+                default   => $_ensure,
+            }
+        }
+    }
+}

--- a/spec/functions/stdlib_ensure_spec.rb
+++ b/spec/functions/stdlib_ensure_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'stdlib::ensure' do
+  context 'work with service resource' do
+    it { is_expected.to run.with_params('present', 'service').and_return('running') }
+    it { is_expected.to run.with_params(true, 'service').and_return('running') }
+    it { is_expected.to run.with_params('absent', 'service').and_return('stopped') }
+    it { is_expected.to run.with_params(false, 'service').and_return('stopped') }
+  end
+  ['directory', 'link', 'mounted', 'file'].each do |resource|
+    context "work with #{resource} resource" do
+      it { is_expected.to run.with_params('present', resource).and_return(resource) }
+      it { is_expected.to run.with_params(true, resource).and_return(resource) }
+      it { is_expected.to run.with_params('absent', resource).and_return('absent') }
+      it { is_expected.to run.with_params(false, resource).and_return('absent') }
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new function to cast the ensureable property to a resource

specific value. e.g.
  * `stdlib::ensure('present', 'service') == 'running'`
  * `stdlib::ensure('present', 'directory') == 'directory'`

This is useful when you want to pass ensure to a custom class and
ensure all the resource get the correct value e.g.

```puppet
class foo(
  Enum['present', 'absent'] $ensure = 'present'
) {
  file {'/some/dir':
    ensure => stdlib::ensure($ensure, 'directory')
  }
  file {'/some/file':
    ensure => stdlib::ensure($ensure, 'file')
  }
  file {'/some/link':
    ensure => stdlib::ensure($ensure, 'link')
  }
  service {'some-service':
    ensure => stdlib::ensure($ensure, 'service')
  }
}
```

something similar to this was discussed in #869