### PR TITLE
Ignore Puppet's `strict` setting when calling function without namespace

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -115,7 +115,7 @@ task :regenerate_unamespaced_shims do
           repeated_param 'Any', :args
         end
         def deprecation_gen(*args)
-          call_function('deprecation', '#{function_name}', 'This function is deprecated, please use stdlib::#{function_name} instead.')
+          call_function('deprecation', '#{function_name}', 'This function is deprecated, please use stdlib::#{function_name} instead.', false)
           call_function('stdlib::#{function_name}', *args)
         end
       end

--- a/lib/puppet/functions/batch_escape.rb
+++ b/lib/puppet/functions/batch_escape.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:batch_escape) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'batch_escape', 'This function is deprecated, please use stdlib::batch_escape instead.')
+    call_function('deprecation', 'batch_escape', 'This function is deprecated, please use stdlib::batch_escape instead.', false)
     call_function('stdlib::batch_escape', *args)
   end
 end

--- a/lib/puppet/functions/ensure_packages.rb
+++ b/lib/puppet/functions/ensure_packages.rb
@@ -7,7 +7,7 @@ Puppet::Functions.create_function(:ensure_packages, Puppet::Functions::InternalF
     repeated_param 'Any', :args
   end
   def deprecation_gen(scope, *args)
-    call_function('deprecation', 'ensure_packages', 'This function is deprecated, please use stdlib::ensure_packages instead.')
+    call_function('deprecation', 'ensure_packages', 'This function is deprecated, please use stdlib::ensure_packages instead.', false)
     scope.call_function('stdlib::ensure_packages', args)
   end
 end

--- a/lib/puppet/functions/fqdn_rand_string.rb
+++ b/lib/puppet/functions/fqdn_rand_string.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:fqdn_rand_string) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'fqdn_rand_string', 'This function is deprecated, please use stdlib::fqdn_rand_string instead.')
+    call_function('deprecation', 'fqdn_rand_string', 'This function is deprecated, please use stdlib::fqdn_rand_string instead.', false)
     call_function('stdlib::fqdn_rand_string', *args)
   end
 end

--- a/lib/puppet/functions/has_interface_with.rb
+++ b/lib/puppet/functions/has_interface_with.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:has_interface_with) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'has_interface_with', 'This function is deprecated, please use stdlib::has_interface_with instead.')
+    call_function('deprecation', 'has_interface_with', 'This function is deprecated, please use stdlib::has_interface_with instead.', false)
     call_function('stdlib::has_interface_with', *args)
   end
 end

--- a/lib/puppet/functions/merge.rb
+++ b/lib/puppet/functions/merge.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:merge) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'merge', 'This function is deprecated, please use stdlib::merge instead.')
+    call_function('deprecation', 'merge', 'This function is deprecated, please use stdlib::merge instead.', false)
     call_function('stdlib::merge', *args)
   end
 end

--- a/lib/puppet/functions/os_version_gte.rb
+++ b/lib/puppet/functions/os_version_gte.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:os_version_gte) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'os_version_gte', 'This function is deprecated, please use stdlib::os_version_gte instead.')
+    call_function('deprecation', 'os_version_gte', 'This function is deprecated, please use stdlib::os_version_gte instead.', false)
     call_function('stdlib::os_version_gte', *args)
   end
 end

--- a/lib/puppet/functions/parsehocon.rb
+++ b/lib/puppet/functions/parsehocon.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:parsehocon) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'parsehocon', 'This function is deprecated, please use stdlib::parsehocon instead.')
+    call_function('deprecation', 'parsehocon', 'This function is deprecated, please use stdlib::parsehocon instead.', false)
     call_function('stdlib::parsehocon', *args)
   end
 end

--- a/lib/puppet/functions/powershell_escape.rb
+++ b/lib/puppet/functions/powershell_escape.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:powershell_escape) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'powershell_escape', 'This function is deprecated, please use stdlib::powershell_escape instead.')
+    call_function('deprecation', 'powershell_escape', 'This function is deprecated, please use stdlib::powershell_escape instead.', false)
     call_function('stdlib::powershell_escape', *args)
   end
 end

--- a/lib/puppet/functions/seeded_rand.rb
+++ b/lib/puppet/functions/seeded_rand.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:seeded_rand) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'seeded_rand', 'This function is deprecated, please use stdlib::seeded_rand instead.')
+    call_function('deprecation', 'seeded_rand', 'This function is deprecated, please use stdlib::seeded_rand instead.', false)
     call_function('stdlib::seeded_rand', *args)
   end
 end

--- a/lib/puppet/functions/seeded_rand_string.rb
+++ b/lib/puppet/functions/seeded_rand_string.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:seeded_rand_string) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'seeded_rand_string', 'This function is deprecated, please use stdlib::seeded_rand_string instead.')
+    call_function('deprecation', 'seeded_rand_string', 'This function is deprecated, please use stdlib::seeded_rand_string instead.', false)
     call_function('stdlib::seeded_rand_string', *args)
   end
 end

