### PR TITLE
Fix `fqdn_rand_string` regression

### DIFF
--- a/lib/puppet/functions/stdlib/fqdn_rand_string.rb
+++ b/lib/puppet/functions/stdlib/fqdn_rand_string.rb
@@ -15,17 +15,19 @@ Puppet::Functions.create_function(:'stdlib::fqdn_rand_string') do
   # @example Example Usage:
   #   stdlib::fqdn_rand_string(10)
   #   stdlib::fqdn_rand_string(10, 'ABCDEF!@$%^')
-  #   stdlib::fqdn_rand_string(10, '', 'custom seed')
+  #   stdlib::fqdn_rand_string(10, undef, 'custom seed')
   dispatch :fqdn_rand_string do
     param 'Integer[1]', :length
-    optional_param 'String', :charset
+    optional_param 'Optional[String]', :charset
     optional_repeated_param 'Any', :seed
   end
 
-  def fqdn_rand_string(length, charset = '', *seed)
-    charset = charset.chars.to_a
-
-    charset = (0..9).map(&:to_s) + ('A'..'Z').to_a + ('a'..'z').to_a if charset.empty?
+  def fqdn_rand_string(length, charset = nil, *seed)
+    charset = if charset && !charset.empty?
+                charset.chars.to_a
+              else
+                (0..9).map(&:to_s) + ('A'..'Z').to_a + ('a'..'z').to_a
+              end
 
     rand_string = ''
     length.times do |current|

--- a/spec/functions/fqdn_rand_string_spec.rb
+++ b/spec/functions/fqdn_rand_string_spec.rb
@@ -14,13 +14,15 @@ describe 'stdlib::fqdn_rand_string' do
   it { is_expected.to run.with_params('string').and_raise_error(ArgumentError, %r{parameter 'length' expects an Integer\ value, got String}) }
   it { is_expected.to run.with_params([]).and_raise_error(ArgumentError, %r{parameter 'length' expects an Integer value, got Array}) }
   it { is_expected.to run.with_params({}).and_raise_error(ArgumentError, %r{parameter 'length' expects an Integer value, got Hash}) }
-  it { is_expected.to run.with_params(1, 1).and_raise_error(ArgumentError, %r{parameter 'charset' expects a String value, got Integer}) }
-  it { is_expected.to run.with_params(1, []).and_raise_error(ArgumentError, %r{parameter 'charset' expects a String value, got Array}) }
-  it { is_expected.to run.with_params(1, {}).and_raise_error(ArgumentError, %r{parameter 'charset' expects a String value, got Hash}) }
+  it { is_expected.to run.with_params(1, 1).and_raise_error(ArgumentError, %r{parameter 'charset' expects a value of type Undef or String, got Integer}) }
+  it { is_expected.to run.with_params(1, []).and_raise_error(ArgumentError, %r{parameter 'charset' expects a value of type Undef or String, got Array}) }
+  it { is_expected.to run.with_params(1, {}).and_raise_error(ArgumentError, %r{parameter 'charset' expects a value of type Undef or String, got Hash}) }
   it { is_expected.to run.with_params('100').and_raise_error(ArgumentError, %r{parameter 'length' expects an Integer value, got String}) }
-  it { is_expected.to run.with_params(100, nil).and_raise_error(ArgumentError, %r{parameter 'charset' expects a String value, got Undef}) }
-  it { is_expected.to run.with_params(100).and_return(default_charset) }
+  it { is_expected.to run.with_params(100, nil).and_return(default_charset) }
   it { is_expected.to run.with_params(100, '').and_return(default_charset) }
+  it { is_expected.to run.with_params(100, nil, 'MY_CUSTOM_SEED').and_return(default_charset) }
+  it { is_expected.to run.with_params(100, '', 'MY_CUSTOM_SEED').and_return(default_charset) }
+  it { is_expected.to run.with_params(100).and_return(default_charset) }
   it { is_expected.to run.with_params(100, 'a').and_return(%r{\Aa{100}\z}) }
   it { is_expected.to run.with_params(100, 'ab').and_return(%r{\A[ab]{100}\z}) }
   it { is_expected.to run.with_params(100, 'ãβ').and_return(%r{\A[ãβ]{100}\z}) }


### PR DESCRIPTION
The function use to be able to accept `undef` as its second argument.

eg.
```puppet
fqdn_rand_string(10, undef, 'custom seed')
```

Using `undef` to mean 'use the default' is much more conventional than `''` (empty string).

This commit restores the old interface broken in `9.0.0`