### PR TITLE
Fix validate_domain_name called without parameters

### DIFF
--- a/lib/puppet/functions/validate_domain_name.rb
+++ b/lib/puppet/functions/validate_domain_name.rb
@@ -24,5 +24,11 @@ Puppet::Functions.create_function(:validate_domain_name) do
     repeated_param 'Variant[Stdlib::Fqdn, Stdlib::Dns::Zone]', :values
   end
 
-  def validate_domain_name(*_values); end
+  def validate_domain_name(*args)
+    assert_arg_count(args)
+  end
+
+  def assert_arg_count(args)
+    raise(ArgumentError, 'validate_domain_name(): Wrong number of arguments need at least one') if args.empty?
+  end
 end

--- a/spec/functions/validate_domain_name_spec.rb
+++ b/spec/functions/validate_domain_name_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 describe 'validate_domain_name' do
   describe 'signature validation' do
     it { is_expected.not_to eq(nil) }
+    it { is_expected.to run.with_params.and_raise_error(ArgumentError, %r{wrong number of arguments}i) }
   end
 
   describe 'valid inputs' do


### PR DESCRIPTION
In #1345, the `validate_domain_name()` function was rewritten to the
Puppet 4.x syntax, but the behavior was slightly changed since we
previously did not allow passing no parameter at all.

Add code to assert as least one parameter is passed to restore the
previous behavior and raise an error when called without parameter.
