### PR TITLE
Add yescrypt support for pw_hash function

### DIFF
--- a/lib/puppet/parser/functions/pw_hash.rb
+++ b/lib/puppet/parser/functions/pw_hash.rb
@@ -24,6 +24,7 @@ Puppet::Parser::Functions.newfunction(:pw_hash, type: :rvalue, arity: 3, doc: <<
   |bcrypt-a |2a    |bug compatible       |
   |bcrypt-x |2x    |bug compatible       |
   |bcrypt-y |2y    |historic alias for 2b|
+  |yescrypt |y     |                     |
 
   The third argument to this function is the salt to use. For bcrypt-type hashes,
   the first two characters of the salt represent a strength parameter, with a value
@@ -54,7 +55,8 @@ DOC
     'bcrypt' => { prefix: '2b', salt: %r{^(0[4-9]|[12][0-9]|3[01])\$[./A-Za-z0-9]{22}} },
     'bcrypt-a' => { prefix: '2a', salt: %r{^(0[4-9]|[12][0-9]|3[01])\$[./A-Za-z0-9]{22}} },
     'bcrypt-x' => { prefix: '2x', salt: %r{^(0[4-9]|[12][0-9]|3[01])\$[./A-Za-z0-9]{22}} },
-    'bcrypt-y' => { prefix: '2y', salt: %r{^(0[4-9]|[12][0-9]|3[01])\$[./A-Za-z0-9]{22}} }
+    'bcrypt-y' => { prefix: '2y', salt: %r{^(0[4-9]|[12][0-9]|3[01])\$[./A-Za-z0-9]{22}} },
+    'yescrypt' => { prefix: 'y', salt: %r{^[./A-Za-z0-9]+\$[./A-Za-z0-9]{0,86}} }
   }
 
   raise ArgumentError, 'pw_hash(): first argument must be a string' unless args[0].is_a?(String) || args[0].nil?
@@ -76,9 +78,11 @@ DOC
 
   # handle weak implementations of String#crypt
   # dup the string to get rid of frozen status for testing
-  if RUBY_PLATFORM == 'java' && !args[1].downcase.start_with?('bcrypt')
+  if RUBY_PLATFORM == 'java' && !['bcrypt', 'bcrypt-a', 'bcrypt-x', 'bcrypt-y', 'yescrypt'].include?(args[1].downcase)
     # puppetserver bundles Apache Commons Codec
     org.apache.commons.codec.digest.Crypt.crypt(password.to_java_bytes, salt)
+  elsif args[1].casecmp('yescrypt').zero? && (+'test').crypt('$y$j9T$') == '$y$j9T$$6tN6tt5mmPHxQskcf5Oi7Sb.1nKYbi5cOZgTiMq7Qw4'
+    password.crypt(salt)
   elsif (+'test').crypt('$1$1') == '$1$1$Bp8CU9Oujr9SSEw53WV6G.'
     password.crypt(salt)
   else

--- a/spec/functions/pw_hash_spec.rb
+++ b/spec/functions/pw_hash_spec.rb
@@ -111,4 +111,10 @@ describe 'pw_hash' do
       end
     end
   end
+
+  if 'test'.crypt('$y$j9T$') == '$y$j9T$$6tN6tt5mmPHxQskcf5Oi7Sb.1nKYbi5cOZgTiMq7Qw4'
+    describe 'on systems with yescrypt support' do
+      it { is_expected.to run.with_params('password', 'yescrypt', 'j9T$salt').and_return('$y$j9T$salt$Cw3H19laQT.rHIYMLvuoUzLb8st7PboO9rfxAylYPx9') }
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Add support for yescrypt hashing algorithm in the pw_hash function.

## Additional Context
The underlying OS must support `yescrypt`.  For exemple, it does not work on RockyLinux 8, because libxcrypt does not support it, but it does work in RockyLinux 9.

## Related Issues (if any)
#1445 

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)