### PR TITLE
(IAC-1414) Throw error in range() function when step size invalid

### DIFF
--- a/lib/puppet/parser/functions/range.rb
+++ b/lib/puppet/parser/functions/range.rb
@@ -51,6 +51,8 @@ module Puppet::Parser::Functions
       stop  = arguments[1]
       step  = arguments[2].nil? ? 1 : arguments[2].to_i.abs
 
+      raise(ArgumentError, 'range(): 3rd arg (step size) must be a non zero integer (e.g. 1 or -1)') if step.zero?
+
       type = '..' # Use the simplest type of Range available in Ruby
 
     else # arguments.size == 1


### PR DESCRIPTION
Prior to this commit, on Ruby 2.7, the range() method would NOT
throw an ArgumentError exception if it was passed an invalid value as the
step size (3rd arg). Instead, it would return an array of size
1,000,000 with repeated integer values of the 2nd arg.

The function invokes Ruby's in built range method and `step` to
define a step size to increment / decrement by  and then passes the
output to `first`, limiting to the first 1,000,000 values.

On Ruby < 2.7, `step` would throw an `ArgumentError` if the step
size passed was `0`:

```
1..2).step(0).first(1_000_000).to_a
Traceback (most recent call last):
        5: from ~/.rvm/rubies/ruby-2.5.8/bin/irb:11:in `<main>'
        4: from (irb):7
        3: from (irb):7:in `first'
        2: from (irb):7:in `each'
        1: from (irb):7:in `step'
ArgumentError (step can't be 0)
```

However, on Ruby 2.7, the `step` method returns an Enumerator that
will then subsequently generate an Array of the size specified when
passed to `first`, made up of the 2nd arg value (last):

```
(1..2).step(0).first(10).to_a
 => [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
```

This is an issue, as the 3rd arg is passed to `to_i`, which then
becomes the step size. For any values that cannot be converted to
a positive / negative (or legit 0) Integer, a 0 is returned.

This commit will perform a check on the value of `step` and throw
an ArgumentError if it is not zero.