### PR TITLE
[MODULES-11082] Fix Ruby lang typo in root_home.rb

### DIFF
--- a/lib/facter/root_home.rb
+++ b/lib/facter/root_home.rb
@@ -40,7 +40,7 @@ Facter.add(:root_home) do
   root_home = nil
   setcode do
     str = Facter::Util::Resolution.exec('lsuser -c -a home root')
-    str&.split("\n")&.each do |line|
+    str.split("\n").each do |line|
       next if %r{^#}.match?(line)
       root_home = line.split(%r{:})[1]
     end


### PR DESCRIPTION
Fixes `/var/lib/puppet/lib/facter/root_home.rb:43: syntax error unexpected '.'`

* Adapt changes introduced by 03d4b82630b911b6e574fae58f47520669096133
* Fixes [MODULES-11082](https://tickets.puppetlabs.com/browse/MODULES-11082)