### PR TITLE
Re-add block support to deprecated top-level merge

### DIFF
--- a/lib/puppet/functions/merge.rb
+++ b/lib/puppet/functions/merge.rb
@@ -6,9 +6,10 @@
 Puppet::Functions.create_function(:merge) do
   dispatch :deprecation_gen do
     repeated_param 'Any', :args
+    optional_block_param 'Variant[Callable[2,2], Callable[3,3]]', :block
   end
-  def deprecation_gen(*args)
+  def deprecation_gen(*args, &block)
     call_function('deprecation', 'merge', 'This function is deprecated, please use stdlib::merge instead.', false)
-    call_function('stdlib::merge', *args)
+    call_function('stdlib::merge', *args, &block)
   end
 end


### PR DESCRIPTION
## Summary
The block parameter functionality of the deprecated top-level merge was broken when it was moved to the stdlib namespace in #1356.  This restores the original behavior.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)