### PR TITLE
Simplify stdlib::manage

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,20 @@ node default {
 }
 ```
 
-The `stdlib::manage` class provides an interface for generating trivial resource declarations via the `create_resources` parameter.
+The `stdlib::manage` class provides an interface for generating trivial resource declarations via the `create_resources` parameter.  Depending on your usage, you may want to set `hiera`'s `lookup_options` for the `stdlib::manage::create_resources:` element.
+
+```yaml
+---
+stdlib::manage::create_resources:
+  file:
+    /etc/somefile:
+      ensure: file
+      owner: root
+      group: root
+  package:
+    badpackage:
+      ensure: absent
+```
 
 ## Reference
 

--- a/manifests/manage.pp
+++ b/manifests/manage.pp
@@ -5,13 +5,12 @@
 # resource.  There are a number of possible patterns to
 # generate trivial resource definitions.  This is an attempt
 # to create a single clear method for uncomplicated resources.
-# There is limited support for `before`, `require`, `notify`,
-# and `subscribe`.  However, the target resources must be defined
-# before this module is run.
+# There is __limited__ support for `before`, `require`, `notify`,
+# and `subscribe`.
 #
 # @param create_resources
 #   A hash of resources to create
-#   NOTE: functions, such as `template` or `epp` are not evaluated.
+#   NOTE: functions, such as `template` or `epp`, are not evaluated.
 #
 # @example
 #   class { 'stdlib::manage':
@@ -25,6 +24,7 @@
 #         'package' => {
 #           'example' => {
 #             'ensure' => 'installed',
+#             'subscribe' => ['Service[sshd]', 'Exec[something]'],
 #           }
 #         }
 #       }
@@ -38,40 +38,15 @@
 #     package:
 #       example:
 #         ensure: installed
+#         subscribe:
+#           - 'Service[sshd]'
+#           - 'Exec[something]'
 class stdlib::manage (
   Hash[String, Hash] $create_resources = {}
 ) {
   $create_resources.each |$type, $resources| {
     $resources.each |$title, $attributes| {
-      $filtered_attributes = $attributes.filter |$key, $value| {
-        $key !~ /(before|require|notify|subscribe)/
-      }
-
-      if $attributes['before'] {
-        $_before = stdlib::str2resource($attributes['before'])
-      } else {
-        $_before = undef
-      }
-
-      if $attributes['require'] {
-        $_require = stdlib::str2resource($attributes['require'])
-      } else {
-        $_require = undef
-      }
-
-      if $attributes['notify'] {
-        $_notify = stdlib::str2resource($attributes['notify'])
-      } else {
-        $_notify = undef
-      }
-
-      if $attributes['subscribe'] {
-        $_subscribe = stdlib::str2resource($attributes['subscribe'])
-      } else {
-        $_subscribe = undef
-      }
-
-      create_resources($type, { $title => $filtered_attributes }, { 'before' => $_before, 'require' => $_require, 'notify' => $_notify, 'subscribe' => $_subscribe })
+      create_resources($type, { $title => $attributes })
     }
   }
 }

--- a/spec/classes/manage_spec.rb
+++ b/spec/classes/manage_spec.rb
@@ -39,6 +39,6 @@ describe 'stdlib::manage' do
 
     it { is_expected.to compile }
     it { is_expected.to contain_file('/etc/motd.d/hello').with_content('I say Hi').with_notify('Service[sshd]') }
-    it { is_expected.to contain_package('example').with_ensure('installed').with_subscribe(['Service[sshd]', 'File[/etc/motd.d]']) }
+    it { is_expected.to contain_package('example').with_ensure('installed').that_subscribes_to(['Service[sshd]', 'File[/etc/motd.d]']) }
   end
 end

--- a/spec/classes/manage_spec.rb
+++ b/spec/classes/manage_spec.rb
@@ -30,6 +30,7 @@ describe 'stdlib::manage' do
           'package' => {
             'example' => {
               'ensure' => 'installed',
+              'subscribe' => ['Service[sshd]', 'File[/etc/motd.d]'],
             }
           }
         }
@@ -38,6 +39,6 @@ describe 'stdlib::manage' do
 
     it { is_expected.to compile }
     it { is_expected.to contain_file('/etc/motd.d/hello').with_content('I say Hi').with_notify('Service[sshd]') }
-    it { is_expected.to contain_package('example').with_ensure('installed') }
+    it { is_expected.to contain_package('example').with_ensure('installed').with_subscribe(['Service[sshd]', 'File[/etc/motd.d]']) }
   end
 end


### PR DESCRIPTION
This should make the resources much less sensitive to parse order,
since pupppet is already "doing the right thing" to Strings in this
parameter location.