### PR TITLE
Revert "(CONT-801) Deprecate uriescape.rb"

### DIFF
--- a/lib/puppet/parser/functions/uriescape.rb
+++ b/lib/puppet/parser/functions/uriescape.rb
@@ -15,13 +15,8 @@ module Puppet::Parser::Functions
     @return [String]
       a string that contains the converted value
 
-    > **Note:**  **Deprecated:** Starting Puppet 8, our Ruby version has upgraded to 3.2.
-    Therefore, its no longer possible to call URI.escape as it was deprecated by 2.7 and removed completely by 3+.
-    This function should be removed once Puppet 7 is no longer supported.
   DOC
   ) do |arguments|
-    raise(Puppet::ParseError, 'Puppet: This function is not available in Puppet 8. URI.escape no longer exists as of Ruby 3+.') if Puppet::Util::Package.versioncmp(Puppet.version, '8').positive?
-
     raise(Puppet::ParseError, "uriescape(): Wrong number of arguments given (#{arguments.size} for 1)") if arguments.empty?
 
     value = arguments[0]

--- a/lib/puppet/parser/functions/uriescape.rb
+++ b/lib/puppet/parser/functions/uriescape.rb
@@ -3,8 +3,6 @@
 require 'uri'
 #
 #  uriescape.rb
-#  Please note: This function is an implementation of a Ruby class and as such may not be entirely UTF8 compatible. To ensure compatibility please use this function with Ruby 2.4.0 or greater - https://bugs.ruby-lang.org/issues/10085.
-#  URI.escape has been fully removed as of Ruby 3. Therefore, it will not work as it stand on Puppet 8. Consider deprecating or updating this function.
 #
 module Puppet::Parser::Functions
   newfunction(:uriescape, type: :rvalue, doc: <<-DOC

--- a/spec/functions/uriescape_spec.rb
+++ b/spec/functions/uriescape_spec.rb
@@ -39,9 +39,5 @@ describe 'uriescape' do
       it { is_expected.to run.with_params(['one}', 'two']).and_return(['one%7D', 'two']) }
       it { is_expected.to run.with_params(['one}', 1, true, {}, 'two']).and_return(['one%7D', 1, true, {}, 'two']) }
     end
-  else
-    describe 'raising errors in Puppet 8' do
-      it { is_expected.to run.with_params([]).and_raise_error(Puppet::ParseError, %r{This function is not available in Puppet 8. URI.escape no longer exists as of Ruby 3+.}) }
-    end
   end
 end


### PR DESCRIPTION


## Summary

This reverts commit 799d608939b90effb7cfa7d0054a3985c78db982.

While uriescape was deprecated for Puppet 8 in https://github.com/puppetlabs/puppetlabs-stdlib/pull/1307 it was already fixed earlier for Puppet 8 and ruby 3 in https://github.com/puppetlabs/puppetlabs-stdlib/pull/1195

It is unclear to me why this function was deprecated.


## Additional Context
Add any additional context about the problem here. 
Function was deprecated on Puppet 8.

## Related Issues (if any)
* Fixes #1401


## Checklist
- [x ] 🟢 Spec tests.
- [x ] 🟢 Acceptance tests.
- [x ] Manually verified. (For example `puppet apply`)