### PR TITLE
Safely handle a missing root user

### DIFF
--- a/lib/facter/root_home.rb
+++ b/lib/facter/root_home.rb
@@ -6,6 +6,6 @@ Facter.add(:root_home) do
   rescue LoadError
   # Unavailable on platforms like Windows
   else
-    Etc.getpwnam('root').dir
+    Etc.getpwnam('root')&.dir
   end
 end


### PR DESCRIPTION
In 657cd7126e6d01f883c2e038dae449aea30db5d0 it was assumed that Etc would never be available on Windows and that the LoadError would catch it. Turns out that was an invalid assumption. This uses the safe operator to gracefully handle it.

Fixes #1293