### PR TITLE
(#1389) - pw_hash with bcrypt not working on puppet master

### DIFF
--- a/lib/puppet/parser/functions/pw_hash.rb
+++ b/lib/puppet/parser/functions/pw_hash.rb
@@ -76,7 +76,7 @@ DOC
 
   # handle weak implementations of String#crypt
   # dup the string to get rid of frozen status for testing
-  if RUBY_PLATFORM == 'java'
+  if RUBY_PLATFORM == 'java' && !args[1].downcase.start_with?('bcrypt')
     # puppetserver bundles Apache Commons Codec
     org.apache.commons.codec.digest.Crypt.crypt(password.to_java_bytes, salt)
   elsif (+'test').crypt('$1$1') == '$1$1$Bp8CU9Oujr9SSEw53WV6G.'


### PR DESCRIPTION
## Summary
See linked issue. `pw_hash` with `bcrypt` does not work on puppet master because of https://github.com/puppetlabs/puppetlabs-stdlib/commit/8d525d24a510d377b29a2aed2654ed2de854b94f

`bcrypt` is not supported by the java implementation.

## Additional Context
Add any additional context about the problem here. 
- Only JRuby setup (e.g. puppet server with puppet agents) are affected. Local `puppet apply` not affected.

## Related Issues (if any)
#1389 - Issue for the bug
https://github.com/puppetlabs/puppetlabs-stdlib/pull/1370 - Bug introduced

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`) - tested on opensource puppetserver