### PR TITLE
(IAC-1228) Fix multiple spec test issues in Ruby 2.7

### DIFF
--- a/spec/functions/load_module_metadata_spec.rb
+++ b/spec/functions/load_module_metadata_spec.rb
@@ -7,6 +7,8 @@ describe 'load_module_metadata' do
 
   describe 'when calling with valid arguments' do
     before :each do
+      # In Puppet 7, there are two prior calls to File.read prior to the responses we want to mock
+      allow(File).to receive(:read).with(anything, anything).and_call_original
       allow(File).to receive(:read).with(%r{\/(stdlib|test)\/metadata.json}, :encoding => 'utf-8').and_return('{"name": "puppetlabs-stdlib"}')
       allow(File).to receive(:read).with(%r{\/(stdlib|test)\/metadata.json}).and_return('{"name": "puppetlabs-stdlib"}')
       # Additional modules used by litmus which are identified while running these dues to being in fixtures

--- a/spec/functions/loadjson_spec.rb
+++ b/spec/functions/loadjson_spec.rb
@@ -6,6 +6,8 @@ describe 'loadjson' do
 
   describe 'when calling with valid arguments' do
     before :each do
+      # In Puppet 7, there are two prior calls to File.read prior to the responses we want to mock
+      allow(File).to receive(:read).with(anything, anything).and_call_original
       allow(File).to receive(:read).with(%r{\/(stdlib|test)\/metadata.json}, :encoding => 'utf-8').and_return('{"name": "puppetlabs-stdlib"}')
       allow(File).to receive(:read).with(%r{\/(stdlib|test)\/metadata.json}).and_return('{"name": "puppetlabs-stdlib"}')
       # Additional modules used by litmus which are identified while running these dues to being in fixtures

--- a/spec/functions/shell_escape_spec.rb
+++ b/spec/functions/shell_escape_spec.rb
@@ -17,8 +17,8 @@ describe 'shell_escape' do
     it { is_expected.to run.with_params('foo').and_return('foo') }
     it { is_expected.to run.with_params('foo bar').and_return('foo\ bar') }
     it {
-      is_expected.to run.with_params('~`!@#$%^&*()_+-=[]\{}|;\':",./<>?')
-                        .and_return('\~\`\!@\#\$\%\^\&\*\(\)_\+-\=\[\]\\\\\{\}\|\;\\\':\",./\<\>\?')
+      is_expected.to run.with_params('~`!@#$%^&*()_-=[]\{}|;\':",./<>?')
+                        .and_return('\~\`\!@\#\$\%\^\&\*\(\)_-\=\[\]\\\\\{\}\|\;\\\':\",./\<\>\?')
     }
   end
 

--- a/spec/functions/shell_join_spec.rb
+++ b/spec/functions/shell_join_spec.rb
@@ -14,8 +14,8 @@ describe 'shell_join' do
     it { is_expected.to run.with_params(['foo', 'bar']).and_return('foo bar') }
     it { is_expected.to run.with_params(['foo', 'bar baz']).and_return('foo bar\ baz') }
     it {
-      is_expected.to run.with_params(['~`!@#$', '%^&*()_+-=', '[]\{}|;\':"', ',./<>?'])
-                        .and_return('\~\`\!@\#\$ \%\^\&\*\(\)_\+-\= \[\]\\\\\{\}\|\;\\\':\" ,./\<\>\?')
+      is_expected.to run.with_params(['~`!@#$', '%^&*()_-=', '[]\{}|;\':"', ',./<>?'])
+                        .and_return('\~\`\!@\#\$ \%\^\&\*\(\)_-\= \[\]\\\\\{\}\|\;\\\':\" ,./\<\>\?')
     }
 
     context 'with UTF8 and double byte characters' do


### PR DESCRIPTION
This PR is made up of two commits:

### (IAC-1228) Remove '+' from shell_join_spec test data

Prior to this commit, the `spec/functions/shell_join_spec.rb` tests
were failing on Ruby 2.7 as the `Shellwords.shelljoin` method in
2.7 does not escape the `+` character.

Rather than have specific datasets for Ruby versions `< 2.7` and
`>= 2.7`, it seemed easiest to simply remove this character from
the tests.

### (IAC-1228) Allow File.read to passthrough for JSON spec tests

In the context of Puppet 7 there are two subsequent calls to
File.read from the catalog generated from the tests of `loadjson_spec.rb`
and `load_module_metadata_spec.rb`

Prior to this commit, these calls were causing exceptions from
RSpec as the mock expectations for File.read were being thrown off.

This did not manifest on Puppet 5 or 6.

After this commit, any calls to File.read that do not conform to
the expected arguments we want to mock a response for, are passed
through to File.read.