### PR TITLE
(MODULES-11099) Make merge parameter data types actually backwards compatible

### DIFF
--- a/lib/puppet/functions/merge.rb
+++ b/lib/puppet/functions/merge.rb
@@ -40,8 +40,8 @@ Puppet::Functions.create_function(:merge) do
   # @return
   #   The merged hash
   dispatch :merge2hashes do
-    repeated_param 'Variant[Hash, Undef, String[0,0]]', :args # this strange type is backwards compatible
-    return_type 'Hash'
+    repeated_param 'Variant[Hash[Scalar,Any], Undef, String[0,0]]', :args # this strange type is backwards compatible
+    return_type 'Hash[Scalar,Any]'
   end
 
   # @param args

--- a/spec/functions/merge_spec.rb
+++ b/spec/functions/merge_spec.rb
@@ -9,7 +9,7 @@ describe 'merge' do
       .with_params({}, 'two') \
       .and_raise_error(
         ArgumentError, \
-        Regexp.new(Regexp.escape("rejected: parameter 'args' expects a value of type Undef, Hash, or String[0, 0], got String")),
+        Regexp.new(Regexp.escape("rejected: parameter 'args' expects a value of type Undef, Hash[Scalar, Any], or String[0, 0], got String")),
       )
   }
   it {


### PR DESCRIPTION
`Hash` defaults to `Hash[Scalar,Data]` however, class/type references are valid hash values but are not covered by the `Data` type.

see also https://github.com/voxpupuli/puppet-jenkins/pull/909