### PR TITLE
Change Stdlib::Host to no longer accept subnets

### DIFF
--- a/spec/type_aliases/host_spec.rb
+++ b/spec/type_aliases/host_spec.rb
@@ -35,6 +35,8 @@ describe 'Stdlib::Host' do
         'bob@example.com',
         '%.example.com',
         '2001:0d8',
+        '192.0.2.0/24',
+        '2001:db8::/32',
       ].each do |value|
         describe value.inspect do
           it { is_expected.not_to allow_value(value) }

--- a/types/host.pp
+++ b/types/host.pp
@@ -1,2 +1,2 @@
 # @summary Validate a host (FQDN or IP address)
-type Stdlib::Host = Variant[Stdlib::Fqdn, Stdlib::IP::Address]
+type Stdlib::Host = Variant[Stdlib::Fqdn, Stdlib::IP::Address::Nosubnet]


### PR DESCRIPTION
A host should be a specific IP and not allow a subnet.