### PR TITLE
Fix fqdn_rotate determinism

### DIFF
--- a/lib/puppet/parser/functions/fqdn_rotate.rb
+++ b/lib/puppet/parser/functions/fqdn_rotate.rb
@@ -36,7 +36,7 @@ DOC
 
   elements = result.size
 
-  seed = Digest::MD5.hexdigest([lookupvar('::fqdn'), args].join(':')).hex
+  seed = Digest::MD5.hexdigest([self['facts']['networking']['fqdn'], args].join(':')).hex
   # deterministic_rand() was added in Puppet 3.2.0; reimplement if necessary
   if Puppet::Util.respond_to?(:deterministic_rand)
     offset = Puppet::Util.deterministic_rand(seed, elements).to_i

--- a/lib/puppet/parser/functions/fqdn_rotate.rb
+++ b/lib/puppet/parser/functions/fqdn_rotate.rb
@@ -36,7 +36,7 @@ DOC
 
   elements = result.size
 
-  seed = Digest::MD5.hexdigest([lookupvar('facts'), args].join(':')).hex
+  seed = Digest::MD5.hexdigest([lookupvar('::fqdn'), args].join(':')).hex
   # deterministic_rand() was added in Puppet 3.2.0; reimplement if necessary
   if Puppet::Util.respond_to?(:deterministic_rand)
     offset = Puppet::Util.deterministic_rand(seed, elements).to_i


### PR DESCRIPTION
This was changed in e2d8b18 and ever since fqdn_rotate has changed result on every successive run.

## Summary
Seed fqdn_rotate with the appropriate fact to restore consistency in its output.

## Additional Context
Issue was identifed after upgrading to stdlib 9.0.0  - files with contents depending on result of fqdn_rotate were refreshing every run.

## Related Issues (if any)
May need to review original reason for the original change in e2d8b18

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x ] Manually verified. (For example `puppet apply`)