### PR TITLE
Issue #1478 Avoid validate_legacy deprecation failure on Puppet 8

### DIFF
--- a/lib/puppet/functions/validate_legacy.rb
+++ b/lib/puppet/functions/validate_legacy.rb
@@ -52,6 +52,7 @@ Puppet::Functions.create_function(:validate_legacy) do
   end
 
   def validate_legacy(_scope, target_type, _function_name, value, *_prev_args)
+    call_function('deprecation', 'validate_legacy', 'This method is deprecated, please use Puppet data types to validate parameters', false)
     if assert_type(target_type, value)
       # "Silently" passes
     else

--- a/lib/puppet/functions/validate_legacy.rb
+++ b/lib/puppet/functions/validate_legacy.rb
@@ -52,7 +52,6 @@ Puppet::Functions.create_function(:validate_legacy) do
   end
 
   def validate_legacy(_scope, target_type, _function_name, value, *_prev_args)
-    call_function('deprecation', 'validate_legacy', 'This method is deprecated, please use Puppet data types to validate parameters')
     if assert_type(target_type, value)
       # "Silently" passes
     else

--- a/spec/functions/validate_legacy_spec.rb
+++ b/spec/functions/validate_legacy_spec.rb
@@ -8,8 +8,8 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0
     it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
 
     describe 'when passing the type assertion' do
-      it 'passes without a deprecation warning' do
-        expect(subject.func).not_to receive(:call_function).with('deprecation', anything, anything)
+      it 'passes with a deprecation warning that does not honour strict mode' do
+        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated'), false).once
         expect(scope).not_to receive(:function_validate_foo)
         expect(Puppet).not_to receive(:notice)
         expect(subject).to run.with_params('Integer', 'validate_foo', 5)
@@ -18,7 +18,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0
 
     describe 'when failing the type assertion' do
       it 'fails with a helpful message' do
-        expect(subject.func).not_to receive(:call_function).with('deprecation', anything, anything)
+        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated'), false).once
         expect(scope).not_to receive(:function_validate_foo)
         expect(subject.func).to receive(:call_function).with('fail', 'validate_legacy(Integer, ...) expects an Integer value, got String').once
         expect(subject).to run.with_params('Integer', 'validate_foo', '5')
@@ -27,7 +27,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0
 
     describe 'when passing in undef' do
       it 'passes without failure' do
-        expect(subject.func).not_to receive(:call_function).with('deprecation', anything, anything)
+        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated'), false).once
         expect(scope).not_to receive(:function_validate_foo)
         expect(Puppet).not_to receive(:notice)
         expect(subject).to run.with_params('Optional[Integer]', 'validate_foo', :undef)
@@ -35,8 +35,8 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0
     end
 
     describe 'when passing in multiple arguments' do
-      it 'passes without a deprecation message' do
-        expect(subject.func).not_to receive(:call_function).with('deprecation', anything, anything)
+      it 'passes with a deprecation message that does not honour strict mode' do
+        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated'), false).once
         expect(scope).not_to receive(:function_validate_foo)
         expect(Puppet).not_to receive(:notice)
         expect(subject).to run.with_params('Optional[Integer]', 'validate_foo', :undef, 1, 'foo')

--- a/spec/functions/validate_legacy_spec.rb
+++ b/spec/functions/validate_legacy_spec.rb
@@ -8,8 +8,8 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0
     it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
 
     describe 'when passing the type assertion' do
-      it 'passes with a deprecation warning' do
-        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated')).once
+      it 'passes without a deprecation warning' do
+        expect(subject.func).not_to receive(:call_function).with('deprecation', anything, anything)
         expect(scope).not_to receive(:function_validate_foo)
         expect(Puppet).not_to receive(:notice)
         expect(subject).to run.with_params('Integer', 'validate_foo', 5)
@@ -18,7 +18,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0
 
     describe 'when failing the type assertion' do
       it 'fails with a helpful message' do
