### PR TITLE
(CONT-173) - Updating deprecated facter instances

### DIFF
--- a/lib/facter/root_home.rb
+++ b/lib/facter/root_home.rb
@@ -9,7 +9,7 @@ module Facter::Util::RootHome
   class << self
     # determines the root home directory
     def returnt_root_home
-      root_ent = Facter::Util::Resolution.exec('getent passwd root')
+      root_ent = Facter::Core::Execution.execute('getent passwd root')
       # The home directory is the sixth element in the passwd entry
       # If the platform doesn't have getent, root_ent will be nil and we should
       # return it straight away.
@@ -25,7 +25,7 @@ end
 Facter.add(:root_home) do
   confine kernel: :darwin
   setcode do
-    str = Facter::Util::Resolution.exec('dscacheutil -q user -a name root')
+    str = Facter::Core::Execution.execute('dscacheutil -q user -a name root')
     hash = {}
     str.split("\n").each do |pair|
       key, value = pair.split(%r{:})
@@ -39,7 +39,7 @@ Facter.add(:root_home) do
   confine kernel: :aix
   root_home = nil
   setcode do
-    str = Facter::Util::Resolution.exec('lsuser -c -a home root')
+    str = Facter::Core::Execution.execute('lsuser -c -a home root')
     str&.split("\n")&.each do |line|
       next if %r{^#}.match?(line)
       root_home = line.split(%r{:})[1]

--- a/spec/unit/facter/root_home_spec.rb
+++ b/spec/unit/facter/root_home_spec.rb
@@ -9,7 +9,7 @@ describe 'Root Home Specs' do
       let(:expected_root_home) { '/' }
 
       it 'returns /' do
-        expect(Facter::Util::Resolution).to receive(:exec).with('getent passwd root').and_return(root_ent)
+        expect(Facter::Core::Execution).to receive(:execute).with('getent passwd root').and_return(root_ent)
         expect(described_class.returnt_root_home).to eq(expected_root_home)
       end
     end
@@ -18,13 +18,13 @@ describe 'Root Home Specs' do
       let(:expected_root_home) { '/root' }
 
       it 'returns /root' do
-        expect(Facter::Util::Resolution).to receive(:exec).with('getent passwd root').and_return(root_ent)
+        expect(Facter::Core::Execution).to receive(:execute).with('getent passwd root').and_return(root_ent)
         expect(described_class.returnt_root_home).to eq(expected_root_home)
       end
     end
     context 'when windows' do
       it 'is nil on windows' do
-        expect(Facter::Util::Resolution).to receive(:exec).with('getent passwd root').and_return(nil)
+        expect(Facter::Core::Execution).to receive(:execute).with('getent passwd root').and_return(nil)
         expect(described_class.returnt_root_home).to be_nil
       end
     end
@@ -44,7 +44,7 @@ describe 'Root Home Specs' do
       sample_dscacheutil = File.read(fixtures('dscacheutil', 'root'))
 
       it 'returns /var/root' do
-        allow(Facter::Util::Resolution).to receive(:exec).with('dscacheutil -q user -a name root').and_return(sample_dscacheutil)
+        allow(Facter::Core::Execution).to receive(:execute).with('dscacheutil -q user -a name root').and_return(sample_dscacheutil)
         expect(Facter.fact(:root_home).value).to eq(expected_root_home)
       end
     end
@@ -59,7 +59,7 @@ describe 'Root Home Specs' do
       sample_lsuser = File.read(fixtures('lsuser', 'root'))
 
       it 'returns /root' do
-        allow(Facter::Util::Resolution).to receive(:exec).with('lsuser -c -a home root').and_return(sample_lsuser)
+        allow(Facter::Core::Execution).to receive(:execute).with('lsuser -c -a home root').and_return(sample_lsuser)
         expect(Facter.fact(:root_home).value).to eq(expected_root_home)
       end
     end


### PR DESCRIPTION
Prior to this PR, this module contained instances of Facter::Util::Resolution.exec and Facter::Util::Resolution.which, which are deprecated. This PR aims to replace these exec helpers with their supported Facter::Core::Execution counterparts.

This PR:

Replaces all Facter::Util::Resolution instances with corresponding Facter::Core::Execution exec helpers