### PR TITLE
Allow `deferrable_epp` to return a `Sensitive[String]`

### DIFF
--- a/functions/deferrable_epp.pp
+++ b/functions/deferrable_epp.pp
@@ -5,7 +5,7 @@
 # use facts, class variables, and other variables in scope. This is because when deferred, we
 # have to explicitly pass the entire scope to the client.
 #
-function stdlib::deferrable_epp(String $template, Hash $variables) >> Variant[String, Deferred] {
+function stdlib::deferrable_epp(String $template, Hash $variables) >> Variant[String, Sensitive[String], Deferred] {
   if $variables.any |$key, $value| { $value.is_a(Deferred) } {
     Deferred(
       'inline_epp',


### PR DESCRIPTION
If none of the input variables are `Deferred`, then `deferrable_epp` returns the result of calling normal `epp`.

The `epp` function however will return a `Sensitive` if any of the variables it was called with were `Sensitive`.

See https://github.com/puppetlabs/puppet/pull/8330

Adding `Sensitive[String]` to the list of allowed return types fixes this.