### PR TITLE
(PUP-11752) Fix fqdn_rand_string_spec.rb test

### DIFF
--- a/spec/functions/fqdn_rand_string_spec.rb
+++ b/spec/functions/fqdn_rand_string_spec.rb
@@ -57,7 +57,11 @@ describe 'fqdn_rand_string' do
 
     # workaround not being able to use let(:facts) because some tests need
     # multiple different hostnames in one context
-    allow(scope).to receive(:lookupvar).with('::fqdn', {}).and_return(host)
+    if Gem::Version.new(Puppet::PUPPETVERSION) < Gem::Version.new('7.23.0')
+      allow(scope).to receive(:lookupvar).with('::fqdn', {}).and_return(host)
+    else
+      allow(scope).to receive(:lookupvar).with('facts', {}).and_return({ 'networking' => { 'fqdn' => host } })
+    end
 
     function_args = [max]
     if args.key?(:charset) || !extra.empty?


### PR DESCRIPTION
Since Puppet `7.23.0` `fqdn_rand` uses the modern structured `networking` fact instead of the legacy `fqdn` fact.

In this commit we mock the new fact if using `7.23.0` or later.

Rebase of https://github.com/puppetlabs/puppetlabs-stdlib/pull/1294 incorporating @joshcooper 's suggestion.