### PR TITLE
Add Stdlib::IP::Address::CIDR

### DIFF
--- a/types/ip/address/cidr.pp
+++ b/types/ip/address/cidr.pp
@@ -1,0 +1,5 @@
+# Validate an IP address with subnet
+type Stdlib::IP::Address::CIDR = Variant[
+  Stdlib::IP::Address::V4::CIDR,
+  Stdlib::IP::Address::V6::CIDR,
+]


### PR DESCRIPTION
This type was the only one missing from the hierarchy.