### PR TITLE
Issue #1478 Avoid validate_legacy deprecation failure on Puppet 8

### DIFF
--- a/lib/puppet/functions/validate_legacy.rb
+++ b/lib/puppet/functions/validate_legacy.rb
@@ -52,7 +52,7 @@ Puppet::Functions.create_function(:validate_legacy) do
   end
 
   def validate_legacy(_scope, target_type, _function_name, value, *_prev_args)
-    call_function('deprecation', 'validate_legacy', 'This method is deprecated, please use Puppet data types to validate parameters')
+    call_function('deprecation', 'validate_legacy', 'This method is deprecated, please use Puppet data types to validate parameters', false)
     if assert_type(target_type, value)
       # "Silently" passes
     else

--- a/spec/functions/validate_legacy_spec.rb
+++ b/spec/functions/validate_legacy_spec.rb
@@ -8,8 +8,8 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0
     it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
 
     describe 'when passing the type assertion' do
-      it 'passes with a deprecation warning' do
-        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated')).once
+      it 'passes with a deprecation warning that does not honour strict mode' do
+        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated'), false).once
         expect(scope).not_to receive(:function_validate_foo)
         expect(Puppet).not_to receive(:notice)
         expect(subject).to run.with_params('Integer', 'validate_foo', 5)
@@ -18,7 +18,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0
 
     describe 'when failing the type assertion' do
       it 'fails with a helpful message' do
-        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated')).once
+        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated'), false).once
         expect(scope).not_to receive(:function_validate_foo)
         expect(subject.func).to receive(:call_function).with('fail', 'validate_legacy(Integer, ...) expects an Integer value, got String').once
         expect(subject).to run.with_params('Integer', 'validate_foo', '5')
@@ -27,7 +27,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0
 
     describe 'when passing in undef' do
       it 'passes without failure' do
-        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated')).once
+        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated'), false).once
         expect(scope).not_to receive(:function_validate_foo)
         expect(Puppet).not_to receive(:notice)
         expect(subject).to run.with_params('Optional[Integer]', 'validate_foo', :undef)
@@ -35,8 +35,8 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.4.0') >= 0
     end
 
     describe 'when passing in multiple arguments' do
-      it 'passes with a deprecation message' do
-        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated')).once
+      it 'passes with a deprecation message that does not honour strict mode' do
+        expect(subject.func).to receive(:call_function).with('deprecation', 'validate_legacy', include('deprecated'), false).once
         expect(scope).not_to receive(:function_validate_foo)
         expect(Puppet).not_to receive(:notice)
         expect(subject).to run.with_params('Optional[Integer]', 'validate_foo', :undef, 1, 'foo')


### PR DESCRIPTION
This PR is created to execute tests for the original PR (https://github.com/puppetlabs/puppetlabs-stdlib/pull/1479)