### PR TITLE
(MODULES-11822) Add missing Puppet 7 drop entry to v10.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-stdlib/compare/v9.7.0...v10.0.0)
 
+### Changed
+
+- (CAT-2395) Puppetcore upgrade - drop support for Puppet 7 [#1457](https://github.com/puppetlabs/puppetlabs-stdlib/pull/1457) ([LukasAud](https://github.com/LukasAud))
+
 ### Added
 
 - Support `Sensitive` values in more functions [#1463](https://github.com/puppetlabs/puppetlabs-stdlib/pull/1463) ([alexjfisher](https://github.com/alexjfisher))


### PR DESCRIPTION
## What

Adds the missing `### Changed` entry for the **Puppet 7 support drop** to the `v10.0.0` section of the CHANGELOG.

## Why

`v10.0.0` was a major bump driven entirely by [#1457](https://github.com/puppetlabs/puppetlabs-stdlib/pull/1457) (CAT-2395, Puppetcore upgrade) dropping Puppet 7 support — but that breaking change never appeared in the CHANGELOG. This was flagged on [MODULES-11822](https://perforce.atlassian.net/browse/MODULES-11822).

### Root cause

The changelog generator used in CI (`chelnak/gh-changelog`) excludes any PR labelled `maintenance` by default (`excluded_labels: [maintenance, dependencies]`). PR #1457 carried **both** `backwards-incompatible` **and** `maintenance`, so the exclusion took precedence and the entry was dropped entirely — even though `backwards-incompatible` maps to the `### Changed` section.

I checked every merged PR in the `v9.7.0..v10.0.0` range; #1457 is the only mislabelled one (the other `maintenance` PRs are correctly excluded).

### Fix

1. Removed the `maintenance` label from #1457 (keeping `backwards-incompatible`) so future regenerations are correct — the durable root-cause fix.
2. This PR adds the missing entry to the `v10.0.0` section to correct the historical record. (`gh changelog new` rebuilds the whole file, so once the label is fixed the same entry would be produced on the next regeneration.)

## Note

This is a **documentation-only** correction to `main`; it does not re-release `v10.0.0` (the Forge artifact is immutable and stays untouched). The corrected history will be carried to the Forge with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
