### PR TITLE
Correct casing of Stdlib::IP::Address

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5619,7 +5619,7 @@ Alias of `Pattern[/(?i:\Ahttps?:\/\/.*\z)/]`
 
 Validate a host (FQDN or IP address)
 
-Alias of `Variant[Stdlib::Fqdn, Stdlib::Ip::Address]`
+Alias of `Variant[Stdlib::Fqdn, Stdlib::IP::Address]`
 
 ### <a name="Stdlib--Http--Method"></a>`Stdlib::Http::Method`
 

--- a/types/host.pp
+++ b/types/host.pp
@@ -1,2 +1,2 @@
 # @summary Validate a host (FQDN or IP address)
-type Stdlib::Host = Variant[Stdlib::Fqdn, Stdlib::Ip::Address]
+type Stdlib::Host = Variant[Stdlib::Fqdn, Stdlib::IP::Address]


### PR DESCRIPTION
While Puppet doesn't appear to care about IP vs Ip, but Kafo does and can't find the correct type. This aligns the usage with the actual name in the file.

Fixes: fcbd4267fd83 ("Remove deprecated Stdlib::Compat::* data types")