### PR TITLE
(bugfix) Setting stricter email validation

### DIFF
--- a/spec/type_aliases/email_spec.rb
+++ b/spec/type_aliases/email_spec.rb
@@ -56,6 +56,9 @@ describe 'Stdlib::Email' do
      'email@example.com (Joe Smith)',
      'email@-example.com',
      'email@example..com',
+     'random stuff multiline
+     valid@email.com
+     more random stuff $^*!',
      '”(),:;<>[\]@example.com',
      'just”not”right@example.com',
      'this\ is"really"not\allowed@example.com'].each do |value|

--- a/types/email.pp
+++ b/types/email.pp
@@ -1,2 +1,2 @@
 # https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
-type Stdlib::Email = Pattern[/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/]
+type Stdlib::Email = Pattern[/\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/]


### PR DESCRIPTION
Setting stricter email validation. Currently this type allows for new lines. 
This fix is in relation to the following comment: https://github.com/puppetlabs/puppetlabs-stdlib/pull/1160#issuecomment-776633336

Thank you for bringing this to our attention @pegasd 👍 