### PR TITLE
Support `Sensitive` values in more functions

### DIFF
--- a/lib/puppet/functions/stdlib/to_json.rb
+++ b/lib/puppet/functions/stdlib/to_json.rb
@@ -19,6 +19,8 @@ Puppet::Functions.create_function(:'stdlib::to_json') do
   end
 
   def to_json(data)
-    data.to_json
+    call_function('stdlib::rewrap_sensitive_data', data) do |unwrapped_data|
+      unwrapped_data.to_json
+    end
   end
 end

--- a/lib/puppet/functions/stdlib/to_toml.rb
+++ b/lib/puppet/functions/stdlib/to_toml.rb
@@ -13,10 +13,12 @@ Puppet::Functions.create_function(:'stdlib::to_toml') do
   #     }
   dispatch :to_toml do
     required_param 'Hash', :data
-    return_type 'String'
+    return_type 'Variant[String, Sensitive[String]]'
   end
 
   def to_toml(data)
-    PuppetX::Stdlib::TomlDumper.new(data).toml_str
+    call_function('stdlib::rewrap_sensitive_data', data) do |unwrapped_data|
+      PuppetX::Stdlib::TomlDumper.new(unwrapped_data).toml_str
+    end
   end
 end

--- a/lib/puppet/functions/stdlib/to_yaml.rb
+++ b/lib/puppet/functions/stdlib/to_yaml.rb
@@ -27,6 +27,8 @@ Puppet::Functions.create_function(:'stdlib::to_yaml') do
   end
 
   def to_yaml(data, options = {})
-    data.to_yaml(options.transform_keys(&:to_sym))
+    call_function('stdlib::rewrap_sensitive_data', data) do |unwrapped_data|
+      unwrapped_data.to_yaml(options.transform_keys(&:to_sym))
+    end
   end
 end

--- a/spec/functions/to_json_spec.rb
+++ b/spec/functions/to_json_spec.rb
@@ -22,4 +22,8 @@ describe 'stdlib::to_json' do
   it { is_expected.to run.with_params('竹').and_return('"竹"') }
   it { is_expected.to run.with_params('Ü').and_return('"Ü"') }
   it { is_expected.to run.with_params('∇').and_return('"∇"') }
+
+  context 'with data containing sensitive' do
+    it { is_expected.to run.with_params('key' => sensitive('value')).and_return(sensitive('{"key":"value"}')) }
+  end
 end

--- a/spec/functions/to_toml_spec.rb
+++ b/spec/functions/to_toml_spec.rb
@@ -26,4 +26,8 @@ describe 'stdlib::to_toml' do
     it { is_expected.to run.with_params(foo: ['bar', 'baz']).and_return("foo = [\"bar\", \"baz\"]\n") }
     it { is_expected.to run.with_params(foo: [{ bar: {}, baz: {} }]).and_return("[[foo]]\n[foo.bar]\n[foo.baz]\n") }
   end
+
+  context 'with data containing sensitive' do
+    it { is_expected.to run.with_params('key' => sensitive('value')).and_return(sensitive("key = \"value\"\n")) }
+  end
 end

--- a/spec/functions/to_yaml_spec.rb
+++ b/spec/functions/to_yaml_spec.rb
@@ -22,4 +22,8 @@ describe 'stdlib::to_yaml' do
   it { is_expected.to run.with_params('∇').and_return("--- \"∇\"\n") }
 
   it { is_expected.to run.with_params({ 'foo' => { 'bar' => true, 'baz' => false } }, 'indentation' => 4).and_return("---\nfoo:\n    bar: true\n    baz: false\n") }
+
+  context 'with data containing sensitive' do
+    it { is_expected.to run.with_params('key' => sensitive('value')).and_return(sensitive("---\nkey: value\n")) }
+  end
 end


### PR DESCRIPTION
Support for Sensitive values inside data passed to `to_json_pretty` was added in e7fa6751e3a256772b856d138bbd427bcffbbd8b

This commit uses the same `rewrap_sensitive_data` function to add support for nested Sensitive data to `to_json`, `to_yaml` and `to_toml`.