### PR TITLE
Drop EOL operating systems from operatingsystem_support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
@@ -22,34 +21,18 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8",
         "9"
-      ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
       ]
     },
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "12",
         "15"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11",
         "12"
       ]
@@ -57,7 +40,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
         "22.04",
         "24.04"


### PR DESCRIPTION
## Summary

Drops EOL platforms from `metadata.json`'s `operatingsystem_support` that current/upcoming Puppet releases don't ship agents for:

- RedHat 7, CentOS 7, OracleLinux 7, Scientific 7 (EL7 family)
- CentOS 8
- SLES 12
- Debian 10
- Ubuntu 18.04

Split out from the Puppet 9 support work in #1482 so the OS-support cleanup can be reviewed and merged independently of the Puppet 9 enablement changes.

## Testing

- `bundle exec metadata-json-lint metadata.json` clean.
- `bundle exec rspec spec/classes/manage_spec.rb` passes; `on_supported_os`-driven specs correctly reflect the trimmed OS matrix with no manual spec changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)