### PR TITLE
Use Litmus public fallback for fork PR CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,7 @@ group :development, :release_prep do
   gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
+  gem "puppet_litmus", '~> 2.5',   require: false, platforms: [:ruby, :x64_mingw]
   gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',     require: false
 end


### PR DESCRIPTION
## Summary

Use `puppet_litmus ~> 2.5` for system tests.

The CI workflow keeps passing `flags: "--nightly"` to the shared acceptance workflow. This preserves the intended nightly Puppetcore coverage for trusted CI runs.

The failing fork PR path does not receive repository secrets, so `PUPPET_FORGE_TOKEN` is unavailable. With the previous Gemfile logic, that selected `puppet_litmus ~> 1.0`. That older `matrix_from_metadata_v3` path either rejects `--nightly` or still generates nightly Puppet collections by default, which breaks unauthenticated fork PR acceptance setup/runs.

Litmus 2.5+ has the behavior this workflow needs:

- it accepts `--nightly`
- when `PUPPET_FORGE_TOKEN` is present, it can use nightly Puppetcore collections
- when `PUPPET_FORGE_TOKEN` is absent, it falls back to the public Puppet collection instead of trying to use private nightly packages

## Assumption / Tradeoff

This PR assumes the maintained path for unauthenticated fork PRs is to use current Litmus public fallback behavior rather than keeping fork PRs pinned to Litmus 1.x.

That preserves the existing workflow intent more closely than conditionally removing `--nightly` from fork PRs: trusted runs can still request nightly Puppetcore packages, while fork PRs can complete with public packages when secrets are unavailable.

## Verification

- `ruby -c Gemfile`
- parsed `.github/workflows/ci.yml` with Ruby YAML
- `git diff --check`

Closes #1480
