### PR TITLE
stdlib::ensure: update function to support the generic case

### DIFF
--- a/functions/ensure.pp
+++ b/functions/ensure.pp
@@ -3,7 +3,7 @@
 # @return [String]
 function stdlib::ensure(
   Variant[Boolean, Enum['present', 'absent']] $ensure,
-  Enum['directory', 'link', 'mounted', 'service', 'file', 'package'] $resource,
+  Optional[Enum['directory', 'link', 'mounted', 'service', 'file', 'package']] $resource = undef,
 ) >> String {
   $_ensure = $ensure ? {
     Boolean => $ensure.bool2str('present', 'absent'),
@@ -22,6 +22,7 @@ function stdlib::ensure(
         default   => 'stopped',
       }
     }
+    undef: { $_ensure }
     default: {
       $_ensure ? {
         'present' => $resource,

--- a/spec/functions/stdlib_ensure_spec.rb
+++ b/spec/functions/stdlib_ensure_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 
 describe 'stdlib::ensure' do
+  context 'work without resource' do
+    it { is_expected.to run.with_params(true).and_return('present') }
+    it { is_expected.to run.with_params(false).and_return('absent') }
+  end
   context 'work with service resource' do
     it { is_expected.to run.with_params('present', 'service').and_return('running') }
     it { is_expected.to run.with_params(true, 'service').and_return('running') }


### PR DESCRIPTION
Often custom resources only support present/absent for the ensure parameter and often the inclusion of theses resources are enabled via some boolean value as such i often find my self using the following pattern

```puppet
$ensure_feature = $enable_feature.bool2str('ensure', 'present')
```

This patch updates the stdlib::ensure function so we can simplify this to

```puppet
$ensure_feature = $enable_feature.stdlib::ensure   # or ...
$ensure_feature = stdlib::ensure($enable_feature) 
```