### PR TITLE
(MODULES-11126) Replacing URI.escape with URI::DEFAULT_PARSER

### DIFF
--- a/lib/puppet/parser/functions/uriescape.rb
+++ b/lib/puppet/parser/functions/uriescape.rb
@@ -26,9 +26,9 @@ module Puppet::Parser::Functions
 
     result = if value.is_a?(Array)
                # Numbers in Puppet are often string-encoded which is troublesome ...
-               value.map { |i| i.is_a?(String) ? URI.escape(i) : i }
+               value.map { |i| i.is_a?(String) ? URI::DEFAULT_PARSER.escape(i) : i }
              else
-               URI.escape(value)
+               URI::DEFAULT_PARSER.escape(value)
              end
 
     return result

--- a/spec/functions/uriescape_spec.rb
+++ b/spec/functions/uriescape_spec.rb
@@ -16,16 +16,16 @@ describe 'uriescape' do
   end
 
   describe 'handling normal strings' do
-    it 'calls ruby\'s URI.escape function' do
-      expect(URI).to receive(:escape).with('uri_string').and_return('escaped_uri_string').once
+    it 'calls ruby\'s URI::DEFAULT_PARSER.escape function' do
+      expect(URI::DEFAULT_PARSER).to receive(:escape).with('uri_string').and_return('escaped_uri_string').once
       is_expected.to run.with_params('uri_string').and_return('escaped_uri_string')
     end
   end
 
   describe 'handling classes derived from String' do
-    it 'calls ruby\'s URI.escape function' do
+    it 'calls ruby\'s URI::DEFAULT_PARSER.escape function' do
       uri_string = AlsoString.new('uri_string')
-      expect(URI).to receive(:escape).with(uri_string).and_return('escaped_uri_string').once
+      expect(URI::DEFAULT_PARSER).to receive(:escape).with(uri_string).and_return('escaped_uri_string').once
       is_expected.to run.with_params(uri_string).and_return('escaped_uri_string')
     end
   end


### PR DESCRIPTION
URI.escape was deprecated in ruby-2.7 and removed in ruby-3.x. This
change is breaking stdlib. This is described in detail here [1].

Replacing URI.escape with URI::DEFAULT_PARSER is working properly.

This is affecting openstack-tripleo [2]

[1] https://bugs.ruby-lang.org/issues/17309
[2] https://bugs.launchpad.net/tripleo/+bug/1937166