### PR TITLE
Fix serialization of undef in to_python()

### DIFF
--- a/lib/puppet/functions/to_python.rb
+++ b/lib/puppet/functions/to_python.rb
@@ -28,7 +28,7 @@ Puppet::Functions.create_function(:to_python) do
     case object
     when true then 'True'
     when false then 'False'
-    when :undef then 'None'
+    when nil then 'None'
     when Array then "[#{object.map { |x| to_python(x) }.join(', ')}]"
     when Hash then "{#{object.map { |k, v| "#{to_python(k)}: #{to_python(v)}" }.join(', ')}}"
     else object.inspect

--- a/lib/puppet/functions/to_ruby.rb
+++ b/lib/puppet/functions/to_ruby.rb
@@ -26,7 +26,6 @@ Puppet::Functions.create_function(:to_ruby) do
   #   The String representation of the object
   def to_ruby(object)
     case object
-    when :undef then 'nil'
     when Array then "[#{object.map { |x| to_ruby(x) }.join(', ')}]"
     when Hash then "{#{object.map { |k, v| "#{to_ruby(k)} => #{to_ruby(v)}" }.join(', ')}}"
     else object.inspect

--- a/spec/functions/to_python_spec.rb
+++ b/spec/functions/to_python_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'to_python' do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params('').and_return('""') }
-  it { is_expected.to run.with_params(:undef).and_return('None') }
+  it { is_expected.to run.with_params(nil).and_return('None') }
   it { is_expected.to run.with_params(true).and_return('True') }
   it { is_expected.to run.with_params(false).and_return('False') }
   it { is_expected.to run.with_params('one').and_return('"one"') }

--- a/spec/functions/to_ruby_spec.rb
+++ b/spec/functions/to_ruby_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'to_ruby' do
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params('').and_return('""') }
-  it { is_expected.to run.with_params(:undef).and_return('nil') }
+  it { is_expected.to run.with_params(nil).and_return('nil') }
   it { is_expected.to run.with_params(true).and_return('true') }
   it { is_expected.to run.with_params('one').and_return('"one"') }
   it { is_expected.to run.with_params(42).and_return('42') }


### PR DESCRIPTION
`:undef` was used in old Puppet functions, but modern Puppet 4 functions receive `undef` Puppet values as `nil` Ruby values.  This cause to_python() to serialize `undef` as `nil` instead of `None`, which is not valid Python code.

Fix the to_python() behavior by comparing with `nil`.  Update the test suite accordingly.

While here, also adjust the to_ruby() function which had the same wrong logic but was not causing trouble because in Ruby, we want to serialize `nil` to `nil` :-)