### PR TITLE
New function to_python() / to_ruby()

### DIFF
--- a/lib/puppet/functions/to_python.rb
+++ b/lib/puppet/functions/to_python.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# @summary
+#   Convert an object into a String containing its Python representation
+#
+# @example how to output Python
+#   # output Python to a file
+#   $listen = '0.0.0.0'
+#   $port = 8000
+#   file { '/opt/acme/etc/settings.py':
+#     content => inline_epp(@("SETTINGS")),
+#       LISTEN = <%= $listen.to_python %>
+#       PORT = <%= $mailserver.to_python %>
+#       | SETTINGS
+#   }
+
+Puppet::Functions.create_function(:to_python) do
+  dispatch :to_python do
+    param 'Any', :object
+  end
+
+  # @param object
+  #   The object to be converted
+  #
+  # @return [String]
+  #   The String representation of the object
+  def to_python(object)
+    case object
+    when true then 'True'
+    when false then 'False'
+    when :undef then 'None'
+    when Array then "[#{object.map { |x| to_python(x) }.join(', ')}]"
+    when Hash then "{#{object.map { |k, v| "#{to_python(k)}: #{to_python(v)}" }.join(', ')}}"
+    else object.inspect
+    end
+  end
+end

--- a/lib/puppet/functions/to_ruby.rb
+++ b/lib/puppet/functions/to_ruby.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# @summary
+#   Convert an object into a String containing its Ruby representation
+#
+# @example how to output Ruby
+#   # output Ruby to a file
+#   $listen = '0.0.0.0'
+#   $port = 8000
+#   file { '/opt/acme/etc/settings.rb':
+#     content => inline_epp(@("SETTINGS")),
+#       LISTEN = <%= $listen.to_ruby %>
+#       PORT = <%= $mailserver.to_ruby %>
+#       | SETTINGS
+#   }
+
+Puppet::Functions.create_function(:to_ruby) do
+  dispatch :to_ruby do
+    param 'Any', :object
+  end
+
+  # @param object
+  #   The object to be converted
+  #
+  # @return [String]
+  #   The String representation of the object
+  def to_ruby(object)
+    case object
+    when :undef then 'nil'
+    when Array then "[#{object.map { |x| to_ruby(x) }.join(', ')}]"
+    when Hash then "{#{object.map { |k, v| "#{to_ruby(k)} => #{to_ruby(v)}" }.join(', ')}}"
+    else object.inspect
+    end
+  end
+end

--- a/spec/functions/to_python_spec.rb
+++ b/spec/functions/to_python_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'to_python' do
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params('').and_return('""') }
+  it { is_expected.to run.with_params(:undef).and_return('None') }
+  it { is_expected.to run.with_params(true).and_return('True') }
+  it { is_expected.to run.with_params(false).and_return('False') }
+  it { is_expected.to run.with_params('one').and_return('"one"') }
+  it { is_expected.to run.with_params(42).and_return('42') }
+  it { is_expected.to run.with_params([]).and_return('[]') }
+  it { is_expected.to run.with_params(['one']).and_return('["one"]') }
+  it { is_expected.to run.with_params(['one', 'two']).and_return('["one", "two"]') }
+  it { is_expected.to run.with_params({}).and_return('{}') }
+  it { is_expected.to run.with_params('key' => 'value').and_return('{"key": "value"}') }
+  it {
+    is_expected.to run.with_params('one' => { 'oneA' => 'A', 'oneB' => { 'oneB1' => '1', 'oneB2' => '2' } }, 'two' => ['twoA', 'twoB'])
+                      .and_return('{"one": {"oneA": "A", "oneB": {"oneB1": "1", "oneB2": "2"}}, "two": ["twoA", "twoB"]}')
+  }
+
+  it { is_expected.to run.with_params('‰').and_return('"‰"') }
+  it { is_expected.to run.with_params('竹').and_return('"竹"') }
+  it { is_expected.to run.with_params('Ü').and_return('"Ü"') }
+  it { is_expected.to run.with_params('∇').and_return('"∇"') }
+end

--- a/spec/functions/to_ruby_spec.rb
+++ b/spec/functions/to_ruby_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'to_ruby' do
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params('').and_return('""') }
+  it { is_expected.to run.with_params(:undef).and_return('nil') }
+  it { is_expected.to run.with_params(true).and_return('true') }
+  it { is_expected.to run.with_params('one').and_return('"one"') }
+  it { is_expected.to run.with_params(42).and_return('42') }
+  it { is_expected.to run.with_params([]).and_return('[]') }
+  it { is_expected.to run.with_params(['one']).and_return('["one"]') }
+  it { is_expected.to run.with_params(['one', 'two']).and_return('["one", "two"]') }
+  it { is_expected.to run.with_params({}).and_return('{}') }
+  it { is_expected.to run.with_params('key' => 'value').and_return('{"key" => "value"}') }
+  it {
+    is_expected.to run.with_params('one' => { 'oneA' => 'A', 'oneB' => { 'oneB1' => '1', 'oneB2' => '2' } }, 'two' => ['twoA', 'twoB'])
+                      .and_return('{"one" => {"oneA" => "A", "oneB" => {"oneB1" => "1", "oneB2" => "2"}}, "two" => ["twoA", "twoB"]}')
+  }
+
+  it { is_expected.to run.with_params('‰').and_return('"‰"') }
+  it { is_expected.to run.with_params('竹').and_return('"竹"') }
+  it { is_expected.to run.with_params('Ü').and_return('"Ü"') }
+  it { is_expected.to run.with_params('∇').and_return('"∇"') }
+end


### PR DESCRIPTION
Add two new utility functions to transform Puppet data structures into their corresponding representation in Python and Ruby.

These functions are aimed to help writing templates of Ruby / Python code when managing configuration files in these languages with Puppet.  Quoting strings, managing `undef` can be a bit tedious:

```
EMAIL_USE_TLS = <%= String($taiga::back::email_use_tls, '%T') %>
EMAIL_HOST = <%= if $taiga::back::email_host { String($taiga::back::email_host, '%p') } else { 'None' } %>
```

These functions make this more readable:

```
EMAIL_USE_TLS = <%= $taiga::back::email_use_tls.to_python %>
EMAIL_HOST = <%= $taiga::back::email_host.to_python %>
```

This initial work took place in https://github.com/voxpupuli/puppet-python/pull/616 but it was suggested to move the code in stdlib.