### PR TITLE
Drop Puppet < 3.6 support in package_provider fact

### DIFF
--- a/lib/facter/package_provider.rb
+++ b/lib/facter/package_provider.rb
@@ -16,10 +16,6 @@ require 'puppet/type/package'
 Facter.add(:package_provider) do
   # Instantiates a dummy package resource and return the provider
   setcode do
-    if defined? Gem && Gem::Version.new(Facter.value(:puppetversion).split(' ')[0]) >= Gem::Version.new('3.6')
-      Puppet::Type.type(:package).newpackage(name: 'dummy', allow_virtual: 'true')[:provider].to_s
-    else
-      Puppet::Type.type(:package).newpackage(name: 'dummy')[:provider].to_s
-    end
+    Puppet::Type.type(:package).newpackage(name: 'dummy', allow_virtual: 'true')[:provider].to_s
   end
 end


### PR DESCRIPTION
The metadata states it's only compatible with Puppet 6+ so maintaining compatibility is useless and can only slow things down.