### PR TITLE
Update load_module_metadata.rb to correct capitalisation in strings documentartion

### DIFF
--- a/lib/puppet/parser/functions/load_module_metadata.rb
+++ b/lib/puppet/parser/functions/load_module_metadata.rb
@@ -8,7 +8,7 @@ module Puppet::Parser::Functions
     @summary
       This function loads the metadata of a given module.
 
-    @example Example USage:
+    @example Example Usage:
       $metadata = load_module_metadata('archive')
       notify { $metadata['author']: }
 


### PR DESCRIPTION
Just a simple capitalisation error on usage