### PR TITLE
max, lstrip: fix deprecated message

### DIFF
--- a/lib/puppet/parser/functions/lstrip.rb
+++ b/lib/puppet/parser/functions/lstrip.rb
@@ -12,7 +12,7 @@ module Puppet::Parser::Functions
       The stripped string
 
     > **Note:** **Deprecated** from Puppet 6.0.0, this function has been replaced with a
-    built-in [`max`](https://puppet.com/docs/puppet/latest/function.html#max) function.
+    built-in [`lstrip`](https://puppet.com/docs/puppet/latest/function.html#lstrip) function.
     DOC
   ) do |arguments|
     raise(Puppet::ParseError, "lstrip(): Wrong number of arguments given (#{arguments.size} for 1)") if arguments.empty?

--- a/lib/puppet/parser/functions/max.rb
+++ b/lib/puppet/parser/functions/max.rb
@@ -14,7 +14,7 @@ module Puppet::Parser::Functions
       The highest value among those passed in
 
     > **Note:** **Deprecated** from Puppet 6.0.0, this function has been replaced with a
-    built-in [`lstrip`](https://puppet.com/docs/puppet/latest/function.html#lstrip) function.
+    built-in [`max`](https://puppet.com/docs/puppet/latest/function.html#max) function.
     DOC
   ) do |args|
     raise(Puppet::ParseError, 'max(): Wrong number of arguments need at least one') if args.empty?


### PR DESCRIPTION
lstrip has a deprecation message pointing to max and vice versa this PR updates the doc string