--- a/lib/puppet/functions/shell_escape.rb
+++ b/lib/puppet/functions/shell_escape.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:shell_escape) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'shell_escape', 'This function is deprecated, please use stdlib::shell_escape instead.')
+    call_function('deprecation', 'shell_escape', 'This function is deprecated, please use stdlib::shell_escape instead.', false)
     call_function('stdlib::shell_escape', *args)
   end
 end

--- a/lib/puppet/functions/to_json.rb
+++ b/lib/puppet/functions/to_json.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:to_json) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'to_json', 'This function is deprecated, please use stdlib::to_json instead.')
+    call_function('deprecation', 'to_json', 'This function is deprecated, please use stdlib::to_json instead.', false)
     call_function('stdlib::to_json', *args)
   end
 end

--- a/lib/puppet/functions/to_json_pretty.rb
+++ b/lib/puppet/functions/to_json_pretty.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:to_json_pretty) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'to_json_pretty', 'This function is deprecated, please use stdlib::to_json_pretty instead.')
+    call_function('deprecation', 'to_json_pretty', 'This function is deprecated, please use stdlib::to_json_pretty instead.', false)
     call_function('stdlib::to_json_pretty', *args)
   end
 end

--- a/lib/puppet/functions/to_python.rb
+++ b/lib/puppet/functions/to_python.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:to_python) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'to_python', 'This function is deprecated, please use stdlib::to_python instead.')
+    call_function('deprecation', 'to_python', 'This function is deprecated, please use stdlib::to_python instead.', false)
     call_function('stdlib::to_python', *args)
   end
 end

--- a/lib/puppet/functions/to_ruby.rb
+++ b/lib/puppet/functions/to_ruby.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:to_ruby) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'to_ruby', 'This function is deprecated, please use stdlib::to_ruby instead.')
+    call_function('deprecation', 'to_ruby', 'This function is deprecated, please use stdlib::to_ruby instead.', false)
     call_function('stdlib::to_ruby', *args)
   end
 end

--- a/lib/puppet/functions/to_toml.rb
+++ b/lib/puppet/functions/to_toml.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:to_toml) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'to_toml', 'This function is deprecated, please use stdlib::to_toml instead.')
+    call_function('deprecation', 'to_toml', 'This function is deprecated, please use stdlib::to_toml instead.', false)
     call_function('stdlib::to_toml', *args)
   end
 end

--- a/lib/puppet/functions/to_yaml.rb
+++ b/lib/puppet/functions/to_yaml.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:to_yaml) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'to_yaml', 'This function is deprecated, please use stdlib::to_yaml instead.')
+    call_function('deprecation', 'to_yaml', 'This function is deprecated, please use stdlib::to_yaml instead.', false)
     call_function('stdlib::to_yaml', *args)
   end
 end

--- a/lib/puppet/functions/type_of.rb
+++ b/lib/puppet/functions/type_of.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:type_of) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'type_of', 'This function is deprecated, please use stdlib::type_of instead.')
+    call_function('deprecation', 'type_of', 'This function is deprecated, please use stdlib::type_of instead.', false)
     call_function('stdlib::type_of', *args)
   end
 end

--- a/lib/puppet/functions/validate_domain_name.rb
+++ b/lib/puppet/functions/validate_domain_name.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:validate_domain_name) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'validate_domain_name', 'This function is deprecated, please use stdlib::validate_domain_name instead.')
+    call_function('deprecation', 'validate_domain_name', 'This function is deprecated, please use stdlib::validate_domain_name instead.', false)
     call_function('stdlib::validate_domain_name', *args)
   end
 end

--- a/lib/puppet/functions/validate_email_address.rb
+++ b/lib/puppet/functions/validate_email_address.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:validate_email_address) do
     repeated_param 'Any', :args
   end
   def deprecation_gen(*args)
-    call_function('deprecation', 'validate_email_address', 'This function is deprecated, please use stdlib::validate_email_address instead.')
+    call_function('deprecation', 'validate_email_address', 'This function is deprecated, please use stdlib::validate_email_address instead.', false)
     call_function('stdlib::validate_email_address', *args)
   end
 end


### PR DESCRIPTION
Previously, when a user had the Puppet setting `strict` set to `error` (which is the default in Puppet 8), a call to one of stdlib's functions via the deprecated non-namespaced function would cause a hard failure instead of just logging a warning and calling the real namespaced function.

In this change, all of our shims have been updated to call `deprecation` with its new third parameter, (`use_strict_setting`), set to `false`. The non-namespaced versions will now only ever log warnings informing users to moved to the namespaced versions. It will not raise exceptions even if `strict` is set to `error`.

This change will make it much easier for users to migrate to stdlib 9 (and to upgrade modules that now depend on stdlib 9)

Fixes #1373

(Note, this PR description was updated after the `deprecation` function update was extracted into its own PR https://github.com/puppetlabs/puppetlabs-stdlib/pull/1378)