### PR TITLE
Allow usage of file templates with stdlib::manage

### DIFF
--- a/manifests/manage.pp
+++ b/manifests/manage.pp
@@ -56,7 +56,7 @@ class stdlib::manage (
       case $type {
         'file': {
           if 'template' in $attributes and 'content' in $attributes {
-            fail("You can not set content and template fir file ${title}")
+            fail("You can not set 'content' and 'template' for file ${title}")
           }
           if 'template' in $attributes {
             $content = epp($attributes['template'])

--- a/manifests/manage.pp
+++ b/manifests/manage.pp
@@ -10,28 +10,38 @@
 #
 # @param create_resources
 #   A hash of resources to create
-#   NOTE: functions, such as `template` or `epp`, are not evaluated.
+#   NOTE: functions, such as `template` or `epp`, are not directly evaluated
+#         but processed as Puppet code based on epp and erb hash keys.
 #
 # @example
 #   class { 'stdlib::manage':
-#       'create_resources'      => {
-#         'file'                => {
-#           '/etc/motd.d/hello' => {
-#             'content'         => 'I say Hi',
-#             'notify'          => 'Service[sshd]',
-#           },
-#           '/etc/motd'         => {
-#             'ensure'          => 'file',
-#             'template'        => 'profile/motd.epp',
+#     'create_resources'      => {
+#       'file'                => {
+#         '/etc/motd.d/hello' => {
+#           'content'         => 'I say Hi',
+#           'notify'          => 'Service[sshd]',
+#         },
+#         '/etc/motd'         => {
+#           'ensure'          => 'file',
+#           'epp'             => {
+#             'template'      => 'profile/motd.epp',
 #           }
 #         },
-#         'package'             => {
-#           'example'           => {
-#             'ensure'          => 'installed',
-#             'subscribe'       => ['Service[sshd]', 'Exec[something]'],
+#         '/etc/information'  => {
+#           'ensure'          => 'file',
+#           'erb'             => {
+#             'template'      => 'profile/informaiton.erb',
 #           }
 #         }
+#       },
+#       'package'             => {
+#         'example'           => {
+#           'ensure'          => 'installed',
+#           'subscribe'       => ['Service[sshd]', 'Exec[something]'],
+#         }
 #       }
+#     }
+#   }
 #
 # @example
 #   stdlib::manage::create_resources:

--- a/spec/classes/manage_spec.rb
+++ b/spec/classes/manage_spec.rb
@@ -39,7 +39,8 @@ describe 'stdlib::manage' do
         }
       }
     end
-    Puppet::Functions.create_function(:'epp') do
+
+    Puppet::Functions.create_function(:epp) do
       return 'I am a template'
     end
 

--- a/spec/classes/manage_spec.rb
+++ b/spec/classes/manage_spec.rb
@@ -25,6 +25,9 @@ describe 'stdlib::manage' do
             '/etc/motd.d/hello' => {
               'content' => 'I say Hi',
               'notify' => 'Service[sshd]'
+            },
+            '/etc/motd' => {
+              'template' => 'stdlib/manage_spec.epp'
             }
           },
           'package' => {
@@ -39,6 +42,7 @@ describe 'stdlib::manage' do
 
     it { is_expected.to compile }
     it { is_expected.to contain_file('/etc/motd.d/hello').with_content('I say Hi').with_notify('Service[sshd]') }
+    it { is_expected.to contain_file('/etc/motd').with_content(%r{I am a template}) }
     it { is_expected.to contain_package('example').with_ensure('installed').that_subscribes_to(['Service[sshd]', 'File[/etc/motd.d]']) }
   end
 end

--- a/spec/classes/manage_spec.rb
+++ b/spec/classes/manage_spec.rb
@@ -39,6 +39,9 @@ describe 'stdlib::manage' do
         }
       }
     end
+    Puppet::Functions.create_function(:'epp') do
+      return 'I am a template'
+    end
 
     it { is_expected.to compile }
     it { is_expected.to contain_file('/etc/motd.d/hello').with_content('I say Hi').with_notify('Service[sshd]') }

--- a/spec/classes/manage_spec.rb
+++ b/spec/classes/manage_spec.rb
@@ -27,7 +27,14 @@ describe 'stdlib::manage' do
               'notify' => 'Service[sshd]'
             },
             '/etc/motd' => {
-              'template' => 'stdlib/manage_spec.epp'
+              'epp' => {
+                'template' => 'profile/motd.epp'
+              }
+            },
+            '/etc/information' => {
+              'erb' => {
+                'template' => 'profile/information.erb'
+              }
             }
           },
           'package' => {
@@ -41,12 +48,16 @@ describe 'stdlib::manage' do
     end
 
     Puppet::Functions.create_function(:epp) do
-      return 'I am a template'
+      return 'I am an epp template'
+    end
+    Puppet::Functions.create_function(:template) do
+      return 'I am an erb template'
     end
 
     it { is_expected.to compile }
     it { is_expected.to contain_file('/etc/motd.d/hello').with_content('I say Hi').with_notify('Service[sshd]') }
-    it { is_expected.to contain_file('/etc/motd').with_content(%r{I am a template}) }
+    it { is_expected.to contain_file('/etc/motd').with_content(%r{I am an epp template}) }
+    it { is_expected.to contain_file('/etc/information').with_content(%r{I am an erb template}) }
     it { is_expected.to contain_package('example').with_ensure('installed').that_subscribes_to(['Service[sshd]', 'File[/etc/motd.d]']) }
   end
 end

--- a/templates/manage_spec.epp
+++ b/templates/manage_spec.epp
@@ -1,0 +1,1 @@
+I am a template

--- a/templates/manage_spec.epp
+++ b/templates/manage_spec.epp
@@ -1,1 +1,0 @@
-I am a template


### PR DESCRIPTION
This one only covers epp templates.

## Summary
Users want to make use of stdlib::manage also with templates.
As hiera can not evaluate functions, we must implement this as Puppet code.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)