### PR TITLE
Revert "pdksync - (ITHELP-87329) - replace pull_request_target with pull_request"

### DIFF
--- a/.github/workflows/labeller.yml
+++ b/.github/workflows/labeller.yml
@@ -6,7 +6,7 @@ on:
       - opened
       - labeled
       - unlabeled
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - labeled


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-stdlib#1429

the labeler needs this event and uses it safely