### PR TITLE
stdlib::ensure: Add support for package resource

### DIFF
--- a/functions/ensure.pp
+++ b/functions/ensure.pp
@@ -1,13 +1,19 @@
 # @summary function to cast ensure parameter to resource specific value
 function stdlib::ensure(
     Variant[Boolean, Enum['present', 'absent']]               $ensure,
-    Enum['directory', 'link', 'mounted', 'service', 'file'] $resource,
+    Enum['directory', 'link', 'mounted', 'service', 'file', 'package'] $resource,
 ) >> String {
     $_ensure = $ensure ? {
         Boolean => $ensure.bool2str('present', 'absent'),
         default => $ensure,
     }
     case $resource {
+        'package': {
+            $_ensure ? {
+                'present' => 'installed',
+                default   => 'absent',
+            }
+        }
         'service': {
             $_ensure ? {
                 'present' => 'running',

--- a/spec/functions/stdlib_ensure_spec.rb
+++ b/spec/functions/stdlib_ensure_spec.rb
@@ -17,4 +17,10 @@ describe 'stdlib::ensure' do
       it { is_expected.to run.with_params(false, resource).and_return('absent') }
     end
   end
+  context 'work with package resource' do
+    it { is_expected.to run.with_params('present', 'package').and_return('installed') }
+    it { is_expected.to run.with_params(true, 'package').and_return('installed') }
+    it { is_expected.to run.with_params('absent', 'package').and_return('absent') }
+    it { is_expected.to run.with_params(false, 'package').and_return('absent') }
+  end
 end


### PR DESCRIPTION
This only adds 'installed' and 'absent' support, not 'latest'.