-        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated')).once
+        expect(subject.func).not_to receive(:call_function).with('deprecation', anything, anything)
         expect(scope).not_to receive(:function_validate_foo)
         expect(subject.func).to receive(:call_function).with('fail', 'validate_legacy(Integer, ...) expects an Integer value, got String').once
         expect(subject).to run.with_params('Integer', 'validate_foo', '5')
@@ -27,7 +27,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0
 
     describe 'when passing in undef' do
       it 'passes without failure' do
-        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated')).once
+        expect(subject.func).not_to receive(:call_function).with('deprecation', anything, anything)
         expect(scope).not_to receive(:function_validate_foo)
         expect(Puppet).not_to receive(:notice)
         expect(subject).to run.with_params('Optional[Integer]', 'validate_foo', :undef)
@@ -35,8 +35,8 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0
     end
 
     describe 'when passing in multiple arguments' do
-      it 'passes with a deprecation message' do
-        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated')).once
+      it 'passes without a deprecation message' do
+        expect(subject.func).not_to receive(:call_function).with('deprecation', anything, anything)
         expect(scope).not_to receive(:function_validate_foo)
         expect(Puppet).not_to receive(:notice)
         expect(subject).to run.with_params('Optional[Integer]', 'validate_foo', :undef, 1, 'foo')


### PR DESCRIPTION
## Summary

Fixes the deprecated `validate_legacy()` function so that it emits a deprecation warning, as intended, and no longer lets Puppet's global `strict` setting turn that warning into a catalog failure.

Note that the stdlib `deprecation` helper accepts an optional fourth argument named `use_strict_setting`. It defaults to `true`, which means the helper follows `Puppet.settings[:strict]`:

- `:warning` logs a warning
- `:error` raises an error
- `:off` suppresses the message

This PR changes the `validate_legacy()` call to pass `false` for that argument:

```ruby
call_function('deprecation', 'validate_legacy', 'This method is deprecated, please use Puppet data types to validate parameters', false)
```

With `use_strict_setting` set to `false`, `validate_legacy()` still calls the deprecation helper and still emits the warning, but the warning is always handled as a soft deprecation warning instead of being promoted to an error under strict mode.

That preserves the migration signal for module maintainers while avoiding a hard failure before `validate_legacy()` can perform its type assertion.

## Existing stdlib precedent

This matches the pattern already used by stdlib's generated unnamespaced compatibility shims. Those functions are deprecated, emit a deprecation warning, and then delegate to the namespaced replacement while passing `false` to `deprecation()` so the compatibility path remains usable under strict mode.

Existing examples include:

- [`merge`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/merge.rb#L12)
- [`ensure_packages`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/ensure_packages.rb#L10)
- [`batch_escape`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/batch_escape.rb#L11)
- [`fqdn_rand_string`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/fqdn_rand_string.rb#L11)
- [`fqdn_rotate`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/fqdn_rotate.rb#L11)
- [`has_interface_with`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/has_interface_with.rb#L11)
- [`has_ip_address`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/has_ip_address.rb#L11)
- [`has_ip_network`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/has_ip_network.rb#L11)
- [`os_version_gte`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/os_version_gte.rb#L11)
- [`parsehocon`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/parsehocon.rb#L11)
- [`powershell_escape`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/powershell_escape.rb#L11)
- [`seeded_rand`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/seeded_rand.rb#L11)
- [`seeded_rand_string`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/seeded_rand_string.rb#L11)
- [`shell_escape`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/shell_escape.rb#L11)
- [`to_json`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/to_json.rb#L11)
- [`to_json_pretty`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/to_json_pretty.rb#L11)
- [`to_python`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/to_python.rb#L11)
- [`to_ruby`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/to_ruby.rb#L11)
- [`to_toml`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/to_toml.rb#L11)
- [`to_yaml`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/to_yaml.rb#L11)
- [`type_of`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/type_of.rb#L11)
- [`validate_domain_name`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/validate_domain_name.rb#L11)
- [`validate_email_address`](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/validate_email_address.rb#L11)

The specs have also been updated to assert that `validate_legacy()` continues to call the deprecation helper with `use_strict_setting` set to `false`.

## Checklist

- [x] Spec tests.
- [ ] Acceptance tests.
- [x] Manually verified.
