### PR TITLE
fix(stdlib::manage) parser fails `$type` resources

### DIFF
--- a/manifests/manage.pp
+++ b/manifests/manage.pp
@@ -104,10 +104,8 @@ class stdlib::manage (
           } else {
             $content = undef
           }
-          $type { $title:
-            *       => $attributes - 'erb' - 'epp' - 'content',
-            content => $content,
-          }
+          $merged_attributes = ($attributes - 'erb' - 'epp' - 'content') + { 'content' => $content }
+          create_resources($type, { $title => $merged_attributes })
         }
         default: {
           create_resources($type, { $title => $attributes })

--- a/spec/classes/manage_spec.rb
+++ b/spec/classes/manage_spec.rb
@@ -16,6 +16,9 @@ describe 'stdlib::manage' do
       <<-PRECOND
         file { '/etc/motd.d' : }
         service { 'sshd' : }
+
+        function epp(*$args) { 'I am an epp template' }
+        function template(*$args) { 'I am an erb template' }
       PRECOND
     end
     let :params do
@@ -68,13 +71,6 @@ describe 'stdlib::manage' do
           }
         }
       }
-    end
-
-    Puppet::Functions.create_function(:epp) do
-      return 'I am an epp template'
-    end
-    Puppet::Functions.create_function(:template) do
-      return 'I am an erb template'
     end
 
     it { is_expected.to compile }


### PR DESCRIPTION
## Summary
When the puppet parser is set to its strictest mode, `$type` is not converted to the actual type and instead produces a catalog error.

Eventually the strict parser will be required everywhere, so we should prepare for it.

`pdk test unit` works just fine. It appears to not require the strict parser.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
https://github.com/puppetlabs/puppetlabs-stdlib/commit/3cf1f1e5746b5eada25453ed1dd5fb89a6d2960f

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)