### PR TITLE
Parse deferred templates non deferred first

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3173,18 +3173,38 @@ Type: Puppet Language
 This function returns either a rendered template or a deferred function to render at runtime.
 If any of the values in the variables hash are deferred, then the template will be deferred.
 
-Note: this function requires all parameters to be explicitly passed in. It cannot expect to
-use facts, class variables, and other variables in scope. This is because when deferred, we
-have to explicitly pass the entire scope to the client.
+Note: In the case where at least some of the values are deferred and preparse is `true` the template
+      is parsed twice:
+ The first parse will evalute any parameters in the template that do not have deferred values.
+ The second parse will run deferred and evaluate only the remaining deferred parameters. Consequently
+ any parameters to be deferred must accept a String[1] in original template so as to accept the value
+ "<%= $variable_with_deferred_value %>" on the first parse.
 
-#### `stdlib::deferrable_epp(String $template, Hash $variables)`
+ @param template template location - identical to epp function template location.
+ @param variables parameters to pass into the template - some of which may have deferred values.
+ @param preparse
+     If `true` the epp template will be parsed twice, once normally and then a second time deferred.
+     It may be nescessary to set `preparse` `false` when deferred values are somethig other than
+     a string
+
+#### `stdlib::deferrable_epp(String $template, Hash $variables, Boolean $preparse = true)`
 
 This function returns either a rendered template or a deferred function to render at runtime.
 If any of the values in the variables hash are deferred, then the template will be deferred.
 
-Note: this function requires all parameters to be explicitly passed in. It cannot expect to
-use facts, class variables, and other variables in scope. This is because when deferred, we
-have to explicitly pass the entire scope to the client.
+Note: In the case where at least some of the values are deferred and preparse is `true` the template
+      is parsed twice:
+ The first parse will evalute any parameters in the template that do not have deferred values.
+ The second parse will run deferred and evaluate only the remaining deferred parameters. Consequently
+ any parameters to be deferred must accept a String[1] in original template so as to accept the value
+ "<%= $variable_with_deferred_value %>" on the first parse.
+
+ @param template template location - identical to epp function template location.
+ @param variables parameters to pass into the template - some of which may have deferred values.
+ @param preparse
+     If `true` the epp template will be parsed twice, once normally and then a second time deferred.
+     It may be nescessary to set `preparse` `false` when deferred values are somethig other than
+     a string
 
 Returns: `Variant[String, Sensitive[String], Deferred]`
 
@@ -3197,6 +3217,12 @@ Data type: `String`
 ##### `variables`
 
 Data type: `Hash`
+
+
+
+##### `preparse`
+
+Data type: `Boolean`
 
 
 

--- a/functions/deferrable_epp.pp
+++ b/functions/deferrable_epp.pp
@@ -1,15 +1,39 @@
 # This function returns either a rendered template or a deferred function to render at runtime.
 # If any of the values in the variables hash are deferred, then the template will be deferred.
 #
-# Note: this function requires all parameters to be explicitly passed in. It cannot expect to
-# use facts, class variables, and other variables in scope. This is because when deferred, we
-# have to explicitly pass the entire scope to the client.
+# Note: In the case where at least some of the values are deferred and preparse is `true` the template
+#       is parsed twice:
+#  The first parse will evalute any parameters in the template that do not have deferred values.
+#  The second parse will run deferred and evaluate only the remaining deferred parameters. Consequently
+#  any parameters to be deferred must accept a String[1] in original template so as to accept the value
+#  "<%= $variable_with_deferred_value %>" on the first parse.
 #
