### PR TITLE
(MAINT) Drop support for AIX + Windows EOL OSs

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -67,18 +67,13 @@
     {
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
-        "10",
         "11"
       ]
     },
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "7",
-        "8.1",
         "10",
-        "2008",
-        "2008 R2",
         "2012",
         "2012 R2",
         "2016",
@@ -89,8 +84,6 @@
     {
       "operatingsystem": "AIX",
       "operatingsystemrelease": [
-        "5.3",
-        "6.1",
         "7.1",
         "7.2"
       ]


### PR DESCRIPTION
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported. This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.

In this commit:
Support for AIX 5.3 and 6.1 was removed.
Support for Windows 7, 8.1 and 10 was removed.
Support for Windows Server 2008 and 2008 R2 was removed. ﻿
The list of supported OSs can be found here:
https://puppet.com/docs/pe/2021.7/supported_operating_systems.html