### PR TITLE
Use the read method on the return of open_url to actually get the con…

### DIFF
--- a/lib/puppet/parser/functions/loadjson.rb
+++ b/lib/puppet/parser/functions/loadjson.rb
@@ -44,7 +44,7 @@ module Puppet::Parser::Functions
           url = args[0]
         end
         begin
-          contents = OpenURI.open_uri(url, http_options)
+          contents = OpenURI.open_uri(url, http_options).read
         rescue OpenURI::HTTPError => e
           res = e.io
           warning("Can't load '#{url}' HTTP Error Code: '#{res.status[0]}'")

--- a/spec/functions/loadjson_spec.rb
+++ b/spec/functions/loadjson_spec.rb
@@ -55,7 +55,6 @@ describe 'loadjson' do
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with(filename).and_return(true).once
         allow(File).to receive(:read).with(filename).and_return(json).once
-        allow(File).to receive(:read).with(filename).and_return(json).once
         if Puppet::PUPPETVERSION[0].to_i < 8
           allow(PSON).to receive(:load).with(json).and_return(data).once
         else
@@ -98,7 +97,7 @@ describe 'loadjson' do
       let(:json) { '{"key":"value", {"ķęŷ":"νậŀųề" }, {"キー":"値" }' }
 
       it {
-        expect(OpenURI).to receive(:open_uri).with(filename, {}).and_return(json)
+        expect(OpenURI).to receive(:open_uri).with(filename, {}).and_return(StringIO.new(json))
         if Puppet::PUPPETVERSION[0].to_i < 8
           expect(PSON).to receive(:load).with(json).and_return(data).once
         else
@@ -118,7 +117,7 @@ describe 'loadjson' do
       let(:json) { '{"key":"value", {"ķęŷ":"νậŀųề" }, {"キー":"値" }' }
 
       it {
-        expect(OpenURI).to receive(:open_uri).with(url_no_auth, basic_auth).and_return(json)
+        expect(OpenURI).to receive(:open_uri).with(url_no_auth, basic_auth).and_return(StringIO.new(json))
         if Puppet::PUPPETVERSION[0].to_i < 8
           expect(PSON).to receive(:load).with(json).and_return(data).once
         else
@@ -138,7 +137,7 @@ describe 'loadjson' do
       let(:json) { '{"key":"value", {"ķęŷ":"νậŀųề" }, {"キー":"値" }' }
 
       it {
-        expect(OpenURI).to receive(:open_uri).with(url_no_auth, basic_auth).and_return(json)
+        expect(OpenURI).to receive(:open_uri).with(url_no_auth, basic_auth).and_return(StringIO.new(json))
         if Puppet::PUPPETVERSION[0].to_i < 8
           expect(PSON).to receive(:load).with(json).and_return(data).once
         else
@@ -155,7 +154,7 @@ describe 'loadjson' do
       let(:json) { ',;{"key":"value"}' }
 
       it {
-        expect(OpenURI).to receive(:open_uri).with(filename, {}).and_return(json)
+        expect(OpenURI).to receive(:open_uri).with(filename, {}).and_return(StringIO.new(json))
         if Puppet::PUPPETVERSION[0].to_i < 8
           expect(PSON).to receive(:load).with(json).once.and_raise StandardError, 'Something terrible have happened!'
         else


### PR DESCRIPTION


## Summary
Use the read method on the return of open_url to actually get the content. Otherwise the following error is returned by puppetserver:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call,
 no implicit conversion of Tempfile into String (file: <file_path>, line: 8, column: 15) on node <node_name>
```