### PR TITLE
types - dns: add a new dns type with more specific fqdn definitions

### DIFF
--- a/types/dns/fqdn.pp
+++ b/types/dns/fqdn.pp
@@ -1,0 +1,1 @@
+type Stdlib::DNS::Fqdn = Stdlib::DNS::Fqdn::IANA::ASCII

--- a/types/dns/fqdn/iana/ascii.pp
+++ b/types/dns/fqdn/iana/ascii.pp
@@ -1,0 +1,1 @@
+type Stdlib::DNS::Fqdn::IANA::ASCII = Pattern[/\A(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[a-z0-9]*[a-z]+[a-z0-9]*)\z/]

--- a/types/dns/fqdn/iana/unicode.pp
+++ b/types/dns/fqdn/iana/unicode.pp
@@ -1,0 +1,1 @@
+type Stdlib::DNS::Fqdn::IANA::Unicode = Pattern[/\A((([[:alnum:]]|[[:alnum:]][[:alnum:]-]*[[:alnum:]])\.)*[[:alpha:]]+)\z/]

--- a/types/dns/fqdn/rfc.pp
+++ b/types/dns/fqdn/rfc.pp
@@ -1,0 +1,2 @@
+type Stdlib::DNS::Fqdn::Rfc = Pattern[/\A(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\z/]
+

--- a/types/dns/punycode.pp
+++ b/types/dns/punycode.pp
@@ -1,0 +1,1 @@
+type Stdlib::DNS::Punycpde = Pattern[/xn--[a-z0-9]+/]

--- a/types/fqdn.pp
+++ b/types/fqdn.pp
@@ -1,2 +1,2 @@
 # @summary Validate a Fully Qualified Domain Name
-type Stdlib::Fqdn = Pattern[/\A(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\z/]
+type Stdlib::Fqdn = Stdlib::DNS::Rfc::Fqdn

--- a/types/fqdn.pp
+++ b/types/fqdn.pp
@@ -1,2 +1,2 @@
 # @summary Validate a Fully Qualified Domain Name
-type Stdlib::Fqdn = Stdlib::DNS::Rfc::Fqdn
+type Stdlib::Fqdn = Stdlib::DNS::Fqdn::Rfc


### PR DESCRIPTION
This PR introduces a new set of types for validating FQDN's.  it creates a type for the more loose rfc definitions of domain names and a stricter and likely more useful iana type.

This allows us to create a new type that more does to what most users expect i.e. that a dns name is one that works on the internt, without breaking current uses for users that may be using the Stdlib::Fqdn to validate validate DNS names that don't work with the IANA roots.

The intention of this patch would be to deprecate the currnet Stdlib::Fqdn type and encourage users to move to the appropriate Stdlib::DNS::* type which for most users will likely be the stricter Stdlib::DNS::Fqdn type

Note: this PR is intentionally a bit rough to first garner thoughts as to if this is the correct direction

Fixes #1282 (not sure it fixes but want it tagged)