### PR TITLE
Add option to provide inline epp templates

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -280,6 +280,13 @@ class { 'stdlib::manage':
           'template'      => 'profile/motd.epp',
         }
       },
+      '/etc/inline'       => {
+        'ensure'          => 'file',
+        'epp'             => {
+          'inline'        => 'Hello <%= $name %>',
+          'context'       => { 'name' => 'world' },
+        }
+      },
       '/etc/information'  => {
         'ensure'          => 'file',
         'erb'             => {
@@ -310,6 +317,12 @@ stdlib::manage::create_resources:
       epp:
         template: 'profile/motd.epp'
         context: {}
+    '/etc/inline':
+      ensure: 'file'
+      epp:
+        inline: 'Hello <%= $name %>'
+        context:
+          name: world
     '/etc/information':
       ensure: 'file'
       erb:

--- a/manifests/manage.pp
+++ b/manifests/manage.pp
@@ -27,6 +27,13 @@
 #             'template'      => 'profile/motd.epp',
 #           }
 #         },
+#         '/etc/inline'       => {
+#           'ensure'          => 'file',
+#           'epp'             => {
+#             'inline'        => 'Hello <%= $name %>',
+#             'context'       => { 'name' => 'world' },
+#           }
+#         },
 #         '/etc/information'  => {
 #           'ensure'          => 'file',
 #           'erb'             => {
@@ -54,6 +61,12 @@
 #         epp:
 #           template: 'profile/motd.epp'
 #           context: {}
+#       '/etc/inline':
+#         ensure: 'file'
+#         epp:
+#           inline: 'Hello <%= $name %>'
+#           context:
+#             name: world
 #       '/etc/information':
 #         ensure: 'file'
 #         erb:
@@ -84,14 +97,23 @@ class stdlib::manage (
           }
 
           if 'epp' in $attributes {
+            if 'template' in $attributes['epp'] and 'inline' in $attributes['epp'] {
+              fail("You can not set both 'template' and 'inline' for epp for ${type} ${title}")
+            }
             if 'template' in $attributes['epp'] {
               if 'context' in $attributes['epp'] {
                 $content = epp($attributes['epp']['template'], $attributes['epp']['context'])
               } else {
                 $content = epp($attributes['epp']['template'])
               }
+            } elsif 'inline' in $attributes['epp'] {
+              if 'context' in $attributes['epp'] {
+                $content = inline_epp($attributes['epp']['inline'], $attributes['epp']['context'])
+              } else {
+                $content = inline_epp($attributes['epp']['inline'])
+              }
             } else {
-              fail("No template configured for epp for ${type} ${title}")
+              fail("No template or inline configured for epp for ${type} ${title}")
             }
           } elsif 'erb' in $attributes {
             if 'template' in $attributes['erb'] {

--- a/spec/classes/manage_spec.rb
+++ b/spec/classes/manage_spec.rb
@@ -18,6 +18,7 @@ describe 'stdlib::manage' do
         service { 'sshd' : }
 
         function epp(*$args) { 'I am an epp template' }
+        function inline_epp(*$args) { 'I am an inline epp template' }
         function template(*$args) { 'I am an erb template' }
       PRECOND
     end
@@ -32,6 +33,17 @@ describe 'stdlib::manage' do
             '/etc/motd' => {
               'epp' => {
                 'template' => 'profile/motd.epp'
+              }
+            },
+            '/etc/inline' => {
+              'epp' => {
+                'inline' => 'Hello <%= $name %>',
+                'context' => { 'name' => 'world' }
+              }
+            },
+            '/etc/inline_nocontext' => {
+              'epp' => {
+                'inline' => 'Hello world'
               }
             },
             '/etc/information' => {
@@ -61,6 +73,12 @@ describe 'stdlib::manage' do
               'erb' => {
                 'template' => 'profile/information.erb'
               },
+            },
+            'eppcontent_inline' => {
+              'target' => '/tmp/filename',
+              'epp' => {
+                'inline' => 'inline fragment content'
+              },
             }
           },
           'package' => {
@@ -76,11 +94,286 @@ describe 'stdlib::manage' do
     it { is_expected.to compile }
     it { is_expected.to contain_file('/etc/motd.d/hello').with_content('I say Hi').with_notify('Service[sshd]') }
     it { is_expected.to contain_file('/etc/motd').with_content(%r{I am an epp template}) }
+    it { is_expected.to contain_file('/etc/inline').with_content(%r{I am an inline epp template}) }
+    it { is_expected.to contain_file('/etc/inline_nocontext').with_content(%r{I am an inline epp template}) }
     it { is_expected.to contain_file('/etc/information').with_content(%r{I am an erb template}) }
     it { is_expected.to contain_concat('/tmp/filename') }
     it { is_expected.to contain_concat__fragment('rawcontent').with_content('test content') }
     it { is_expected.to contain_concat__fragment('eppcontent').with_content(%r{I am an epp template}) }
     it { is_expected.to contain_concat__fragment('erbcontent').with_content(%r{I am an erb template}) }
+    it { is_expected.to contain_concat__fragment('eppcontent_inline').with_content(%r{I am an inline epp template}) }
     it { is_expected.to contain_package('example').with_ensure('installed').that_subscribes_to(['Service[sshd]', 'File[/etc/motd.d]']) }
+  end
+
+  describe 'with file epp and content' do
+    let :pre_condition do
+      <<-PRECOND
+        function epp(*$args) { 'I am an epp template' }
+      PRECOND
+    end
+    let :params do
+      {
+        'create_resources' => {
+          'file' => {
+            '/etc/test' => {
+              'epp' => {
+                'template' => 'profile/test.epp'
+              },
+              'content' => 'conflicting content'
+            }
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{You can not set 'epp' and 'content'}) }
+  end
+
+  describe 'with file erb and content' do
+    let :pre_condition do
+      <<-PRECOND
+        function template(*$args) { 'I am an erb template' }
+      PRECOND
+    end
+    let :params do
+      {
+        'create_resources' => {
+          'file' => {
+            '/etc/test' => {
+              'erb' => {
+                'template' => 'profile/test.erb'
+              },
+              'content' => 'conflicting content'
+            }
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{You can not set 'erb' and 'content'}) }
+  end
+
+  describe 'with file erb and epp' do
+    let :pre_condition do
+      <<-PRECOND
+        function epp(*$args) { 'I am an epp template' }
+        function template(*$args) { 'I am an erb template' }
+      PRECOND
+    end
+    let :params do
+      {
+        'create_resources' => {
+          'file' => {
+            '/etc/test' => {
+              'epp' => {
+                'template' => 'profile/test.epp'
+              },
+              'erb' => {
+                'template' => 'profile/test.erb'
+              }
+            }
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{You can not set 'erb' and 'epp'}) }
+  end
+
+  describe 'with file epp template and inline' do
+    let :pre_condition do
+      <<-PRECOND
+        function epp(*$args) { 'I am an epp template' }
+      PRECOND
+    end
+    let :params do
+      {
+        'create_resources' => {
+          'file' => {
+            '/etc/test' => {
+              'epp' => {
+                'template' => 'profile/test.epp',
+                'inline' => 'inline content'
+              }
+            }
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{You can not set both 'template' and 'inline'}) }
+  end
+
+  describe 'with file epp neither template nor inline' do
+    let :params do
+      {
+        'create_resources' => {
+          'file' => {
+            '/etc/test' => {
+              'epp' => {
+                'context' => {}
+              }
+            }
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{No template or inline configured}) }
+  end
+
+  describe 'with file erb but no template' do
+    let :params do
+      {
+        'create_resources' => {
+          'file' => {
+            '/etc/test' => {
+              'erb' => {}
+            }
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{No template configured for erb}) }
+  end
+
+  describe 'with concat::fragment epp and content' do
+    let :pre_condition do
+      <<-PRECOND
+        function epp(*$args) { 'I am an epp template' }
+      PRECOND
+    end
+    let :params do
+      {
+        'create_resources' => {
+          'concat::fragment' => {
+            'test' => {
+              'target' => '/tmp/file',
+              'epp' => {
+                'template' => 'profile/test.epp'
+              },
+              'content' => 'conflicting content'
+            }
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{You can not set 'epp' and 'content'}) }
+  end
+
+  describe 'with concat::fragment erb and content' do
+    let :pre_condition do
+      <<-PRECOND
+        function template(*$args) { 'I am an erb template' }
+      PRECOND
+    end
+    let :params do
+      {
+        'create_resources' => {
+          'concat::fragment' => {
+            'test' => {
+              'target' => '/tmp/file',
+              'erb' => {
+                'template' => 'profile/test.erb'
+              },
+              'content' => 'conflicting content'
+            }
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{You can not set 'erb' and 'content'}) }
+  end
+
+  describe 'with concat::fragment erb and epp' do
+    let :pre_condition do
+      <<-PRECOND
+        function epp(*$args) { 'I am an epp template' }
+        function template(*$args) { 'I am an erb template' }
+      PRECOND
+    end
+    let :params do
+      {
+        'create_resources' => {
+          'concat::fragment' => {
+            'test' => {
+              'target' => '/tmp/file',
+              'epp' => {
+                'template' => 'profile/test.epp'
+              },
+              'erb' => {
+                'template' => 'profile/test.erb'
+              }
+            }
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{You can not set 'erb' and 'epp'}) }
+  end
+
+  describe 'with concat::fragment epp template and inline' do
+    let :pre_condition do
+      <<-PRECOND
+        function epp(*$args) { 'I am an epp template' }
+      PRECOND
+    end
+    let :params do
+      {
+        'create_resources' => {
+          'concat::fragment' => {
+            'test' => {
+              'target' => '/tmp/file',
+              'epp' => {
+                'template' => 'profile/test.epp',
+                'inline' => 'inline content'
+              }
+            }
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{You can not set both 'template' and 'inline'}) }
+  end
+
+  describe 'with concat::fragment epp neither template nor inline' do
+    let :params do
+      {
+        'create_resources' => {
+          'concat::fragment' => {
+            'test' => {
+              'target' => '/tmp/file',
+              'epp' => {
+                'context' => {}
+              }
+            }
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{No template or inline configured}) }
+  end
+
+  describe 'with concat::fragment erb but no template' do
+    let :params do
+      {
+        'create_resources' => {
+          'concat::fragment' => {
+            'test' => {
+              'target' => '/tmp/file',
+              'erb' => {}
+            }
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{No template configured for erb}) }
   end
 end


### PR DESCRIPTION
## Summary
Provide a way to specify inline epp template.

Example use case:
I want to add a snippet like "`profiles: <%= $profiles.join(',') %>`". It feels a bit silly to build and deploy a separate template file when I just want such a simple template.

## Additional Context
Add any additional context about the problem here. 
- [x] Root cause and the steps to reproduce. (If applicable)
- [x] Thought process behind the implementation.

## Related Issues (if any)
None

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)