-function stdlib::deferrable_epp(String $template, Hash $variables) >> Variant[String, Sensitive[String], Deferred] {
+#  @param template template location - identical to epp function template location.
+#  @param variables parameters to pass into the template - some of which may have deferred values.
+#  @param preparse
+#      If `true` the epp template will be parsed twice, once normally and then a second time deferred.
+#      It may be nescessary to set `preparse` `false` when deferred values are somethig other than
+#      a string
+#
+function stdlib::deferrable_epp(String $template, Hash $variables, Boolean $preparse = true) >> Variant[String, Sensitive[String], Deferred] {
   if $variables.stdlib::nested_values.any |$value| { $value.is_a(Deferred) } {
+    if $preparse {
+      $_variables_escaped = $variables.map | $_var , $_value | {
+        if $_value.is_a(Deferred) {
+          { $_var => "<%= \$${_var} %>" }
+        } else {
+          { $_var => $_value }
+        }
+      }.reduce | $_memo, $_kv | { $_memo + $_kv }
+
+      $_template = inline_epp(find_template($template).file,$_variables_escaped)
+    } else {
+      $_template = find_template($template).file
+    }
+
     Deferred(
       'inline_epp',
-      [find_template($template).file, $variables],
+      [$_template, $variables],
     )
   }
   else {

--- a/spec/acceptance/stdlib_deferrable_epp_spec.rb
+++ b/spec/acceptance/stdlib_deferrable_epp_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'stdlib::deferable_epp function' do
+  let(:testfile) { (os[:family] == 'windows') ? 'C:\\test.epp' : '/tmp/test.epp' }
+
+  before(:all) do
+    apply_manifest(<<-MANIFEST)
+      $_epp = @(EPP)
+      <%- |
+      Stdlib::Port $port,
+      String[1] $password,
+      | -%>
+      port=<%= $port %>
+      password=<%= $password %>"
+      | EPP
+      $_testfile = $facts['os']['family'] ? {
+        'windows' => 'C:\\test.epp',
+        default => '/tmp/test.epp',
+      }
+
+      file{ $_testfile:
+        ensure  => file,
+        content => $_epp,
+      }
+    MANIFEST
+  end
+
+  before(:each) do
+    rm_testfile = <<-MANIFEST
+      $_testfile = $facts['os']['family'] ? {
+        'windows' => 'C:\\test.epp',
+        default => '/tmp/test.epp',
+      }
+      file { "${_testfile}.rendered":
+        ensure  => absent,
+      }
+    MANIFEST
+    apply_manifest(rm_testfile)
+  end
+
+  context 'with no deferred values' do
+    let(:pp) do
+      <<-MANIFEST
+        $_testfile = $facts['os']['family'] ? {
+          'windows' => 'C:\\test.epp',
+          default => '/tmp/test.epp',
+        }
+
+        file{ "${_testfile}.rendered":
+          ensure  => file,
+          content => stdlib::deferrable_epp(
+            $_testfile,
+            {'port' => 1234, 'password' => 'top_secret'}
+          ),
+        }
+      MANIFEST
+    end
+
+    it 'applies manifest, generates file' do
+      idempotent_apply(pp)
+      expect(file("#{testfile}.rendered")).to be_file
+      expect(file("#{testfile}.rendered").content).to match(%r{port=1234})
+      expect(file("#{testfile}.rendered").content).to match(%r{password=top_secret})
+    end
+  end
+
+  context 'with deferred values' do
+    let(:pp) do
+      <<-MANIFEST
+        $_testfile = $facts['os']['family'] ? {
+          'windows' => 'C:\\test.epp',
+          default => '/tmp/test.epp',
+        }
+
+        file{ "${_testfile}.rendered":
+          ensure  => file,
+          content => stdlib::deferrable_epp(
+            $_testfile,
+            {'port' => 1234, 'password' => Deferred('inline_epp',['<%= $secret_password %>',{'secret_password' => 'so_secret'}])},
+          ),
+        }
+      MANIFEST
+    end
+
+    it 'applies manifest, generates file' do
+      idempotent_apply(pp)
+      expect(file("#{testfile}.rendered")).to be_file
+      expect(file("#{testfile}.rendered").content).to match(%r{port=1234})
+      expect(file("#{testfile}.rendered").content).to match(%r{password=so_secret})
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Parse templates with deferred values twice so complex data types can be used.

## Additional Context

Currently it is not possible to have a template `file.epp`

```puppet
<%- |
Stdlib::Port $port,
String[1] $password,
| %>
port <%= $port %>
password <%= $password %>

```

and run

```puppet
file{'/tmp/junk':
  content => stdlib::deferrable_epp(
      'module/file.epp',
      { 'port' => '1234', pass => Deferred('secrets::get',['mysecret'])}
   ),
}
```
since the deferred template substitution  will fail:
```
Error: Failed to apply catalog: Evaluation Error: Resource type not found: Stdlib::Port (file: inlined-epp-text, line: 2, column: 3)
```
due to `Stdlib::Port` not being available on the agent node.

This change now parses the EPP twice. The first non deferred parse will reduce the template to:

```puppet
port = 1234
password <%= $password %>
```

and this simpler template will be parsed in deferred mode.

Note the original template type for password must accept the intermediate generated value of `<%= $password %>` which is typically case for a secret password.  If the deferred value is more complicated then the argument `preparse` can be
set `false` to not attempt the epp substitution of non deferred values.

Provide a detailed description of all the changes present in this pull request.

## Related Issues (if any)
Fixes https://github.com/voxpupuli/puppet-redis/issues/513

## Checklist
- [X] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [X] Manually verified. Verified on a separate master and agent with puppet-redis module as per bug. 